### PR TITLE
Fixes status update packet being sent twice

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1377,18 +1377,22 @@ class Shard extends EventEmitter {
             };
             if(!this.preReady && !force) {
                 this.readyQueue.push(() => {
-                    this.globalBucket.queue(func);
                     if(op === OPCodes.STATUS_UPDATE) {
                         waitFor++;
+                        this.globalBucket.queue(func);
                         this.presenceUpdateBucket.queue(func);
+                        return;
                     }
+                    this.globalBucket.queue(func);
                 });
             } else {
-                this.globalBucket.queue(func);
                 if(op === OPCodes.STATUS_UPDATE) {
                     waitFor++;
+                    this.globalBucket.queue(func);
                     this.presenceUpdateBucket.queue(func);
+                    return;
                 }
+                this.globalBucket.queue(func);
             }
         }
     }


### PR DESCRIPTION
Status update was sent twice in a row.  The function was added to the global bucket before waitFor was increased.  

_I hope this isn't actually supposed to happen_ :seedling: 
