### PR TITLE
Added an emoji cache

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -150,6 +150,20 @@ class Client extends EventEmitter {
     get uptime() {
         return this.startTime ? Date.now() - this.startTime : 0;
     }
+    
+    /**
+    * Gets a list of all custom emojis the bot can see.
+    * @returns {Collection<Object>}
+    */
+    get emojis() {
+        var emojis = new Collection(Object, null);
+        for(let guild of this.guilds.values()) 
+            for(let emoji of guild.emojis) {
+                emoji.guild = guild;
+                emojis.set(emoji.id, emoji);
+            }
+        return emojis;
+    }
 
     /**
     * Tells all shards to connect.


### PR DESCRIPTION
Before abal instantly rejects:

PROS:
- have access to all emojis, and can retrieve via ID
- can do emoji searches based criteria such as guild or emoji name
- collection is built on call, so if you don't care about and/or won't use them this it won't affect you performance-wise

CONS:
- 14 more lines of code (including docs and newlines) 👀