### PR TITLE
Replace role.asJSON() with role.json getter

### DIFF
--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -38,8 +38,8 @@ class Role {
     * Generates a JSON representation of the role permissions
     * @returns {Object}
     */
-    asJSON() {
-        return this.permissions.asJSON();
+    get json() {
+        return this.permissions.json;
     }
 
     get mention() {


### PR DESCRIPTION
`role.asJSON()` still referred to a time when the permission class still had a method of the same name, which has since been replaced with a json getter.
