### PR TITLE
Add reaction docs to message

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -22,7 +22,9 @@ const User = require("./User");
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
-* @prop {Object} reactions An object containing the reactions on the message. Contains 'count' and 'me' properties
+* @prop {Object} reactions An object containing the reactions on the message
+* @prop {Number} reactions.count
+* @prop {Boolean} reactions.me 
 * @prop {Boolean} command True if message is a command, false if not (CommandClient only)
 */
 class Message  extends Base {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -23,8 +23,8 @@ const User = require("./User");
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
 * @prop {Object} reactions An object containing the reactions on the message
-* @prop {Number} reactions.count
-* @prop {Boolean} reactions.me 
+* @prop {Number} reactions.count The number of times the reaction was used
+* @prop {Boolean} reactions.me Whether or not the bot user did the reaction
 * @prop {Boolean} command True if message is a command, false if not (CommandClient only)
 */
 class Message  extends Base {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -22,6 +22,7 @@ const User = require("./User");
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
+* @prop {Object} reactions An object containing the reactions on the message. Contains 'count' and 'me' properties
 * @prop {Boolean} command True if message is a command, false if not (CommandClient only)
 */
 class Message  extends Base {


### PR DESCRIPTION
How would one document sub-properties of an object when it comes to using `@prop`? It would be great if Object properties told you what properties they have, and I'd gladly implement this to improve readability.