### PR TITLE
Fix logic behind executeWebhook

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -584,7 +584,7 @@ class Client extends EventEmitter {
         if(!options.content && !options.file && !options.embeds) {
             return Promise.reject(new Error("No content, file, or embeds"));
         }
-        if(options.content && options.disableEveryone !== undefined ? options.disableEveryone : this.options.disableEveryone) {
+        if(options.content && (options.disableEveryone !== undefined ? options.disableEveryone : this.options.disableEveryone)) {
             options.content = options.content.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
         }
         return this.requestHandler.request("POST", Constants.Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), true, {


### PR DESCRIPTION
ur logic is bad and u should feel bad

The logic of this if statement before looked like:

```
if (options.content and options.disableEveryone both exist):
  if (options.disableEveryone):
    remove everyones
else:
  if (bot.options.disableEveryone):
    remove everyones
```

What it should look like now:

```
if (options.content exists):
  if (options.disableEveryone exists && is true):
    remove everyones
  else if (options.disableEveryone doesn't exist && bot.options.disableEveryone is true):
    remove everyones
```

Fixes this error when calling `client.executeWebhook` with no content:

![this error](https://my.mixtape.moe/hklfwp.png) 
