### PR TITLE
Add support for friend suggestion events

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -859,6 +859,24 @@ class Shard extends EventEmitter {
                 this.client.emit("channelRecipientRemove", channel, channel.recipients.remove(packet.d.user));
                 break;
             }
+            case "FRIEND_SUGGESTION_CREATE": {
+                /**
+                * Fired when a client receives a friend suggestion
+                * @event Client#friendSuggestionCreate
+                * @prop {User} user The suggested user
+                */
+                this.client.emit("friendSuggestionCreate",new User(packet.d.suggested_user));
+                break;
+            }
+            case "FRIEND_SUGGESTION_DELETE": {
+                /**
+                * Fired when a client's friend suggestion is removed for any reason
+                * @event Client#friendSuggestionDelete
+                * @prop {User} user The suggested user
+                */
+                this.client.emit("friendSuggestionDelete", this.client.users.get(packet.d.suggested_user_id));
+                break;
+            }
             case "GUILD_MEMBERS_CHUNK": {
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 if(this.getAllUsersCount.hasOwnProperty(guild.id)) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -864,8 +864,12 @@ class Shard extends EventEmitter {
                 * Fired when a client receives a friend suggestion
                 * @event Client#friendSuggestionCreate
                 * @prop {User} user The suggested user
+                * @prop {Array[]} reasons Array of reasons why this suggestion was made
+                * @prop {Number} reasons.type Type of reason?
+                * @prop {String} reasons.platform_type Platform you share with the user
+                * @prop {String} reasons.name Username of suggested user on that platform
                 */
-                this.client.emit("friendSuggestionCreate",new User(packet.d.suggested_user));
+                this.client.emit("friendSuggestionCreate",new User(packet.d.suggested_user), packet.d.reasons);
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -854,15 +854,12 @@ class Shard extends EventEmitter {
                     * Fired when a user leaves a group channel
                     * @event Client#channelRecipientRemove
                     * @prop {GroupChannel} channel The channel
-                    * @prop {User} user The user                    
+                    * @prop {User} user The user
                     */
                 this.client.emit("channelRecipientRemove", channel, channel.recipients.remove(packet.d.user));
                 break;
             }
             case "FRIEND_SUGGESTION_CREATE": {
-                if(this.client.bot) {
-                    break;
-                }
                 /**
                 * Fired when a client receives a friend suggestion
                 * @event Client#friendSuggestionCreate
@@ -876,9 +873,6 @@ class Shard extends EventEmitter {
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {
-                if(this.client.bot) {
-                    break;
-                }
                 /**
                 * Fired when a client's friend suggestion is removed for any reason
                 * @event Client#friendSuggestionDelete

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -854,12 +854,15 @@ class Shard extends EventEmitter {
                     * Fired when a user leaves a group channel
                     * @event Client#channelRecipientRemove
                     * @prop {GroupChannel} channel The channel
-                    * @prop {User} user The user
+                    * @prop {User} user The user                    
                     */
                 this.client.emit("channelRecipientRemove", channel, channel.recipients.remove(packet.d.user));
                 break;
             }
             case "FRIEND_SUGGESTION_CREATE": {
+                if(this.client.bot) {
+                    break;
+                }
                 /**
                 * Fired when a client receives a friend suggestion
                 * @event Client#friendSuggestionCreate
@@ -873,6 +876,9 @@ class Shard extends EventEmitter {
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {
+                if(this.client.bot) {
+                    break;
+                }
                 /**
                 * Fired when a client's friend suggestion is removed for any reason
                 * @event Client#friendSuggestionDelete


### PR DESCRIPTION
Recent update added friend suggestions, which appear to be users who you have as friends on connected platforms, but not on Discord.

**FRIEND_SUGGESTION_CREATE**
When fired, it supplies a user object and an array of reasons.

**FRIEND_SUGGESTION_DELETE**
When fired, it supplies _only_ the user's id. Perhaps in case you no longer share a guild with the user?
