### PR TITLE
For for updating channel permission overwrites

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -428,6 +428,7 @@ class Client extends EventEmitter {
     * @arg {String} overwriteID The overwritten user or role ID
     * @arg {Number} allow The permissions number for allowed permissions
     * @arg {Number} deny The permissions number for denied permissions
+    * @arg {String} Type The object type of the overwrite ID, either 'member' or 'role'
     * @returns {Promise<PermissionOverwrite>}
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -430,10 +430,11 @@ class Client extends EventEmitter {
     * @arg {Number} deny The permissions number for denied permissions
     * @returns {Promise<PermissionOverwrite>}
     */
-    editChannelPermission(channelID, overwriteID, allow, deny) {
+    editChannelPermission(channelID, overwriteID, allow, deny, type) {
         return this.callAPI("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
             allow,
-            deny
+            deny,
+            type
         }).then((permissionOverwrite) => new PermissionOverwrite(permissionOverwrite));
     }
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -10,7 +10,7 @@ module.exports = {
         CHANNEL_MESSAGES:                (chanID) => `/channels/${chanID}/messages`,
         CHANNEL_PIN:              (chanID, msgID) => `/channels/${chanID}/pins/${msgID}`,
         CHANNEL_PINS:                    (chanID) => `/channels/${chanID}/pins`,
-        CHANNEL_PERMISSION:      (chanID, overID) => `/channels/${chanID}/permission/${overID}`,
+        CHANNEL_PERMISSION:      (chanID, overID) => `/channels/${chanID}/permissions/${overID}`,
         CHANNEL_PERMISSIONS:             (chanID) => `/channels/${chanID}/permissions`,
         CHANNEL_TYPING:                  (chanID) => `/channels/${chanID}/typing`,
         CHANNELS:                                    "/channels",


### PR DESCRIPTION
Previously the editChannelPermission() was returning 405 METHOD NOT ALLOWED from the API.

I have fixed the endpoint to use the correct URL, and added the required 'type' parameter to the request body.
