### PR TITLE
Fix error where stream.destroy() function does not exist

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -269,7 +269,7 @@ class Client extends EventEmitter {
     /**
     * Disconnects all shards
     * @arg {?Object} [options] Shard disconnect options
-    * @arg {String | Boolean} [options.autoreconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
+    * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
     */
     disconnect(options) {
         this.ready = false;

--- a/lib/core/Shard.js
+++ b/lib/core/Shard.js
@@ -45,7 +45,7 @@ class Shard extends EventEmitter {
     /**
     * Disconnects the shard
     * @arg {?Object} [options] Shard disconnect options
-    * @arg {String | Boolean} [options.autoreconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
+    * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
     */
     disconnect(options, error) {
         var ws = this.ws;

--- a/lib/core/VoiceConnection.js
+++ b/lib/core/VoiceConnection.js
@@ -327,7 +327,11 @@ class VoiceConnection extends EventEmitter {
 
         var onError = (e) => {
             encoder.kill();
-            stream.destroy();
+            
+            if(typeof stream.destroy === 'function') {
+                stream.destroy();
+            }
+
             if(e && this.playing) {
                 this.emit("error", e);
             }


### PR DESCRIPTION
The following code:

`request.get(downloadUrl, function (error, response, body) {
    if(!error && response.statusCode == 200) {
        var bufferStream = new stream.PassThrough();
        bufferStream.end(body);

```
    vc.playStream(bufferStream);
}
```

});`

Generates the error:

`TypeError: stream.destroy is not a function`

This is because stream.PassThrough does not have a destory() method. I have updated Eris to check this function exists before calling it.
