### PR TITLE
Re-add check for empty response on command-client

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -80,7 +80,11 @@ class CommandClient extends Client {
                 var command;
                 if((command = this.commands[label]) !== undefined || ((command = this.commands[label.toLowerCase()]) !== undefined && command.caseInsensitive)) {
                     msg.command = command;
-                    Promise.resolve(command.process(args,msg)).then((resp) => this.createMessage(msg.channel.id, resp));
+                    Promise.resolve(command.process(args,msg)).then((resp) => {
+                        if(resp) {
+                            this.createMessage(msg.channel.id, resp)
+                        }
+                    });
                     if(command.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(this.user.id).has('manageMessages')) {
                         this.deleteMessage(msg.channel.id, msg.id);
                     }


### PR DESCRIPTION
This was introduces through [#124:a7ac1bc](https://github.com/abalabahaha/eris/pull/124/commits/a7ac1bc543cd5d27348ff5b4a9c631c2e4a42306). createMessage checks for an empty message, however it does not fail silently...