### PR TITLE
fix EPIPE afterWrite error in VoiceConnection

### DIFF
--- a/lib/core/VoiceConnection.js
+++ b/lib/core/VoiceConnection.js
@@ -337,7 +337,10 @@ class VoiceConnection extends EventEmitter {
             "pipe:1"
         ], {stdio: ["pipe", "pipe", "ignore"]});
 
-        stream.pipe(encoder.stdin);
+        var pipe = stream.pipe(encoder.stdin);
+
+        pipe.on('unpipe', () => pipe.destroy());
+        pipe.on('end', () => pipe.destroy());
 
         var onError = (e) => {
             stream.unpipe();


### PR DESCRIPTION
Fixes:
`{ Error: write EPIPE
    at exports._errnoException (util.js:953:11)
    at WriteWrap.afterWrite (net.js:793:14) code: 'EPIPE', errno: 'EPIPE', syscall: 'write' }`
