### PR TITLE
account for non-existent member role edge case

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -58,7 +58,10 @@ class Member extends Base {
         } else {
             var permissions = this.guild.roles.get(this.guild.id).permissions.allow;
             for(var role of this.roles) {
-                var perm = this.guild.roles.get(role).permissions.allow;
+                var role = this.guild.roles.get(role);
+                if (!role) continue;
+
+                var perm = role.permissions.allow;
                 if(perm & Permissions.administrator) {
                     permissions = Permissions.all;
                     break;


### PR DESCRIPTION
I've had a few cases of members having roles that don't exist causing permission checks to error.