### PR TITLE
Edited Guild.iconURL() to return a .webp icon.

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -130,7 +130,7 @@ class Guild extends Base {
     }
 
     get iconURL() {
-        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.jpg` : null;
+        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.webp` : null;
     }
 
     get splashURL() {


### PR DESCRIPTION
I've noticed that guild icons also support .webp and .png format.