### PR TITLE
Add support for shard latency checking

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -31,6 +31,9 @@ var Inflator = typeof window !== "undefined" && Pako ? Pako.inflate : Zlib.infla
 * @prop {Number} guildCount The number of guilds this shard should be handling
 * @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
 * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
+* @prop {Number} lastHeartbeatReceived Timestamp when Discord last acknowledged a heartbeat
+* @prop {Number} lastHeartbeatSent Timestamp when shard last sent a heartbeat
+* @prop {Number} latency Current latency between shard and Discord
 */
 class Shard extends EventEmitter {
     constructor(id, client) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -42,6 +42,10 @@ class Shard extends EventEmitter {
         this.hardReset();
     }
 
+    get latency() {
+        return this.lastHeartbeatSent && this.lastHeartbeatReceived ? this.lastHeartbeatReceived - this.lastHeartbeatSent : null;
+    }
+
     /**
     * Tells the shard to connect
     */
@@ -124,6 +128,8 @@ class Shard extends EventEmitter {
         this.guildSyncQueueLength = 1;
         this.unsyncedGuilds = 0;
         this.lastHeartbeatAck = true;
+        this.lastHeartbeatReceived = null;
+        this.lastHeartbeatSent = null;
         this.status = "disconnected";
     }
 
@@ -1456,6 +1462,7 @@ class Shard extends EventEmitter {
                     }
                     case OPCodes.HEARTBEAT_ACK: {
                         this.lastHeartbeatAck = true;
+                        this.lastHeartbeatReceived = new Date().getTime();
                         break;
                     }
                     default: {
@@ -1523,6 +1530,7 @@ class Shard extends EventEmitter {
             }, new Error("Server didn't acknowledge previous heartbeat, possible lost connection"));
         }
         this.lastHeartbeatAck = false;
+        this.lastHeartbeatSent = new Date().getTime()
         this.sendWS(OPCodes.HEARTBEAT, this.seq, true);
     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -31,8 +31,8 @@ var Inflator = typeof window !== "undefined" && Pako ? Pako.inflate : Zlib.infla
 * @prop {Number} guildCount The number of guilds this shard should be handling
 * @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
 * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
-* @prop {Number} lastHeartbeatReceived Timestamp when Discord last acknowledged a heartbeat
-* @prop {Number} lastHeartbeatSent Timestamp when shard last sent a heartbeat
+* @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
+* @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
 * @prop {Number} latency Current latency between shard and Discord
 */
 class Shard extends EventEmitter {
@@ -46,7 +46,7 @@ class Shard extends EventEmitter {
     }
 
     get latency() {
-        return this.lastHeartbeatSent && this.lastHeartbeatReceived ? this.lastHeartbeatReceived - this.lastHeartbeatSent : null;
+        return this.lastHeartbeatSent && this.lastHeartbeatReceived ? this.lastHeartbeatReceived - this.lastHeartbeatSent : Infinity;
     }
 
     /**


### PR DESCRIPTION
- Each shard now stores the last time it sent a heartbeat, and when it was last acknowledged
- Shard getter returns latency if both values exist