### PR TITLE
update voice state on disconnect

### DIFF
--- a/lib/core/VoiceConnection.js
+++ b/lib/core/VoiceConnection.js
@@ -286,6 +286,7 @@ class VoiceConnection extends EventEmitter {
         }
         if(!reconnecting) {
             this.channelID = null;
+            this.updateVoiceState();
             /**
             * Fired when the voice connection disconnects
             * @event VoiceConnection#disconnect


### PR DESCRIPTION
fixes client not leaving voice channel on disconnect, might not be the correct way of doing it, but this was how it was done before https://github.com/abalabahaha/eris/commit/c110bb671ef7350c254c2e9fae83fd8773be967f
