### PR TITLE
Prevent users removed from guild members collection from being immediately re-added

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -234,7 +234,7 @@ class Shard extends EventEmitter {
                         status: member.status
                     };
                 }
-                if(!member || oldPresence) {
+                if((!member && packet.d.user.username) || oldPresence) {
                     member = guild.members.update(packet.d, guild);
                     this.client.emit("presenceUpdate", member, oldPresence);
                 }


### PR DESCRIPTION
For some reason, Discord likes sending a presence update along with guild member removals, so because of that, the member would get re-added. However, these presence updates do not include a username, only ID, which only happens with guild member removals, and cases where the user did not have an oldPresence (was offline when bot launched). This now checks to see if the packet includes a username, to filter out presence updates sent because of guild removals.
