### PR TITLE
Make null content not break createMessage

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -861,6 +861,10 @@ class Client extends EventEmitter {
             content = {
                 content: content
             };
+        } else if(content === null) {
+            content = {
+                content: ""
+            }
         } else if(typeof content !== "object" || content.content === undefined) {
             content = {
                 content: "" + content


### PR DESCRIPTION
If `null` is passed as the content argument to `Client.createMessage()` it no longer breaks. If there's a file provided, it will send the file with no message; otherwise, it will error out as it should.