### PR TITLE
fixed pickCommand to no longer ENOENT

### DIFF
--- a/lib/core/VoiceConnection.js
+++ b/lib/core/VoiceConnection.js
@@ -82,7 +82,7 @@ class VoiceConnection extends EventEmitter {
 
     pickCommand() {
         for(var command of ["ffmpeg", "avconv"]) {
-            if(!ChildProcess.spawnSync(command + " -h").error) {
+            if(!ChildProcess.spawnSync(command, ["-h"]).error) {
                 this.converterCommand = command;
                 break;
             }


### PR DESCRIPTION
Should fix Bad argument error when trying to use playStream. Works correctly with ffmpeg, didn't check with avconv. This'll probably fix #16.
