### PR TITLE
Fix array prefix resolve

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -70,7 +70,7 @@ class CommandClient extends Client {
             }
 
             if(msg.author.id !== this.user.id && (!this.commandOptions.ignoreBots || !msg.author.bot) && this.checkPrefix(msg)) {
-                var args = msg.content.substring(this.commandOptions.prefix.length).split(" ");
+                var args = msg.content.substring(this.checkPrefix(msg).length).split(" ");
                 var label = args.shift();
                 label = this.commandAliases[label] || label;
                 var command;
@@ -162,7 +162,7 @@ class CommandClient extends Client {
     }
 
     checkPrefix(msg) {
-        var prefixes = (this.guildPrefixes[msg.channel.guild.id] || this.commandOptions).prefix;
+        var prefixes = this.guildPrefixes[msg.channel.guild.id] || this.commandOptions.prefix;
         if(typeof prefixes === "string") {
             return msg.content.startsWith(prefixes);
         } else if(Array.isArray(prefixes)) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -162,7 +162,10 @@ class CommandClient extends Client {
     }
 
     checkPrefix(msg) {
-        var prefixes = this.guildPrefixes[msg.channel.guild.id] || this.commandOptions.prefix;
+        var prefixes = this.commandOptions.prefix;
+        if(msg.channel.guild!==undefined && this.guildPrefixes[msg.channel.guild.id] !== undefined){
+            prefixes = this.guildPrefixes[msg.channel.guild.id];
+        }
         if(typeof prefixes === "string") {
             return msg.content.startsWith(prefixes);
         } else if(Array.isArray(prefixes)) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -163,7 +163,7 @@ class CommandClient extends Client {
 
     checkPrefix(msg) {
         var prefixes = this.commandOptions.prefix;
-        if(msg.channel.guild!==undefined && this.guildPrefixes[msg.channel.guild.id] !== undefined){
+        if(msg.channel.guild !== undefined && this.guildPrefixes[msg.channel.guild.id] !== undefined){
             prefixes = this.guildPrefixes[msg.channel.guild.id];
         }
         if(typeof prefixes === "string") {


### PR DESCRIPTION
This fixes some problems with arrays as command-prefixes:
1. DM's threw errors when checking for a prefix
2. The prefix couldn't be re resolved correctly when using a array of prefixes
