### PR TITLE
Fix prefix-arrays not handled correctly

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -46,9 +46,22 @@ class CommandClient extends Client {
             if(!this.commandOptions.name) {
                 this.commandOptions.name = `**${this.user.username}**`;
             }
-            this.commandOptions.prefix = this.commandOptions.prefix.replace(/@mention/g, this.user.mention);
+            if(Array.isArray(this.commandOptions.prefix)){
+                for(var i in this.commandOptions.prefix){
+                    this.commandOptions.prefix[i] = this.commandOptions.prefix[i].replace(/@mention/g, this.user.mention);
+                }
+            } else {
+                this.commandOptions.prefix = this.commandOptions.prefix.replace(/@mention/g, this.user.mention);
+            }
             for(var key in this.guildPrefixes) {
-                this.guildPrefixes[key] = this.guildPrefixes[key].replace(/@mention/g, this.user.mention);
+                if(Array.isArray(this.guildPrefixes[key])){
+                    var that = this;
+                    for(var i in this.guildPrefixes[key]){
+                        this.guildPrefixes[key][i] = this.guildPrefixes[key][i].replace(/@mention/g, this.user.mention);
+                    }
+                } else {
+                    this.guildPrefixes[key] = this.guildPrefixes[key].replace(/@mention/g, this.user.mention);
+                }
             }
         });
 
@@ -135,7 +148,18 @@ class CommandClient extends Client {
     * @arg {String|Array} prefix The bot prefix. Can be either an array of prefixes or a single prefix. "@mention" will be automatically replaced with the bot's actual mention
     */
     registerGuildPrefix(guildID, prefix) {
-        this.guildPrefixes[guildID] = this.preReady ? prefix.replace(/@mention/g, this.user.mention) : prefix;
+        if(this.preReady){
+            this.guildPrefixes[guildID] = prefix;
+        } else {
+            if(Array.isArray(prefix)){
+                for(var i in prefix){
+                    prefix[i] = prefix[i].replace(/@mention/g, this.user.mention);
+                }
+                this.guildPrefixes[guildID] = prefix;
+            } else {
+                this.guildPrefixes[guildID] = prefix.replace(/@mention/g, this.user.mention);
+            }
+        }
     }
 
     checkPrefix(msg) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -55,7 +55,6 @@ class CommandClient extends Client {
             }
             for(var key in this.guildPrefixes) {
                 if(Array.isArray(this.guildPrefixes[key])){
-                    var that = this;
                     for(var i in this.guildPrefixes[key]){
                         this.guildPrefixes[key][i] = this.guildPrefixes[key][i].replace(/@mention/g, this.user.mention);
                     }


### PR DESCRIPTION
The documentation states, that arrays can be passed to set possible command prefixes for the CommandClient. However, the replacer for the '@mention'-prefix could only handle strings and threw an error when passing an array. This should fix it by iterating over a passed array.
