### PR TITLE
Typo in docs

### DIFF
--- a/lib/core/VoiceState.js
+++ b/lib/core/VoiceState.js
@@ -2,7 +2,7 @@
 
 /**
 * Represents a user's voice state in a call/guild
-* @prop {String} id The ID of teh guild
+* @prop {String} id The ID of the guild
 * @prop {String?} sessionID The ID of the user's current voice session
 * @prop {String} mute Whether the user is server muted or not
 * @prop {String} deaf Whether the user is server deafened or not


### PR DESCRIPTION
Fix the **magnificent** typo 'teh', in the 'id' property.
