### PR TITLE
fix default help command not working after command unregistered

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -128,7 +128,7 @@ class CommandClient extends Client {
                     result += "\n";
                     result += "**Commands:**\n";
                     for(label in this.commands) {
-                        if(this.commands[label].permissionCheck(msg)) {
+                        if(this.commands[label] && this.commands[label].permissionCheck(msg)) {
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
                         }
                     }


### PR DESCRIPTION
When a command is removed with the `CommandClient#unregisterCommand` method it sets `commands[label] = undefined`. The `for..in` loop inside help will still iterate over the undefined command causing an error.
