### PR TITLE
Added Permission checking for deleteCommand

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -86,7 +86,7 @@ class CommandClient extends Client {
                             content: resp
                         });
                     }
-                    if(command.deleteCommand) {
+                    if(command.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(bot.user.id).has('manageMessages')) {
                         this.deleteMessage(msg.channel.id, msg.id);
                     }
                 }


### PR DESCRIPTION
Should no longer try to delete commands when it can't either through lack of permissions or in private/group channels
