### PR TITLE
Fix stream stopping on remove()

### DIFF
--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -61,6 +61,7 @@ class SharedStream extends EventEmitter {
     * @arg {VoiceConnection} connection The voice connection to remove
     */
     remove(_connection) {
+        this.voiceConnections.get(_connection.id).ws.close();
         return this.voiceConnections.remove(_connection);
     }
 


### PR DESCRIPTION
I believe it came from unclosed socket, I've done several tests, and this one has worked out best for me.
This only affects SharedStream