### PR TITLE
Basic shared stream support

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -18,6 +18,8 @@ const Role = require("./structures/Role");
 const Shard = require("./gateway/Shard");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
+const VoiceConnection = require("./voice/VoiceConnection");
+const SharedStream = require("./voice/SharedStream");
 
 var EventEmitter;
 try {
@@ -129,6 +131,7 @@ class Client extends EventEmitter {
         this.retryAfters = {};
         this.guildShardMap = {};
         this.voiceConnections = new VoiceConnectionManager(this);
+		this.sharedStreams = {};
         this.unavailableGuilds = new Collection(Guild);
         this.relationships = new Collection(Relationship);
         this.users = new Collection(User);
@@ -327,6 +330,24 @@ class Client extends EventEmitter {
             });
         }
     }
+
+	/** Creates a shared stream. Each shared stream contains a collection of VoiceConnections to output to.
+	* @arg {String} source The input audio stream as a URL. Currently only supports web streams.
+	* @returns {SharedStream}
+	*/
+	createSharedStream(source, userAgent) {
+		if (typeof source !== "string") {
+			return null;
+		}
+
+		if (this.sharedStreams[source]) {
+			return this.sharedStreams[source];
+		}
+
+		var sharedStream = new SharedStream(this, source, userAgent);
+		this.sharedStreams[source] = sharedStream;
+		return sharedStream;
+	}
 
     /**
     * Leaves a voice channel

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -18,7 +18,6 @@ const Role = require("./structures/Role");
 const Shard = require("./gateway/Shard");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
-const VoiceConnection = require("./voice/VoiceConnection");
 const SharedStream = require("./voice/SharedStream");
 
 var EventEmitter;
@@ -131,7 +130,7 @@ class Client extends EventEmitter {
         this.retryAfters = {};
         this.guildShardMap = {};
         this.voiceConnections = new VoiceConnectionManager(this);
-		this.sharedStreams = {};
+        this.sharedStreams = {};
         this.unavailableGuilds = new Collection(Guild);
         this.relationships = new Collection(Relationship);
         this.users = new Collection(User);
@@ -331,23 +330,23 @@ class Client extends EventEmitter {
         }
     }
 
-	/** Creates a shared stream. Each shared stream contains a collection of VoiceConnections to output to.
-	* @arg {String} source The input audio stream as a URL. Currently only supports web streams.
-	* @returns {SharedStream}
-	*/
-	createSharedStream(source, userAgent) {
-		if (typeof source !== "string") {
-			return null;
-		}
+    /** Creates a shared stream. Each shared stream contains a collection of VoiceConnections to output to.
+    * @arg {String} source The input audio stream as a URL. Currently only supports web streams.
+    * @returns {SharedStream}
+    */
+    createSharedStream(source, userAgent) {
+        if (typeof source !== "string") {
+            return null;
+        }
 
-		if (this.sharedStreams[source]) {
-			return this.sharedStreams[source];
-		}
+        if (this.sharedStreams[source]) {
+            return this.sharedStreams[source];
+        }
 
-		var sharedStream = new SharedStream(this, source, userAgent);
-		this.sharedStreams[source] = sharedStream;
-		return sharedStream;
-	}
+        var sharedStream = new SharedStream(this, source, userAgent);
+        this.sharedStreams[source] = sharedStream;
+        return sharedStream;
+    }
 
     /**
     * Leaves a voice channel

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -128,8 +128,8 @@ class SharedStream extends EventEmitter {
         }
         connection = this.client.voiceConnections.get(guildID);
         if (connection) {
-            return Promise.reject(new Error("A VoiceConnection has already been created for this guild. Disconnect and \
-                destroy that VoiceConnection first before attempting to join a voice channel on a shared stream."))
+            return Promise.reject(new Error("A VoiceConnection has already been created for this guild. Disconnect and " +
+                "destroy that VoiceConnection first before attempting to join a voice channel on a shared stream."))
         } else {
             var shard = this.client.shards.get(channel.guild && this.client.guildShardMap[guildID] || 0);
             connection = this.voiceConnections.add(new VoiceConnection(guildID, this.client.user.id, shard.sessionID, shard, true));

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -1,0 +1,246 @@
+"use strict";
+
+const ChildProcess = require("child_process");
+const Piper = require("./Piper");
+const VoiceConnection = require("./VoiceConnection");
+const Collection = require("../util/Collection");
+
+var EventEmitter;
+try {
+    EventEmitter = require("eventemitter3");
+} catch(err) {
+    EventEmitter = require("events").EventEmitter;
+}
+
+var OpusScript;
+try {
+    OpusScript = require("opusscript");
+} catch(err) { // eslint-disable no-empty
+}
+
+const MAX_FRAME_SIZE = 1276 * 3;
+const ENCRYPTION_MODE = "xsalsa20_poly1305";
+const SILENCE = new Buffer([0xF8, 0xFF, 0xFE]);
+
+/**
+* Represents a collection of VoiceConnections sharing an input stream
+* @extends EventEmitter
+*/
+class SharedStream extends EventEmitter {
+    constructor(client, source, userAgent) {
+        super();
+
+        if(typeof window !== "undefined") {
+            throw new Error("Voice is not supported in browsers at this time");
+        }
+
+        this.client = client;
+
+        this.samplingRate = 48000;
+        this.channels = 2;
+        this.frameDuration = 60;
+        this.frameSize = this.samplingRate * this.frameDuration / 1000;
+        this.pcmSize = this.frameSize * this.channels * 2;
+        this.bitrate = 64000;
+
+        if(this.shard && this.shard.client.opus) {
+            this.opus = this.shard.client.opus;
+        } else {
+            try {
+                this.opus = new (require("node-opus")).OpusEncoder(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+            } catch(err) {
+                this.emit("debug", "Error initializing node-opus encoder, falling back to opusscript");
+                try {
+                    this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+                    this.opus.setBitrate(this.bitrate);
+                } catch(err) {
+                    this.emit((shard.client.options.opusOnly ? "warn" : "error"), "No opus encoder found, playing non-opus audio will not work.");
+                }
+            }
+            if(this.shard) {
+                this.shard.client.opus = this.opus;
+            }
+        }
+
+        this.voiceConnections = new Collection(VoiceConnection);
+        this.sequence = 0;
+        this.timestamp = 0;
+        this.converterCommand = null;
+        var pick = this.pickCommand();
+        if(pick instanceof Error) {
+            this.emit("error", pick);
+        }
+
+        this.piper = new Piper(this.converterCommand, this.opus);
+        this.piper.on("error", (e) => this.emit("error", e));
+
+        if(pick && this.converterCommand) {
+            this.piper.libopus = false;
+        }
+
+        var options = {};
+        options.samplingRate = this.samplingRate;
+        options.frameDuration = this.frameDuration;
+        options.frameSize = this.frameSize;
+        options.inlineVolume = true;
+        this.piper.encode(source, options);
+        this._play(options);
+    }
+
+    pickCommand() {
+        var tentative;
+        for(var command of ["./ffmpeg", "./avconv", "ffmpeg", "avconv"]) {
+            var res = ChildProcess.spawnSync(command, ["-encoders"]);
+            if(!res.error) {
+                if(!res.stdout.toString().includes("libopus")) {
+                    tentative = command;
+                    continue;
+                }
+                this.converterCommand = command;
+                return;
+            }
+        }
+        if(tentative) {
+            this.converterCommand = tentative;
+            return new Error(tentative + " does not have libopus support. Non-opus playback may be laggy");
+        }
+        return new Error("Neither ffmpeg nor avconv was found. Make sure you installed either one, and check that it is in your PATH");
+    }
+
+    /** Joins a voice channel using this shared stream as input. If a VoiceConnection has already been initialised on
+    * that guild, you will need to disconnect that VoiceConnection first.
+    * @arg {String} channelID
+    * @return {Promise<VoiceConnection>} Resolves with an established VoiceConnection set to shared mode
+    */
+    joinVoiceChannel(channelID) {
+        var channel = this.client.getChannel(channelID);
+        if (!channel) {
+            return Promise.reject(new Error("Channel not found"));
+        }
+        if(channel.guild && !channel.permissionsOf(this.client.user.id).json.voiceConnect) {
+            return Promise.reject(new Error("Insufficient permission to connect to voice channel"));
+        }
+        var guildID = channel.guild && this.client.channelGuildMap[channelID] || "call";
+        var connection = this.voiceConnections.get(guildID);
+        if (connection) {
+            connection.switchChannel(channelID);
+            return Promise.resolve(connection);
+        }
+        connection = this.client.voiceConnections.get(guildID);
+        if (connection) {
+            return Promise.reject(new Error("A VoiceConnection has already been created for this guild. Disconnect and \
+                destroy that VoiceConnection first before attempting to join a voice channel on a shared stream."))
+        } else {
+            var shard = this.client.shards.get(channel.guild && this.client.guildShardMap[guildID] || 0);
+            connection = this.voiceConnections.add(new VoiceConnection(guildID, this.client.user.id, shard.sessionID, shard, true));
+            this.client.voiceConnections.add(connection);
+            connection.connect(channelID);
+
+            if (connection.ready) {
+                return Promise.resolve(connection);
+            }
+        }
+        return new Promise((resolve, reject) => {
+            var disconnectHandler, readyHandler;
+            disconnectHandler = (err) => {
+                connection.removeListener("ready", readyHandler);
+                reject(err);
+            };
+            readyHandler = () => {
+                connection.removeListener("disconnect", disconnectHandler);
+                resolve(connection);
+            };
+            connection.once("ready", readyHandler);
+            connection.once("disconnect", disconnectHandler);
+        });
+    }
+
+    _incrementTimestamps(val) {
+        for (var vc of this.voiceConnections.values()) {
+            vc.timestamp += val;
+            if (vc.timestamp >= 4294967295) {
+                vc.timestamp -= 4294967295;
+            }
+        }
+    }
+
+    _incrementSequences() {
+        for (var vc of this.voiceConnections.values()) {
+            vc.sequence++;
+            if (vc.sequence >= 65536) {
+                vc.sequence -= 65536;
+            }
+        }
+    }
+
+    _setSpeaking(speaking) {
+        for (var vc of this.voiceConnections.values()) {
+            vc.setSpeaking(speaking);
+        }
+    }
+
+    //End of stream or encoder died
+    _end() {
+        this.emit("end");
+        this._setSpeaking(false);
+        this.piper.stop();
+    }
+
+    _play(options) {
+        console.log("Starting playback of shared stream");
+        var startTime = Date.now();
+        var packets = 0;
+        var waitingForData = 0;
+        var buffer;
+        var pausedTime = 0;
+        options.voiceDataTimeout = options.voiceDataTimeout || 2000;
+
+        var send = () => {
+            if (!this.piper.encoding && this.piper.dataPackets.length === 0) {
+                this._end();
+                return;
+            }
+
+            this._incrementTimestamps(options.frameSize);
+
+            this._incrementSequences();
+
+            if ((buffer = this.piper.getDataPacket())) {
+                if (waitingForData) {
+                    waitingForData = 0;
+                    this._setSpeaking(true);
+                }
+            } else if (options.voiceDataTimeout === -1 || waitingForData < options.voiceDataTimeout / options.frameDuration) { // wait for data
+                if (++waitingForData <= 5) {
+                    this._setSpeaking(false);
+                    buffer = SILENCE;
+                } else {
+                    pausedTime += 4 * options.frameDuration;
+                    this._incrementTimestamps(4 * options.frameSize);
+                    return setTimeout(send, 4 * options.frameDuration);
+                }
+            } else {
+                this._end();
+                return;
+            }
+
+            for (var vc of this.voiceConnections.values()) {
+                if (!vc.ready) {
+                    continue;
+                }
+                if (!vc._sendPacket(vc._createPacket(buffer))) {
+                    //Disconnected from this VC, remove it
+                    this.voiceConnections.remove(vc);
+                    this.emit("disconnect", vc);
+                    vc._stopPlaying();
+                }
+            }
+            return setTimeout(send, startTime + pausedTime + ++packets * options.frameDuration - Date.now());
+        };
+
+        this.emit("start");
+        send();
+    }
+}
+
+module.exports = SharedStream;

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -18,8 +18,6 @@ try {
 } catch(err) { // eslint-disable no-empty
 }
 
-const MAX_FRAME_SIZE = 1276 * 3;
-const ENCRYPTION_MODE = "xsalsa20_poly1305";
 const SILENCE = new Buffer([0xF8, 0xFF, 0xFE]);
 
 /**
@@ -43,22 +41,15 @@ class SharedStream extends EventEmitter {
         this.pcmSize = this.frameSize * this.channels * 2;
         this.bitrate = 64000;
 
-        if(this.shard && this.shard.client.opus) {
-            this.opus = this.shard.client.opus;
-        } else {
+        try {
+            this.opus = new (require("node-opus")).OpusEncoder(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+        } catch(err) {
+            this.emit("debug", "Error initializing node-opus encoder, falling back to opusscript");
             try {
-                this.opus = new (require("node-opus")).OpusEncoder(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+                this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+                this.opus.setBitrate(this.bitrate);
             } catch(err) {
-                this.emit("debug", "Error initializing node-opus encoder, falling back to opusscript");
-                try {
-                    this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
-                    this.opus.setBitrate(this.bitrate);
-                } catch(err) {
-                    this.emit((shard.client.options.opusOnly ? "warn" : "error"), "No opus encoder found, playing non-opus audio will not work.");
-                }
-            }
-            if(this.shard) {
-                this.shard.client.opus = this.opus;
+                this.emit("error", "No opus encoder found, playing non-opus audio will not work.");
             }
         }
 
@@ -83,6 +74,9 @@ class SharedStream extends EventEmitter {
         options.frameDuration = this.frameDuration;
         options.frameSize = this.frameSize;
         options.inlineVolume = true;
+        options.encoderArgs = [
+            "-headers", "'User Agent: \"" + userAgent + "\"'"
+        ];
         this.piper.encode(source, options);
         this._play(options);
     }
@@ -129,7 +123,7 @@ class SharedStream extends EventEmitter {
         connection = this.client.voiceConnections.get(guildID);
         if (connection) {
             return Promise.reject(new Error("A VoiceConnection has already been created for this guild. Disconnect and " +
-                "destroy that VoiceConnection first before attempting to join a voice channel on a shared stream."))
+                "destroy that VoiceConnection first before attempting to join a voice channel on a shared stream."));
         } else {
             var shard = this.client.shards.get(channel.guild && this.client.guildShardMap[guildID] || 0);
             connection = this.voiceConnections.add(new VoiceConnection(guildID, this.client.user.id, shard.sessionID, shard, true));

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -187,7 +187,6 @@ class SharedStream extends EventEmitter {
     }
 
     _play(options) {
-        console.log("Starting playback of shared stream");
         var startTime = Date.now();
         var packets = 0;
         var waitingForData = 0;

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -38,7 +38,7 @@ const SILENCE = new Buffer([0xF8, 0xFF, 0xFE]);
 * @prop {Number} playTime Position of playback of current resource in milliseconds
 */
 class VoiceConnection extends EventEmitter {
-    constructor(guildID, userID, sessionID, shard) {
+    constructor(guildID, userID, sessionID, shard, shared) {
         super();
 
         if(typeof window !== "undefined") {
@@ -57,23 +57,26 @@ class VoiceConnection extends EventEmitter {
         this.frameSize = this.samplingRate * this.frameDuration / 1000;
         this.pcmSize = this.frameSize * this.channels * 2;
         this.bitrate = 64000;
+        this.shared = shared;
 
-        if(this.shard && this.shard.client && this.shard.client.opus) {
-            this.opus = this.shard.client.opus;
-        } else {
-            try {
-                this.opus = new (require("node-opus")).OpusEncoder(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
-            } catch(err) {
-                this.emit("debug", "Error initializing node-opus encoder, falling back to opusscript");
+        if (!this.shared) {
+            if(this.shard && this.shard.client.opus) {
+                this.opus = this.shard.client.opus;
+            } else {
                 try {
-                    this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
-                    this.opus.setBitrate(this.bitrate);
+                    this.opus = new (require("node-opus")).OpusEncoder(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
                 } catch(err) {
-                    this.emit("warn", "No opus encoder found, playing non-opus audio will not work.");
+                    this.emit("debug", "Error initializing node-opus encoder, falling back to opusscript");
+                    try {
+                        this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
+                        this.opus.setBitrate(this.bitrate);
+                    } catch(err) {
+                        this.emit((shard.client.options.opusOnly ? "warn" : "error"), "No opus encoder found, playing non-opus audio will not work.");
+                    }
                 }
-            }
-            if(this.shard && this.shard.client) {
-                this.shard.client.opus = this.opus;
+                if(this.shard) {
+                    this.shard.client.opus = this.opus;
+                }
             }
         }
 
@@ -98,16 +101,18 @@ class VoiceConnection extends EventEmitter {
         this.packetBuffer[0] = 0x80;
         this.packetBuffer[1] = 0x78;
 
-        var pick = this.pickCommand();
-        if(pick) {
-            process.nextTick(() => (this.shard ? this.shard.client || this : this).emit("warn", pick));
-        }
+        if (!this.shared) {
+            var pick = this.pickCommand();
+            if(pick instanceof Error) {
+                this.emit("error", pick);
+            }
 
-        this.piper = new Piper(this.converterCommand, this.opus);
-        this.piper.on("error", (e) => this.emit("error", e));
+            this.piper = new Piper(this.converterCommand, this.opus);
+            this.piper.on("error", (e) => this.emit("error", e));
 
-        if(pick && this.converterCommand) {
-            this.piper.libopus = false;
+            if(pick && this.converterCommand) {
+                this.piper.libopus = false;
+            }
         }
     }
 
@@ -438,7 +443,9 @@ class VoiceConnection extends EventEmitter {
         }
         this.ended = true;
 
-        this.piper.stop();
+        if (!this.shared) {
+            this.piper.stop();
+        }
 
         for(var i = 0; i < 5; i++) {
             this.timestamp += this.frameSize;


### PR DESCRIPTION
This allows a "SharedStream" to be created (intended to be sourced via web streams, although I don't see why it can't be expanded to filesystem/anything else Piper supports as well).  
You can call joinVoiceChannel on the SharedStream, just as you would do with a client. The input stream will be encoded to Opus once, then broadcasted to all the output VoiceConnections. This is to keep resources low on, say, a Discord radio bot connected to 85 servers. 

I've updated the listen.moe bot to use this and it seems to be working well, you can check usage out [here](https://github.com/Geo1088/listen.moe-streaming-bot/blob/master/index.js#L18). Tell me if there's anything else you need :)
