### PR TITLE
fix error when trying to get voiceConnection

### DIFF
--- a/lib/core/Shard.js
+++ b/lib/core/Shard.js
@@ -2,11 +2,9 @@
 
 const Bucket = require("../util/Bucket");
 const Call = require("./Call");
-const Collection = require("../util/Collection");
 const EventEmitter = require('events').EventEmitter;
 const OPCodes = require("../Constants").GatewayOPCodes;
 const User = require("./User");
-const VoiceConnection = require("./VoiceConnection");
 const WebSocket = require("ws");
 const Zlib = require("zlib");
 
@@ -14,7 +12,6 @@ const Zlib = require("zlib");
 * Represents a shard
 * @extends EventEmitter
 * @prop {Number} id The ID of the shard
-* @prop {Collection} voiceConnections Collection of VoiceConnections
 * @prop {Boolean} connecting Whether the shard is connecting
 * @prop {Boolean} ready Whether the shard is ready
 * @prop {Number} guildCount The number of guilds this shard handles

--- a/lib/core/Shard.js
+++ b/lib/core/Shard.js
@@ -274,7 +274,7 @@ class Shard extends EventEmitter {
                 var oldChannelID = member.channelID;
                 member.update(packet.d, this.client);
                 if(member.user.id === this.client.user.id) {
-                    var voiceConnection = this.voiceConnections.get(packet.d.guild_id);
+                    var voiceConnection = this.client.voiceConnections.get(packet.d.guild_id);
                     if(voiceConnection) {
                         voiceConnection.channelID = packet.d.channel_id;
                     }


### PR DESCRIPTION
The shard class doesn't have a voiceConnections property anymore, but it was still being referenced at least once and throwing an error when trying to join a voice channel. This probably needs to be fixed before #28 can be resolved. 
