### PR TITLE
Add guildMemberChunk Event

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -12,29 +12,29 @@ const Zlib = require("zlib");
 var EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch(err) {
+} catch (err) {
     EventEmitter = require("events").EventEmitter;
 }
 var Pako;
 try {
     Pako = require("pako");
-} catch(err) { // eslint-disable no-empty
+} catch (err) { // eslint-disable no-empty
 }
 var Inflator = typeof window !== "undefined" && Pako ? Pako.inflate : Zlib.inflateSync;
 
 /**
-* Represents a shard
-* @extends EventEmitter
-* @prop {Number} id The ID of the shard
-* @prop {Boolean} connecting Whether the shard is connecting
-* @prop {Boolean} ready Whether the shard is ready
-* @prop {Number} guildCount The number of guilds this shard should be handling
-* @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
-* @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
-* @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} latency Current latency between shard and Discord
-*/
+ * Represents a shard
+ * @extends EventEmitter
+ * @prop {Number} id The ID of the shard
+ * @prop {Boolean} connecting Whether the shard is connecting
+ * @prop {Boolean} ready Whether the shard is ready
+ * @prop {Number} guildCount The number of guilds this shard should be handling
+ * @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
+ * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
+ * @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
+ * @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
+ * @prop {Number} latency Current latency between shard and Discord
+ */
 class Shard extends EventEmitter {
     constructor(id, client) {
         super();
@@ -50,10 +50,10 @@ class Shard extends EventEmitter {
     }
 
     /**
-    * Tells the shard to connect
-    */
+     * Tells the shard to connect
+     */
     connect() {
-        if(this.ws && this.ws.readyState != WebSocket.CLOSED) {
+        if (this.ws && this.ws.readyState != WebSocket.CLOSED) {
             this.client.emit("error", new Error("Existing connection detected"), this.id);
             return;
         }
@@ -63,59 +63,59 @@ class Shard extends EventEmitter {
     }
 
     /**
-    * Disconnects the shard
-    * @arg {Object?} [options] Shard disconnect options
-    * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
-    */
+     * Disconnects the shard
+     * @arg {Object?} [options] Shard disconnect options
+     * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
+     */
     disconnect(options, error) {
-        if(!this.ws) {
+        if (!this.ws) {
             return;
         }
         options = options || {};
-        if(this.heartbeatInterval) {
+        if (this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
         }
-        if(this.ws) {
+        if (this.ws) {
             this.ws.onclose = undefined;
             try {
-                if(options.reconnect && this.sessionID) {
+                if (options.reconnect && this.sessionID) {
                     this.ws.terminate();
                 } else {
                     this.ws.close();
                 }
-            } catch(err) {
+            } catch (err) {
                 /**
-                * Fired when the shard encounters an error
-                * @event Client#error
-                * @prop {Error} err The error
-                * @prop {Number} id The ID of the shard
-                */
+                 * Fired when the shard encounters an error
+                 * @event Client#error
+                 * @prop {Error} err The error
+                 * @prop {Number} id The ID of the shard
+                 */
                 this.client.emit("error", err, this.id);
             }
             /**
-            * Fired when the shard disconnects
-            * @event Shard#disconnect
-            * @prop {Error?} err The error, if any
-            */
+             * Fired when the shard disconnects
+             * @event Shard#disconnect
+             * @prop {Error?} err The error, if any
+             */
             this.emit("disconnect", error || null);
             this.ws = null;
         }
         this.status = "disconnected";
         this.reset();
-        if(options.reconnect === "auto" && this.client.options.autoreconnect) {
+        if (options.reconnect === "auto" && this.client.options.autoreconnect) {
             /**
-            * Fired when stuff happens and gives more info
-            * @event Client#debug
-            * @prop {String} message The debug message
-            * @prop {Number} id The ID of the shard
-            */
+             * Fired when stuff happens and gives more info
+             * @event Client#debug
+             * @prop {String} message The debug message
+             * @prop {Number} id The ID of the shard
+             */
             this.client.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
             setTimeout(() => {
                 this.client.shards.connect(this);
             }, this.reconnectInterval);
             this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
-        } else if(!options.reconnect) {
+        } else if (!options.reconnect) {
             this.hardReset();
         }
     }
@@ -172,10 +172,10 @@ class Shard extends EventEmitter {
                 "device": "Eris"
             }
         };
-        if(this.client.options.maxShards > 1) {
+        if (this.client.options.maxShards > 1) {
             identify.shard = [this.id, this.client.options.maxShards];
         }
-        if(this.presence.status) {
+        if (this.presence.status) {
             identify.presence = this.presence;
         }
         this.sendWS(OPCodes.IDENTIFY, identify, true);
@@ -184,36 +184,36 @@ class Shard extends EventEmitter {
     wsEvent(packet) {
         // var startTime = Date.now();
         // var debugStr = "";
-        switch(packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
+        switch (packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
             case "PRESENCE_UPDATE": {
-                if(packet.d.user.username !== undefined) {
+                if (packet.d.user.username !== undefined) {
                     var user = this.client.users.get(packet.d.user.id);
                     var oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar)) {
+                    if (user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
                             username: user.username,
                             discriminator: user.discriminator,
                             avatar: user.avatar
                         };
                     }
-                    if(!user || oldUser) {
+                    if (!user || oldUser) {
                         user = this.client.users.update(packet.d.user);
                         /**
-                        * Fired when a user's username or avatar changes
-                        * @event Client#userUpdate
-                        * @prop {User} user The updated user
-                        * @prop {Object?} oldUser The old user data
-                        * @prop {String} oldUser.username The username of the user
-                        * @prop {String} oldUser.discriminator The discriminator of the user
-                        * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
-                        */
+                         * Fired when a user's username or avatar changes
+                         * @event Client#userUpdate
+                         * @prop {User} user The updated user
+                         * @prop {Object?} oldUser The old user data
+                         * @prop {String} oldUser.username The username of the user
+                         * @prop {String} oldUser.discriminator The discriminator of the user
+                         * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
+                         */
                         this.client.emit("userUpdate", user, oldUser);
                     }
                 }
-                if(!packet.d.guild_id) {
+                if (!packet.d.guild_id) {
                     packet.d.id = packet.d.user.id;
                     var relationship = this.client.relationships.get(packet.d.id);
-                    if(!relationship) { // Removing relationships
+                    if (!relationship) { // Removing relationships
                         return;
                     }
                     var oldPresence = {
@@ -221,66 +221,66 @@ class Shard extends EventEmitter {
                         status: relationship.status
                     };
                     /**
-                    * Fired when a guild member or relationship's status or game changes
-                    * @event Client#presenceUpdate
-                    * @prop {Member | Relationship} other The updated member or relationship
-                    * @prop {Object?} oldPresence The old presence data. If the user was offline when the bot started and the client option getAllUsers is not true, this will be null
-                    * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
-                    * @prop {Object?} oldPresence.game The old game the other user was playing
-                    * @prop {String} oldPresence.game.name The name of the active game
-                    * @prop {Number} oldPresence.game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
-                    * @prop {String} oldPresence.game.url The url of the active game
-                    */
+                     * Fired when a guild member or relationship's status or game changes
+                     * @event Client#presenceUpdate
+                     * @prop {Member | Relationship} other The updated member or relationship
+                     * @prop {Object?} oldPresence The old presence data. If the user was offline when the bot started and the client option getAllUsers is not true, this will be null
+                     * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
+                     * @prop {Object?} oldPresence.game The old game the other user was playing
+                     * @prop {String} oldPresence.game.name The name of the active game
+                     * @prop {Number} oldPresence.game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
+                     * @prop {String} oldPresence.game.url The url of the active game
+                     */
                     this.client.emit("presenceUpdate", this.client.relationships.update(packet.d), oldPresence);
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     this.client.emit("warn", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
                 }
                 var member = guild.members.get(packet.d.id = packet.d.user.id);
                 var oldPresence = null;
-                if(member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url)))) {
+                if (member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url)))) {
                     oldPresence = {
                         game: member.game,
                         status: member.status
                     };
                 }
-                if((!member && packet.d.user.username) || oldPresence) {
+                if ((!member && packet.d.user.username) || oldPresence) {
                     member = guild.members.update(packet.d, guild);
                     this.client.emit("presenceUpdate", member, oldPresence);
                 }
                 break;
             }
             case "VOICE_STATE_UPDATE": { // (╯°□°）╯︵ ┻━┻
-                if(packet.d.guild_id === undefined) {
+                if (packet.d.guild_id === undefined) {
                     packet.d.id = packet.d.user_id;
-                    if(packet.d.channel_id === null) {
+                    if (packet.d.channel_id === null) {
                         var flag = false;
-                        for(var groupChannel of this.client.groupChannels) {
+                        for (var groupChannel of this.client.groupChannels) {
                             var call = (groupChannel[1].call || groupChannel[1].lastCall);
-                            if(call && call.voiceStates.remove(packet.d)) {
+                            if (call && call.voiceStates.remove(packet.d)) {
                                 flag = true;
                                 break;
                             }
                         }
-                        if(!flag) {
-                            for(var privateChannel of this.client.privateChannels) {
+                        if (!flag) {
+                            for (var privateChannel of this.client.privateChannels) {
                                 var call = (privateChannel[1].call || privateChannel[1].lastCall);
-                                if(call && call.voiceStates.remove(packet.d)) {
+                                if (call && call.voiceStates.remove(packet.d)) {
                                     flag = true;
                                     break;
                                 }
                             }
-                            if(!flag) {
+                            if (!flag) {
                                 this.client.emit("error", new Error("VOICE_STATE_UPDATE for user leaving call not found"));
                                 break;
                             }
                         }
                     } else {
                         var channel = this.client.getChannel(packet.d.channel_id);
-                        if(!channel.call && !channel.lastCall) {
+                        if (!channel.call && !channel.lastCall) {
                             this.client.emit("error", new Error("VOICE_STATE_UPDATE for untracked call"));
                             break;
                         }
@@ -289,17 +289,17 @@ class Shard extends EventEmitter {
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if(!guild) {
+                if (!guild) {
                     break;
                 }
-                if(guild.pendingVoiceStates) {
+                if (guild.pendingVoiceStates) {
                     guild.pendingVoiceStates.push(packet.d);
                     break;
                 }
                 var member = guild.members.get(packet.d.id = packet.d.user_id);
-                if(!member) {
+                if (!member) {
                     var channel = guild.channels.find((channel) => channel.type === 2 && channel.voiceMembers.get(packet.d.id));
-                    if(channel) {
+                    if (channel) {
                         channel.voiceMembers.remove(packet.d);
                         this.client.emit("warn", "VOICE_STATE_UPDATE member null but in channel: " + packet.d.id, this.id);
                         break;
@@ -314,83 +314,83 @@ class Shard extends EventEmitter {
                 };
                 var oldChannelID = member.voiceState.channelID;
                 member.update(packet.d, this.client);
-                if(member.user.id === this.client.user.id) {
+                if (member.user.id === this.client.user.id) {
                     var voiceConnection = this.client.voiceConnections.guilds[packet.d.guild_id];
-                    if(voiceConnection && voiceConnection.channelID !== packet.d.channel_id) {
+                    if (voiceConnection && voiceConnection.channelID !== packet.d.channel_id) {
                         voiceConnection.switchChannel(packet.d.channel_id, true);
                     }
                 }
-                if(oldChannelID != packet.d.channel_id) {
+                if (oldChannelID != packet.d.channel_id) {
                     var oldChannel, newChannel;
-                    if(oldChannelID) {
+                    if (oldChannelID) {
                         oldChannel = guild.channels.get(oldChannelID);
                     }
-                    if(packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && newChannel.type === 2) { // Welcome to Discord, where one can "join" text channels
-                        if(oldChannel) {
+                    if (packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && newChannel.type === 2) { // Welcome to Discord, where one can "join" text channels
+                        if (oldChannel) {
                             /**
-                            * Fired when a guild member switches voice channels
-                            * @event Client#voiceChannelSwitch
-                            * @prop {Member} member The member
-                            * @prop {GuildChannel} newChannel The new voice channel
-                            * @prop {GuildChannel} oldChannel The old voice channel
-                            */
+                             * Fired when a guild member switches voice channels
+                             * @event Client#voiceChannelSwitch
+                             * @prop {Member} member The member
+                             * @prop {GuildChannel} newChannel The new voice channel
+                             * @prop {GuildChannel} oldChannel The old voice channel
+                             */
                             oldChannel.voiceMembers.remove(member);
                             this.client.emit("voiceChannelSwitch", newChannel.voiceMembers.add(member, guild), newChannel, oldChannel);
                         } else {
                             /**
-                            * Fired when a guild member joins a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
-                            * @event Client#voiceChannelJoin
-                            * @prop {Member} member The member
-                            * @prop {GuildChannel} newChannel The voice channel
-                            */
+                             * Fired when a guild member joins a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
+                             * @event Client#voiceChannelJoin
+                             * @prop {Member} member The member
+                             * @prop {GuildChannel} newChannel The voice channel
+                             */
                             this.client.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
-                    } else if(oldChannel) {
+                    } else if (oldChannel) {
                         /**
-                        * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
-                        * @event Client#voiceChannelLeave
-                        * @prop {Member} member The member
-                        * @prop {GuildChannel} oldChannel The voice channel
-                        */
+                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
+                         * @event Client#voiceChannelLeave
+                         * @prop {Member} member The member
+                         * @prop {GuildChannel} oldChannel The voice channel
+                         */
                         this.client.emit("voiceChannelLeave", oldChannel.voiceMembers.remove(member), oldChannel);
                     }
                 }
-                if(oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf) {
+                if (oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf) {
                     /**
-                    * Fired when a guild member's voice state changes
-                    * @event Client#voiceStateUpdate
-                    * @prop {Member} member The member
-                    * @prop {Object} oldState The old voice state
-                    * @prop {Boolean} oldState.mute The previous server mute status
-                    * @prop {Boolean} oldState.deaf The previous server deaf status
-                    * @prop {Boolean} oldState.selfMute The previous self mute status
-                    * @prop {Boolean} oldState.selfDeaf The previous self deaf status
-                    */
+                     * Fired when a guild member's voice state changes
+                     * @event Client#voiceStateUpdate
+                     * @prop {Member} member The member
+                     * @prop {Object} oldState The old voice state
+                     * @prop {Boolean} oldState.mute The previous server mute status
+                     * @prop {Boolean} oldState.deaf The previous server deaf status
+                     * @prop {Boolean} oldState.selfMute The previous self mute status
+                     * @prop {Boolean} oldState.selfDeaf The previous self deaf status
+                     */
                     this.client.emit("voiceStateUpdate", member, oldState);
                 }
                 break;
             }
             case "TYPING_START": {
-                if(this.client.listeners("typingStart").length > 0) {
+                if (this.client.listeners("typingStart").length > 0) {
                     /**
-                    * Fired when a user begins typing
-                    * @event Client#typingStart
-                    * @prop {Channel} channel The text channel the user is typing in
-                    * @prop {User} user The user
-                    */
+                     * Fired when a user begins typing
+                     * @event Client#typingStart
+                     * @prop {Channel} channel The text channel the user is typing in
+                     * @prop {User} user The user
+                     */
                     this.client.emit("typingStart", this.client.getChannel(packet.d.channel_id), this.client.users.get(packet.d.user_id));
                 }
                 break;
             }
             case "MESSAGE_CREATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(channel) { // MESSAGE_CREATE just when deleting o.o
+                if (channel) { // MESSAGE_CREATE just when deleting o.o
                     channel.lastMessageID = packet.d.id;
                     /**
-                    * Fired when a message is created
-                    * @event Client#messageCreate
-                    * @prop {Message} message The message
-                    */
+                     * Fired when a message is created
+                     * @event Client#messageCreate
+                     * @prop {Message} message The message
+                     */
                     this.client.emit("messageCreate", channel.messages.add(packet.d, this.client));
                 } else {
                     this.client.emit("debug", "MESSAGE_CREATE but channel not found (OK if deleted channel)", this.id);
@@ -399,14 +399,14 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.id);
                 var oldMessage = {
                     id: packet.d.id
                 };
-                if(message) {
+                if (message) {
                     oldMessage = {
                         attachments: message.attachments,
                         content: message.content,
@@ -420,50 +420,50 @@ class Shard extends EventEmitter {
                     };
                 }
                 /**
-                * Fired when a message is updated
-                * @event Client#messageUpdate
-                * @prop {Message} message The updated message. If oldMessage was undefined, it is not recommended to use this since it will be very incomplete
-                * @prop {Object?} oldMessage The old message data, if the message was cached
-                * @prop {Object[]} oldMessage.id The ID of the message
-                * @prop {Object[]?} oldMessage.attachments Array of attachments
-                * @prop {Object[]?} oldMessage.embeds Array of embeds
-                * @prop {String?} oldMessage.content Message content
-                * @prop {Number?} oldMessage.editedTimestamp Timestamp of latest message edit
-                * @prop {Object?} oldMessage.mentionedBy Object of if different things mention the bot user
-                * @prop {Boolean?} oldMessage.tts Whether to play the message using TTS or not
-                * @prop {String[]?} oldMessage.mentions Array of mentioned users' ids
-                * @prop {String[]?} oldMessage.roleMentions Array of mentioned roles' ids.
-                * @prop {String[]?} oldMessage.channelMentions Array of mentions channels' ids.
-                */
+                 * Fired when a message is updated
+                 * @event Client#messageUpdate
+                 * @prop {Message} message The updated message. If oldMessage was undefined, it is not recommended to use this since it will be very incomplete
+                 * @prop {Object?} oldMessage The old message data, if the message was cached
+                 * @prop {Object[]} oldMessage.id The ID of the message
+                 * @prop {Object[]?} oldMessage.attachments Array of attachments
+                 * @prop {Object[]?} oldMessage.embeds Array of embeds
+                 * @prop {String?} oldMessage.content Message content
+                 * @prop {Number?} oldMessage.editedTimestamp Timestamp of latest message edit
+                 * @prop {Object?} oldMessage.mentionedBy Object of if different things mention the bot user
+                 * @prop {Boolean?} oldMessage.tts Whether to play the message using TTS or not
+                 * @prop {String[]?} oldMessage.mentions Array of mentioned users' ids
+                 * @prop {String[]?} oldMessage.roleMentions Array of mentioned roles' ids.
+                 * @prop {String[]?} oldMessage.channelMentions Array of mentions channels' ids.
+                 */
                 this.client.emit("messageUpdate", channel.messages.update(packet.d, this.client), oldMessage);
                 break;
             }
             case "MESSAGE_DELETE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 /**
-                * Fired when a cached message is deleted
-                * @event Client#messageDelete
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                */
+                 * Fired when a cached message is deleted
+                 * @event Client#messageDelete
+                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                 */
                 this.client.emit("messageDelete", channel.messages.remove(packet.d) || {
-                    id: packet.d.id,
-                    channel: channel
-                });
+                        id: packet.d.id,
+                        channel: channel
+                    });
                 break;
             }
             case "MESSAGE_DELETE_BULK": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
 
                 /**
                  * Fired when a bulk delete occurs
                  * @event Client#messageDeleteBulk
-                * @prop {Message[] | Object[]} messages An array of (potentially partial) message objects. If a message is not cached, it will be an object with `id` and `channel` keys. No other property is guaranteed
+                 * @prop {Message[] | Object[]} messages An array of (potentially partial) message objects. If a message is not cached, it will be an object with `id` and `channel` keys. No other property is guaranteed
                  */
                 this.client.emit("messageDeleteBulk", packet.d.ids.map((id) => (channel.messages.remove({
                     id
@@ -475,15 +475,15 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_REACTION_ADD": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.message_id);
-                if(message) {
+                if (message) {
                     var reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if(message.reactions[reaction]) {
+                    if (message.reactions[reaction]) {
                         ++message.reactions[reaction].count;
-                        if(packet.d.user_id === this.client.user.id) {
+                        if (packet.d.user_id === this.client.user.id) {
                             message.reactions[reaction].me = true;
                         }
                     } else {
@@ -494,68 +494,68 @@ class Shard extends EventEmitter {
                     }
                 }
                 /**
-                * Fired when someone adds a reaction to a message
-                * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                * @prop {Object} emoji The reaction emoji object
-                * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
-                * @prop {String} emoji.name The emoji name
-                * @prop {String} userID The ID of the user that added the reaction
-                */
+                 * Fired when someone adds a reaction to a message
+                 * @event Client#messageReactionAdd
+                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                 * @prop {Object} emoji The reaction emoji object
+                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
+                 * @prop {String} emoji.name The emoji name
+                 * @prop {String} userID The ID of the user that added the reaction
+                 */
                 this.client.emit("messageReactionAdd", message || {
-                    id: packet.d.message_id,
-                    channel: channel
-                }, packet.d.emoji, packet.d.user_id);
+                        id: packet.d.message_id,
+                        channel: channel
+                    }, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.message_id);
-                if(message) {
+                if (message) {
                     var reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if(message.reactions[reaction]) {
+                    if (message.reactions[reaction]) {
                         --message.reactions[reaction].count;
-                        if(packet.d.user_id === this.client.user.id) {
+                        if (packet.d.user_id === this.client.user.id) {
                             message.reactions[reaction].me = false;
                         }
                     }
                 }
                 /**
-                * Fired when someone removes a reaction from a message
-                * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                * @prop {Object} emoji The reaction emoji object
-                * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
-                * @prop {String} emoji.name The emoji name
-                * @prop {String} userID The ID of the user that removed the reaction
-                */
+                 * Fired when someone removes a reaction from a message
+                 * @event Client#messageReactionRemove
+                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                 * @prop {Object} emoji The reaction emoji object
+                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
+                 * @prop {String} emoji.name The emoji name
+                 * @prop {String} userID The ID of the user that removed the reaction
+                 */
                 this.client.emit("messageReactionRemove", message || {
-                    id: packet.d.message_id,
-                    channel: channel
-                }, packet.d.emoji, packet.d.user_id);
+                        id: packet.d.message_id,
+                        channel: channel
+                    }, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTIONS_REMOVE_ALL": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     break;
                 }
                 /**
-                * Fired when someone removes a reaction from a message
-                * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                * @prop {Object} emoji The reaction emoji object
-                * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
-                * @prop {String} emoji.name The emoji name
-                * @prop {String} userID The ID of the user that removed the reaction
-                */
+                 * Fired when someone removes a reaction from a message
+                 * @event Client#messageReactionRemove
+                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                 * @prop {Object} emoji The reaction emoji object
+                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
+                 * @prop {String} emoji.name The emoji name
+                 * @prop {String} userID The ID of the user that removed the reaction
+                 */
                 this.client.emit("messageReactionRemoveAll", channel.messages.get(packet.d.message_id) || {
-                    id: packet.d.message_id,
-                    channel: channel
-                });
+                        id: packet.d.message_id,
+                        channel: channel
+                    });
                 break;
             }
             case "GUILD_MEMBER_ADD": {
@@ -563,11 +563,11 @@ class Shard extends EventEmitter {
                 packet.d.id = packet.d.user.id;
                 ++guild.memberCount;
                 /**
-                * Fired when a member joins a server
-                * @event Client#guildMemberAdd
-                * @prop {Guild} guild The guild
-                * @prop {Member} member The member
-                */
+                 * Fired when a member joins a server
+                 * @event Client#guildMemberAdd
+                 * @prop {Guild} guild The guild
+                 * @prop {Member} member The member
+                 */
                 this.client.emit("guildMemberAdd", guild, guild.members.add(packet.d, guild));
                 break;
             }
@@ -575,7 +575,7 @@ class Shard extends EventEmitter {
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 var member = guild.members.get(packet.d.id = packet.d.user.id);
                 var oldMember = null;
-                if(member) {
+                if (member) {
                     oldMember = {
                         roles: member.roles,
                         nick: member.nick
@@ -583,53 +583,53 @@ class Shard extends EventEmitter {
                 }
                 member = guild.members.update(packet.d, guild);
                 /**
-                * Fired when a member's roles or nickname are updated
-                * @event Client#guildMemberUpdate
-                * @prop {Guild} guild The guild
-                * @prop {Member} member The updated member
-                * @prop {Object?} oldMember The old member data
-                * @prop {String[]} oldMember.roles An array of role IDs this member is a part of
-                * @prop {String?} oldMember.nick The server nickname of the member
-                */
+                 * Fired when a member's roles or nickname are updated
+                 * @event Client#guildMemberUpdate
+                 * @prop {Guild} guild The guild
+                 * @prop {Member} member The updated member
+                 * @prop {Object?} oldMember The old member data
+                 * @prop {String[]} oldMember.roles An array of role IDs this member is a part of
+                 * @prop {String?} oldMember.nick The server nickname of the member
+                 */
                 this.client.emit("guildMemberUpdate", guild, member, oldMember);
                 break;
             }
             case "GUILD_MEMBER_REMOVE": {
-                if(packet.d.user.id === this.client.user.id) { // The bot is probably leaving
+                if (packet.d.user.id === this.client.user.id) { // The bot is probably leaving
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 --guild.memberCount;
                 packet.d.id = packet.d.user.id;
                 /**
-                * Fired when a member leaves a server
-                * @event Client#guildMemberRemove
-                * @prop {Guild} guild The guild
-                * @prop {Member | Object} member The member. If the member is not cached, this will be an object with `id` and `user` key
-                */
+                 * Fired when a member leaves a server
+                 * @event Client#guildMemberRemove
+                 * @prop {Guild} guild The guild
+                 * @prop {Member | Object} member The member. If the member is not cached, this will be an object with `id` and `user` key
+                 */
                 this.client.emit("guildMemberRemove", guild, guild.members.remove(packet.d) || {
-                    id: packet.d.id,
-                    user: new User(packet.d.user)
-                });
+                        id: packet.d.id,
+                        user: new User(packet.d.user)
+                    });
                 break;
             }
             case "GUILD_CREATE": {
-                if(!packet.d.unavailable) {
+                if (!packet.d.unavailable) {
                     var guild = this.createGuild(packet.d);
-                    if(this.ready) {
-                        if(this.client.unavailableGuilds.remove(packet.d)) {
+                    if (this.ready) {
+                        if (this.client.unavailableGuilds.remove(packet.d)) {
                             /**
-                            * Fired when an guild becomes available
-                            * @event Client#guildAvailable
-                            * @prop {Guild} guild The guild
-                            */
+                             * Fired when an guild becomes available
+                             * @event Client#guildAvailable
+                             * @prop {Guild} guild The guild
+                             */
                             this.client.emit("guildAvailable", guild);
                         } else {
                             /**
-                            * Fired when an guild is created
-                            * @event Client#guildCreate
-                            * @prop {Guild} guild The guild
-                            */
+                             * Fired when an guild is created
+                             * @event Client#guildCreate
+                             * @prop {Guild} guild The guild
+                             */
                             this.client.emit("guildCreate", guild);
                         }
                     } else {
@@ -639,10 +639,10 @@ class Shard extends EventEmitter {
                 } else {
                     this.client.guilds.remove(packet.d);
                     /**
-                    * Fired when an unavailable guild is created
-                    * @event Client#unavailableGuildCreate
-                    * @prop {UnavailableGuild} guild The unavailable guild
-                    */
+                     * Fired when an unavailable guild is created
+                     * @event Client#unavailableGuildCreate
+                     * @prop {UnavailableGuild} guild The unavailable guild
+                     */
                     this.client.emit("unavailableGuildCreate", this.client.unavailableGuilds.add(packet.d, this.client));
                 }
                 break;
@@ -663,78 +663,78 @@ class Shard extends EventEmitter {
                     afkTimeout: guild.afk_timeout
                 };
                 /**
-                * Fired when an guild is updated
-                * @event Client#guildUpdate
-                * @prop {Guild} guild The guild
-                * @prop {Object} oldGuild The old guild data
-                * @prop {String} oldGuild.name The name of the guild
-                * @prop {Number} oldGuild.verificationLevel The guild verification level
-                * @prop {String} oldGuild.region The region of the guild
-                * @prop {String?} oldGuild.icon The hash of the guild icon, or null if no icon
-                * @prop {String} oldGuild.afkChannelID The ID of the AFK voice channel
-                * @prop {Number} oldGuild.afkTimeout The AFK timeout in seconds
-                * @prop {String} oldGuild.ownerID The ID of the user that is the guild owner
-                * @prop {String?} oldGuild.splash The hash of the guild splash image, or null if no splash (VIP only)
-                * @prop {Object[]} oldGuild.features An array of guild features
-                * @prop {Object[]} oldGuild.emojis An array of guild emojis
-                */
+                 * Fired when an guild is updated
+                 * @event Client#guildUpdate
+                 * @prop {Guild} guild The guild
+                 * @prop {Object} oldGuild The old guild data
+                 * @prop {String} oldGuild.name The name of the guild
+                 * @prop {Number} oldGuild.verificationLevel The guild verification level
+                 * @prop {String} oldGuild.region The region of the guild
+                 * @prop {String?} oldGuild.icon The hash of the guild icon, or null if no icon
+                 * @prop {String} oldGuild.afkChannelID The ID of the AFK voice channel
+                 * @prop {Number} oldGuild.afkTimeout The AFK timeout in seconds
+                 * @prop {String} oldGuild.ownerID The ID of the user that is the guild owner
+                 * @prop {String?} oldGuild.splash The hash of the guild splash image, or null if no splash (VIP only)
+                 * @prop {Object[]} oldGuild.features An array of guild features
+                 * @prop {Object[]} oldGuild.emojis An array of guild emojis
+                 */
                 this.client.emit("guildUpdate", this.client.guilds.update(packet.d, this.client), oldGuild);
                 break;
             }
             case "GUILD_DELETE": {
                 delete this.client.guildShardMap[packet.d.id];
                 var guild = this.client.guilds.remove(packet.d);
-                if(guild) { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
+                if (guild) { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
                     guild.channels.forEach((channel) => {
                         delete this.client.channelGuildMap[channel.id];
                     });
                 }
-                if(packet.d.unavailable) {
+                if (packet.d.unavailable) {
                     /**
-                    * Fired when an guild becomes unavailable
-                    * @event Client#guildUnavailable
-                    * @prop {Guild} guild The guild
-                    */
+                     * Fired when an guild becomes unavailable
+                     * @event Client#guildUnavailable
+                     * @prop {Guild} guild The guild
+                     */
                     this.client.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
                 } else {
                     /**
-                    * Fired when an guild is deleted
-                    * @event Client#guildDelete
-                    * @prop {Guild} guild The guild
-                    */
+                     * Fired when an guild is deleted
+                     * @event Client#guildDelete
+                     * @prop {Guild} guild The guild
+                     */
                     this.client.emit("guildDelete", guild || {
-                        id: packet.d.id
-                    });
+                            id: packet.d.id
+                        });
                 }
                 break;
             }
             case "GUILD_BAN_ADD": {
                 /**
-                * Fired when a user is banned from a guild
-                * @event Client#guildBanAdd
-                * @prop {Guild} guild The guild
-                * @prop {User} user The banned user
-                */
+                 * Fired when a user is banned from a guild
+                 * @event Client#guildBanAdd
+                 * @prop {Guild} guild The guild
+                 * @prop {User} user The banned user
+                 */
                 this.client.emit("guildBanAdd", this.client.guilds.get(packet.d.guild_id), this.client.users.add(packet.d.user, this.client));
                 break;
             }
             case "GUILD_BAN_REMOVE": {
                 /**
-                * Fired when a user is unbanned from a guild
-                * @event Client#guildBanRemove
-                * @prop {Guild} guild The guild
-                * @prop {User} user The banned user
-                */
+                 * Fired when a user is unbanned from a guild
+                 * @event Client#guildBanRemove
+                 * @prop {Guild} guild The guild
+                 * @prop {User} user The banned user
+                 */
                 this.client.emit("guildBanRemove", this.client.guilds.get(packet.d.guild_id), this.client.users.add(packet.d.user, this.client));
                 break;
             }
             case "GUILD_ROLE_CREATE": {
                 /**
-                * Fired when a guild role is created
-                * @event Client#guildRoleCreate
-                * @prop {Guild} guild The guild
-                * @prop {Role} role The role
-                */
+                 * Fired when a guild role is created
+                 * @event Client#guildRoleCreate
+                 * @prop {Guild} guild The guild
+                 * @prop {Role} role The role
+                 */
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 this.client.emit("guildRoleCreate", guild, guild.roles.add(packet.d.role, guild));
                 break;
@@ -743,7 +743,7 @@ class Shard extends EventEmitter {
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 var role = guild.roles.add(packet.d.role, guild);
                 var oldRole = null;
-                if(role) {
+                if (role) {
                     oldRole = {
                         color: role.color,
                         hoist: role.hoist,
@@ -754,55 +754,55 @@ class Shard extends EventEmitter {
                     };
                 }
                 /**
-                * Fired when a guild role is updated
-                * @event Client#guildRoleUpdate
-                * @prop {Guild} guild The guild
-                * @prop {Role} role The updated role
-                * @prop {Object} oldRole The old role data
-                * @prop {String} oldRole.name The name of the role
-                * @prop {Boolean} oldRole.managed Whether a guild integration manages this role or not
-                * @prop {Boolean} oldRole.hoist Whether users with this role are hoisted in the user list or not
-                * @prop {Number} oldRole.color The hex color of the role in base 10
-                * @prop {Number} oldRole.position The position of the role
-                * @prop {Number} oldRole.permissions The permissions number of the role
-                */
+                 * Fired when a guild role is updated
+                 * @event Client#guildRoleUpdate
+                 * @prop {Guild} guild The guild
+                 * @prop {Role} role The updated role
+                 * @prop {Object} oldRole The old role data
+                 * @prop {String} oldRole.name The name of the role
+                 * @prop {Boolean} oldRole.managed Whether a guild integration manages this role or not
+                 * @prop {Boolean} oldRole.hoist Whether users with this role are hoisted in the user list or not
+                 * @prop {Number} oldRole.color The hex color of the role in base 10
+                 * @prop {Number} oldRole.position The position of the role
+                 * @prop {Number} oldRole.permissions The permissions number of the role
+                 */
                 this.client.emit("guildRoleUpdate", guild, guild.roles.update(packet.d.role, guild), oldRole);
                 break;
             }
             case "GUILD_ROLE_DELETE": {
                 /**
-                * Fired when a guild role is deleted
-                * @event Client#guildRoleDelete
-                * @prop {Guild} guild The guild
-                * @prop {Role} role The role
-                */
+                 * Fired when a guild role is deleted
+                 * @event Client#guildRoleDelete
+                 * @prop {Guild} guild The guild
+                 * @prop {Role} role The role
+                 */
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if(guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
+                if (guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
                     this.client.emit("guildRoleDelete", guild, guild.roles.remove({id: packet.d.role_id}));
                 }
                 break;
             }
             case "CHANNEL_CREATE": {
-                if(packet.d.type === undefined || packet.d.type === 1) {
-                    if(this.id === 0) {
+                if (packet.d.type === undefined || packet.d.type === 1) {
+                    if (this.id === 0) {
                         /**
-                        * Fired when a channel is created
-                        * @event Client#channelCreate
-                        * @prop {Channel} channel The channel
-                        */
+                         * Fired when a channel is created
+                         * @event Client#channelCreate
+                         * @prop {Channel} channel The channel
+                         */
                         this.client.privateChannelMap[packet.d.recipients[0].id] = packet.d.id;
                         this.client.emit("channelCreate", this.client.privateChannels.add(packet.d, this.client));
                     }
-                } else if(packet.d.type === 0 || packet.d.type === 2) {
+                } else if (packet.d.type === 0 || packet.d.type === 2) {
                     var guild = this.client.guilds.get(packet.d.guild_id);
-                    if(!guild) {
+                    if (!guild) {
                         break;
                     }
                     var channel = guild.channels.add(packet.d, guild);
                     this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
                     this.client.emit("channelCreate", channel);
-                } else if(packet.d.type === 3) {
-                    if(this.id === 0) {
+                } else if (packet.d.type === 3) {
+                    if (this.id === 0) {
                         this.client.emit("channelCreate", this.client.groupChannels.add(packet.d, this.client));
                     }
                 } else {
@@ -812,11 +812,11 @@ class Shard extends EventEmitter {
             }
             case "CHANNEL_UPDATE": {
                 var channel = this.client.getChannel(packet.d.id);
-                if(!channel) {
+                if (!channel) {
                     return;
                 }
-                if(channel.type === 3) {
-                    if(this.id !== 0) {
+                if (channel.type === 3) {
+                    if (this.id !== 0) {
                         break;
                     }
                     var oldChannel = {
@@ -825,7 +825,7 @@ class Shard extends EventEmitter {
                         icon: channel.icon
                     };
                 }
-                if(channel.type === 0 || channel.type === 2) {
+                if (channel.type === 0 || channel.type === 2) {
                     var oldChannel = {
                         name: channel.name,
                         topic: channel.topic,
@@ -836,47 +836,47 @@ class Shard extends EventEmitter {
                 }
                 channel.update(packet.d);
                 /**
-                * Fired when a channel is updated
-                * @event Client#channelUpdate
-                * @prop {Channel} channel The updated channel
-                * @prop {Object} oldChannel The old channel data
-                * @prop {String} oldChannel.name The name of the channel
-                * @prop {Number} oldChannel.position The position of the channel
-                * @prop {String?} oldChannel.topic The topic of the channel (text channels only)
-                * @prop {Number?} oldChannel.bitrate The bitrate of the channel (voice channels only)
-                * @prop {Collection} oldChannel.permissionOverwrites Collection of PermissionOverwrites in this channel
-                */
+                 * Fired when a channel is updated
+                 * @event Client#channelUpdate
+                 * @prop {Channel} channel The updated channel
+                 * @prop {Object} oldChannel The old channel data
+                 * @prop {String} oldChannel.name The name of the channel
+                 * @prop {Number} oldChannel.position The position of the channel
+                 * @prop {String?} oldChannel.topic The topic of the channel (text channels only)
+                 * @prop {Number?} oldChannel.bitrate The bitrate of the channel (voice channels only)
+                 * @prop {Collection} oldChannel.permissionOverwrites Collection of PermissionOverwrites in this channel
+                 */
                 this.client.emit("channelUpdate", channel, oldChannel);
                 break;
             }
             case "CHANNEL_DELETE": {
-                if(packet.d.type === 1 || packet.d.type === undefined) {
-                    if(this.id === 0) {
+                if (packet.d.type === 1 || packet.d.type === undefined) {
+                    if (this.id === 0) {
                         var channel = this.client.privateChannels.remove(packet.d);
-                        if(channel) {
+                        if (channel) {
                             delete this.client.privateChannelMap[channel.recipient.id];
                             /**
-                            * Fired when a channel is deleted
-                            * @event Client#channelDelete
-                            * @prop {Channel} channel The channel
-                            */
+                             * Fired when a channel is deleted
+                             * @event Client#channelDelete
+                             * @prop {Channel} channel The channel
+                             */
                             this.client.emit("channelDelete", channel);
                         }
                     }
-                } else if(packet.d.type === 0 || packet.d.type === 2) {
+                } else if (packet.d.type === 0 || packet.d.type === 2) {
                     delete this.client.channelGuildMap[packet.d.id];
                     var channel = this.client.guilds.get(packet.d.guild_id).channels.remove(packet.d);
-                    if(!channel) {
+                    if (!channel) {
                         return;
                     }
-                    if(channel.type === 2) {
+                    if (channel.type === 2) {
                         channel.voiceMembers.forEach((member) => {
                             this.client.emit("voiceChannelLeave", channel.voiceMembers.remove(member), channel);
                         });
                     }
                     this.client.emit("channelDelete", channel);
-                } else if(packet.d.type === 3) {
-                    if(this.id === 0) {
+                } else if (packet.d.type === 3) {
+                    if (this.id === 0) {
                         this.client.emit("channelDelete", this.client.groupChannels.remove(packet.d));
                     }
                 } else {
@@ -887,41 +887,41 @@ class Shard extends EventEmitter {
             case "CALL_CREATE": {
                 packet.d.id = packet.d.message_id;
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(channel.call) {
+                if (channel.call) {
                     channel.call.update(packet.d);
                 } else {
                     channel.call = new Call(packet.d, channel);
                     var incrementedID = "";
                     var overflow = true;
                     var chunks = packet.d.id.match(/\d{1,9}/g).map((chunk) => parseInt(chunk));
-                    for(var i = chunks.length - 1; i >= 0; --i) {
-                        if(overflow) {
+                    for (var i = chunks.length - 1; i >= 0; --i) {
+                        if (overflow) {
                             ++chunks[i];
                             overflow = false;
                         }
-                        if(chunks[i] > 999999999) {
+                        if (chunks[i] > 999999999) {
                             overflow = true;
                             incrementedID = "000000000" + incrementedID;
                         } else {
                             incrementedID = chunks[i] + incrementedID;
                         }
                     }
-                    if(overflow) {
+                    if (overflow) {
                         incrementedID = overflow + incrementedID;
                     }
                     this.client.getMessages(channel.id, 1, incrementedID);
                 }
                 /**
-                * Fired when a call is created
-                * @event Client#callCreate
-                * @prop {Call} call The call
-                */
+                 * Fired when a call is created
+                 * @event Client#callCreate
+                 * @prop {Call} call The call
+                 */
                 this.client.emit("callCreate", channel.call);
                 break;
             }
             case "CALL_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel.call) {
+                if (!channel.call) {
                     throw new Error("CALL_UPDATE but channel has no call");
                 }
                 var oldCall = {
@@ -932,92 +932,99 @@ class Shard extends EventEmitter {
                     unavailable: channel.call.unavailable,
                 };
                 /**
-                * Fired when a call is updated
-                * @event Client#callUpdate
-                * @prop {Call} call The updated call
-                * @prop {Object} oldCall The old call data
-                * @prop {String[]} oldCall.participants The IDs of the call participants
-                * @prop {Number?} oldCall.endedTimestamp The timestamp of the call end
-                * @prop {String[]?} oldCall.ringing The IDs of people that were being rung
-                * @prop {String?} oldCall.region The region of the call server
-                * @prop {Boolean} oldCall.unavailable Whether the call was unavailable or not
-                */
+                 * Fired when a call is updated
+                 * @event Client#callUpdate
+                 * @prop {Call} call The updated call
+                 * @prop {Object} oldCall The old call data
+                 * @prop {String[]} oldCall.participants The IDs of the call participants
+                 * @prop {Number?} oldCall.endedTimestamp The timestamp of the call end
+                 * @prop {String[]?} oldCall.ringing The IDs of people that were being rung
+                 * @prop {String?} oldCall.region The region of the call server
+                 * @prop {Boolean} oldCall.unavailable Whether the call was unavailable or not
+                 */
                 this.client.emit("callUpdate", channel.call.update(packet.d), oldCall);
                 break;
             }
             case "CALL_DELETE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel.call) {
+                if (!channel.call) {
                     throw new Error("CALL_DELETE but channel has no call");
                 }
                 channel.lastCall = channel.call;
                 channel.call = null;
                 /**
-                * Fired when a call is deleted
-                * @event Client#callDelete
-                * @prop {Call} call The call
-                */
+                 * Fired when a call is deleted
+                 * @event Client#callDelete
+                 * @prop {Call} call The call
+                 */
                 this.client.emit("callDelete", channel.lastCall);
                 break;
             }
             case "CHANNEL_RECIPIENT_ADD": {
                 var channel = this.client.groupChannels.get(packet.d.channel_id);
-                    /**
-                    * Fired when a user joins a group channel
-                    * @event Client#channelRecipientAdd
-                    * @prop {GroupChannel} channel The channel
-                    * @prop {User} user The user
-                    */
+                /**
+                 * Fired when a user joins a group channel
+                 * @event Client#channelRecipientAdd
+                 * @prop {GroupChannel} channel The channel
+                 * @prop {User} user The user
+                 */
                 this.client.emit("channelRecipientAdd", channel, channel.recipients.add(this.client.users.add(packet.d.user, this.client)));
                 break;
             }
             case "CHANNEL_RECIPIENT_REMOVE": {
                 var channel = this.client.groupChannels.get(packet.d.channel_id);
-                    /**
-                    * Fired when a user leaves a group channel
-                    * @event Client#channelRecipientRemove
-                    * @prop {GroupChannel} channel The channel
-                    * @prop {User} user The user
-                    */
+                /**
+                 * Fired when a user leaves a group channel
+                 * @event Client#channelRecipientRemove
+                 * @prop {GroupChannel} channel The channel
+                 * @prop {User} user The user
+                 */
                 this.client.emit("channelRecipientRemove", channel, channel.recipients.remove(packet.d.user));
                 break;
             }
             case "FRIEND_SUGGESTION_CREATE": {
                 /**
-                * Fired when a client receives a friend suggestion
-                * @event Client#friendSuggestionCreate
-                * @prop {User} user The suggested user
-                * @prop {String[]} reasons Array of reasons why this suggestion was made
-                * @prop {Number} reasons.type Type of reason?
-                * @prop {String} reasons.platform_type Platform you share with the user
-                * @prop {String} reasons.name Username of suggested user on that platform
-                */
-                this.client.emit("friendSuggestionCreate",new User(packet.d.suggested_user), packet.d.reasons);
+                 * Fired when a client receives a friend suggestion
+                 * @event Client#friendSuggestionCreate
+                 * @prop {User} user The suggested user
+                 * @prop {String[]} reasons Array of reasons why this suggestion was made
+                 * @prop {Number} reasons.type Type of reason?
+                 * @prop {String} reasons.platform_type Platform you share with the user
+                 * @prop {String} reasons.name Username of suggested user on that platform
+                 */
+                this.client.emit("friendSuggestionCreate", new User(packet.d.suggested_user), packet.d.reasons);
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {
                 /**
-                * Fired when a client's friend suggestion is removed for any reason
-                * @event Client#friendSuggestionDelete
-                * @prop {User} user The suggested user
-                */
+                 * Fired when a client's friend suggestion is removed for any reason
+                 * @event Client#friendSuggestionDelete
+                 * @prop {User} user The suggested user
+                 */
                 this.client.emit("friendSuggestionDelete", this.client.users.get(packet.d.suggested_user_id));
                 break;
             }
             case "GUILD_MEMBERS_CHUNK": {
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if(this.getAllUsersCount.hasOwnProperty(guild.id)) {
-                    if(this.getAllUsersCount[guild.id] <= 1) {
+                if (this.getAllUsersCount.hasOwnProperty(guild.id)) {
+                    if (this.getAllUsersCount[guild.id] <= 1) {
                         delete this.getAllUsersCount[guild.id];
                         this.checkReady();
                     } else {
                         --this.getAllUsersCount[guild.id];
                     }
                 }
-                packet.d.members.forEach((member) => {
+
+                /**
+                 * Fired when discord sends members on startup
+                 * @event Client#guildMemberChunk
+                 * @prop {Guild} The guild the members were loaded from
+                 * @prop {Array<Member>} members The newly added members
+                 */
+                this.client.emit("guildMemberChunk", guild, packet.d.members.map((member) => {
                     member.id = member.user.id;
-                    guild.members.add(member, guild);
-                });
+                    return guild.members.add(member, guild);
+                }));
 
                 this.lastHeartbeatAck = true;
 
@@ -1027,14 +1034,14 @@ class Shard extends EventEmitter {
             }
             case "GUILD_SYNC": {// (╯°□°）╯︵ ┻━┻ thx Discord devs
                 var guild = this.client.guilds.get(packet.d.id);
-                for(var member of packet.d.members) {
+                for (var member of packet.d.members) {
                     member.id = member.user.id;
                     guild.members.add(member, guild);
                 }
-                for(var presence of packet.d.presences) {
-                    if(!guild.members.get(presence.user.id)) {
+                for (var presence of packet.d.presences) {
+                    if (!guild.members.get(presence.user.id)) {
                         var userData = this.client.users.get(presence.user.id);
-                        if(userData) {
+                        if (userData) {
                             userData = `{username: ${userData.username}, id: ${userData.id}, discriminator: ${userData.discriminator}}`;
                         }
                         this.client.emit("debug", `Presence without member. ${presence.user.id}. In global user cache: ${userData}. ` + JSON.stringify(presence), this.id);
@@ -1043,16 +1050,16 @@ class Shard extends EventEmitter {
                     presence.id = presence.user.id;
                     guild.members.update(presence);
                 }
-                if(guild.pendingVoiceStates && guild.pendingVoiceStates.length > 0) {
-                    for(var voiceState of guild.pendingVoiceStates) {
-                        if(!guild.members.get(voiceState.user_id)) {
+                if (guild.pendingVoiceStates && guild.pendingVoiceStates.length > 0) {
+                    for (var voiceState of guild.pendingVoiceStates) {
+                        if (!guild.members.get(voiceState.user_id)) {
                             continue;
                         }
                         voiceState.id = voiceState.user_id;
                         var channel = guild.channels.get(voiceState.channel_id);
-                        if(channel) {
+                        if (channel) {
                             channel.voiceMembers.add(guild.members.update(voiceState));
-                            if(this.client.options.seedVoiceConnections && voiceState.id === this.client.user.id && !this.client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
+                            if (this.client.options.seedVoiceConnections && voiceState.id === this.client.user.id && !this.client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
                                 this.client.joinVoiceChannel(channel.id, false);
                             }
                         } else { // Phantom voice states from connected users in deleted channels (╯°□°）╯︵ ┻━┻
@@ -1075,37 +1082,37 @@ class Shard extends EventEmitter {
                 this.presence.status = "online";
                 this.client.shards._readyPacketCB();
 
-                if(packet.t === "RESUMED") {
+                if (packet.t === "RESUMED") {
                     this.preReady = true;
                     this.ready = true;
 
                     /**
-                    * Fired when a shard finishes resuming
-                    * @event Shard#resume
-                    * @prop {Number} id The ID of the shard
-                    */
+                     * Fired when a shard finishes resuming
+                     * @event Shard#resume
+                     * @prop {Number} id The ID of the shard
+                     */
                     this.emit("resume");
                     break;
                 }
 
                 this.client.user = this.client.users.add(new ExtendedUser(packet.d.user), this.client);
-                if(this.client.user.bot) {
+                if (this.client.user.bot) {
                     this.client.bot = true;
-                    if(!this.client.token.startsWith("Bot ")) {
+                    if (!this.client.token.startsWith("Bot ")) {
                         this.client.token = "Bot " + this.client.token;
                     }
                 } else {
                     this.client.bot = false;
                 }
 
-                if(packet.d._trace) {
+                if (packet.d._trace) {
                     this.discordServerTrace = packet.d._trace;
                 }
 
                 this.sessionID = packet.d.session_id;
 
                 packet.d.guilds.forEach((guild) => {
-                    if(guild.unavailable) {
+                    if (guild.unavailable) {
                         this.client.guilds.remove(guild);
                         this.client.unavailableGuilds.add(guild, this.client, true);
                     } else {
@@ -1115,25 +1122,25 @@ class Shard extends EventEmitter {
                 this.guildCount = packet.d.guilds.length;
 
                 packet.d.private_channels.forEach((channel) => {
-                    if(channel.type === undefined || channel.type === 1) {
+                    if (channel.type === undefined || channel.type === 1) {
                         this.client.privateChannelMap[channel.recipients[0].id] = channel.id;
                         this.client.privateChannels.add(channel, this.client, true);
-                    } else if(channel.type === 3) {
+                    } else if (channel.type === 3) {
                         this.client.groupChannels.add(channel, this.client, true);
                     } else {
                         this.emit("error", new Error("Unhandled READY private_channel type: " + JSON.stringify(channel, null, 2)));
                     }
                 });
 
-                if(packet.d.relationships) {
+                if (packet.d.relationships) {
                     packet.d.relationships.forEach((relationship) => {
                         this.client.relationships.add(relationship, this.client, true);
                     });
                 }
 
-                if(packet.d.presences) {
+                if (packet.d.presences) {
                     packet.d.presences.forEach((presence) => {
-                        if(this.client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
+                        if (this.client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
                             presence.id = presence.user.id;
                             this.client.relationships.update(presence, null, true);
                         }
@@ -1142,13 +1149,13 @@ class Shard extends EventEmitter {
 
                 this.preReady = true;
                 /**
-                * Fired when a shard finishes processing the ready packet
-                * @event Client#shardPreReady
-                * @prop {Number} id The ID of the shard
-                */
+                 * Fired when a shard finishes processing the ready packet
+                 * @event Client#shardPreReady
+                 * @prop {Number} id The ID of the shard
+                 */
                 this.client.emit("shardPreReady", this.id);
 
-                if(this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
+                if (this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
                     this.restartGuildCreateTimeout();
                 } else {
                     this.checkReady();
@@ -1171,41 +1178,41 @@ class Shard extends EventEmitter {
                 break;
             }
             case "RELATIONSHIP_ADD": {
-                if(this.client.bot) {
+                if (this.client.bot) {
                     break;
                 }
                 var relationship = this.client.relationships.get(packet.d.id);
-                if(relationship) {
+                if (relationship) {
                     var oldRelationship = {
                         type: relationship.type
                     };
                     /**
-                    * Fired when a relationship is updated
-                    * @event Client#relationshipUpdate
-                    * @prop {Relationship} relationship The relationship
-                    * @prop {Object} oldRelationship The old relationship data
-                    * @prop {Number} oldRelationship.type The old type of the relationship
-                    */
+                     * Fired when a relationship is updated
+                     * @event Client#relationshipUpdate
+                     * @prop {Relationship} relationship The relationship
+                     * @prop {Object} oldRelationship The old relationship data
+                     * @prop {Number} oldRelationship.type The old type of the relationship
+                     */
                     this.client.emit("relationshipUpdate", this.client.relationships.update(packet.d), oldRelationship);
                 } else {
                     /**
-                    * Fired when a relationship is added
-                    * @event Client#relationshipAdd
-                    * @prop {Relationship} relationship The relationship
-                    */
+                     * Fired when a relationship is added
+                     * @event Client#relationshipAdd
+                     * @prop {Relationship} relationship The relationship
+                     */
                     this.client.emit("relationshipAdd", this.client.relationships.add(packet.d, this.client));
                 }
                 break;
             }
             case "RELATIONSHIP_REMOVE": {
-                if(this.client.bot) {
+                if (this.client.bot) {
                     break;
                 }
                 /**
-                * Fired when a relationship is removed
-                * @event Client#relationshipRemove
-                * @prop {Relationship} relationship The relationship
-                */
+                 * Fired when a relationship is removed
+                 * @event Client#relationshipRemove
+                 * @prop {Relationship} relationship The relationship
+                 */
                 this.client.emit("relationshipRemove", this.client.relationships.remove(packet.d));
                 break;
             }
@@ -1214,42 +1221,42 @@ class Shard extends EventEmitter {
                 var oldEmojis = guild.emojis;
                 guild.update(packet.d);
                 /**
-                * Fired when a guild's emojis are updated
-                * @event Client#guildEmojisUpdate
-                * @prop {Guild} guild The guild
-                * @prop {Array} emojis The updated emojis of the guild
-                * @prop {Array} oldEmojis The old emojis of the guild
-                */
+                 * Fired when a guild's emojis are updated
+                 * @event Client#guildEmojisUpdate
+                 * @prop {Guild} guild The guild
+                 * @prop {Array} emojis The updated emojis of the guild
+                 * @prop {Array} oldEmojis The old emojis of the guild
+                 */
                 this.client.emit("guildEmojisUpdate", guild, guild.emojis, oldEmojis);
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
+                if (!channel) {
                     this.client.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;
                 }
                 var oldTimestamp = channel.lastPinTimestamp;
                 channel.lastPinTimestamp = Date.parse(packet.d.timestamp);
                 /**
-                * Fired when a channel pin timestamp is updated
-                * @event Client#channelPinUpdate
-                * @prop {Channel} channel The channel
-                * @prop {Number} timestamp The new timestamp
-                * @prop {Number} oldTimestamp The old timestamp
-                */
+                 * Fired when a channel pin timestamp is updated
+                 * @event Client#channelPinUpdate
+                 * @prop {Channel} channel The channel
+                 * @prop {Number} timestamp The new timestamp
+                 * @prop {Number} oldTimestamp The old timestamp
+                 */
                 this.client.emit("channelPinUpdate", channel, channel.lastPinTimestamp, oldTimestamp);
                 break;
             }
             case "PRESENCES_REPLACE": {
-                for(var presence of packet.d) {
+                for (var presence of packet.d) {
                     var guild = this.client.guilds.get(presence.guild_id);
-                    if(!guild) {
+                    if (!guild) {
                         this.client.emit("warn", "Rogue presences replace: " + JSON.stringify(presence), this.id);
                         continue;
                     }
                     var member = guild.members.get(presence.user.id);
-                    if(!member && presence.user.username) {
+                    if (!member && presence.user.username) {
                         presence.id = presence.user.id;
                         member.update(presence);
                     }
@@ -1264,24 +1271,25 @@ class Shard extends EventEmitter {
             }
             default: {
                 /**
-                * Fired when the shard encounters an unknown packet
-                * @event Client#unknown
-                * @prop {Object} packet The unknown packet
-                * @prop {Number} id The ID of the shard
-                */
+                 * Fired when the shard encounters an unknown packet
+                 * @event Client#unknown
+                 * @prop {Object} packet The unknown packet
+                 * @prop {Number} id The ID of the shard
+                 */
                 this.client.emit("unknown", packet, this.id);
                 break;
             }
-        } /* eslint-enable no-redeclare */
+        }
+        /* eslint-enable no-redeclare */
         // this.client.emit("debug", packet.t + ": " + (Date.now() - startTime) + "ms" + debugStr, this.id);
     }
 
     syncGuild(guildID) {
-        if(this.guildSyncQueueLength + 3 + guildID.length > 4081) { // 4096 - "{\"op\":12,\"d\":[]}".length + 1 for lazy comma offset
+        if (this.guildSyncQueueLength + 3 + guildID.length > 4081) { // 4096 - "{\"op\":12,\"d\":[]}".length + 1 for lazy comma offset
             this.requestGuildSync(this.guildSyncQueue);
             this.guildSyncQueue = [guildID];
             this.guildSyncQueueLength = 1 + guildID.length + 3;
-        } else if(this.ready) {
+        } else if (this.ready) {
             this.requestGuildSync([guildID]);
         } else {
             this.guildSyncQueue.push(guildID);
@@ -1296,23 +1304,23 @@ class Shard extends EventEmitter {
     createGuild(_guild) {
         this.client.guildShardMap[_guild.id] = this.id;
         var guild = this.client.guilds.add(_guild, this.client, true);
-        if(this.client.bot === false) {
+        if (this.client.bot === false) {
             ++this.unsyncedGuilds;
             this.syncGuild(guild.id);
         }
-        if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
+        if (this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
             guild.fetchAllMembers();
         }
         return guild;
     }
 
     restartGuildCreateTimeout() {
-        if(this.guildCreateTimeout) {
+        if (this.guildCreateTimeout) {
             clearTimeout(this.guildCreateTimeout);
             this.guildCreateTimeout = null;
         }
-        if(!this.ready) {
-            if(this.client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
+        if (!this.ready) {
+            if (this.client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
@@ -1323,11 +1331,11 @@ class Shard extends EventEmitter {
 
     getGuildMembers(guildID, chunkCount) {
         this.getAllUsersCount[guildID] = chunkCount;
-        if(this.getAllUsersLength + 3 + guildID.length > 4048) { // 4096 - "{\"op\":8,\"d\":{\"guild_id\":[],\"query\":\"\",\"limit\":0}}".length + 1 for lazy comma offset
+        if (this.getAllUsersLength + 3 + guildID.length > 4048) { // 4096 - "{\"op\":8,\"d\":{\"guild_id\":[],\"query\":\"\",\"limit\":0}}".length + 1 for lazy comma offset
             this.requestGuildMembers(this.getAllUsersQueue);
             this.getAllUsersQueue = [guildID];
             this.getAllUsersLength = 1 + guildID.length + 3;
-        } else if(this.ready) {
+        } else if (this.ready) {
             this.requestGuildMembers([guildID]);
         } else {
             this.getAllUsersQueue.push(guildID);
@@ -1344,28 +1352,28 @@ class Shard extends EventEmitter {
     }
 
     checkReady() {
-        if(!this.ready) {
-            if(this.guildSyncQueue.length > 0) {
+        if (!this.ready) {
+            if (this.guildSyncQueue.length > 0) {
                 this.requestGuildSync(this.guildSyncQueue);
                 this.guildSyncQueue = [];
                 this.guildSyncQueueLength = 1;
                 return;
             }
-            if(this.unsyncedGuilds > 0) {
+            if (this.unsyncedGuilds > 0) {
                 return;
             }
-            if(this.getAllUsersQueue.length > 0) {
+            if (this.getAllUsersQueue.length > 0) {
                 this.requestGuildMembers(this.getAllUsersQueue);
                 this.getAllUsersQueue = [];
                 this.getAllUsersLength = 1;
                 return;
             }
-            if(Object.keys(this.getAllUsersCount).length === 0) {
+            if (Object.keys(this.getAllUsersCount).length === 0) {
                 this.ready = true;
                 /**
-                * Fired when the shard turns ready
-                * @event Shard#ready
-                */
+                 * Fired when the shard turns ready
+                 * @event Shard#ready
+                 */
                 this.emit("ready");
             }
         }
@@ -1375,53 +1383,53 @@ class Shard extends EventEmitter {
         this.status = "connecting";
         this.ws = new WebSocket(this.client.gatewayURL);
         this.ws.onopen = () => {
-            if(!this.client.token) {
+            if (!this.client.token) {
                 return this.disconnect(null, new Error("Token not specified"));
             }
             this.status = "handshaking";
             /**
-            * Fired when the shard establishes a connection
-            * @event Client#connect
-            * @prop {Number} id The ID of the shard
-            */
+             * Fired when the shard establishes a connection
+             * @event Client#connect
+             * @prop {Number} id The ID of the shard
+             */
             this.client.emit("connect", this.id);
             this.lastHeartbeatAck = true;
         };
         this.ws.onmessage = (m) => {
             try {
                 m = m.data;
-                if(typeof m !== "string") {
+                if (typeof m !== "string") {
                     m = Inflator(m).toString();
                 }
 
                 var packet = JSON.parse(m);
 
-                if(this.client.listeners("rawWS").length > 0) {
+                if (this.client.listeners("rawWS").length > 0) {
                     /**
-                    * Fired when the shard receives a websocket packet
-                    * @event Client#rawWS
-                    * @prop {Object} packet The packet
-                    * @prop {Number} id The ID of the shard
-                    */
+                     * Fired when the shard receives a websocket packet
+                     * @event Client#rawWS
+                     * @prop {Object} packet The packet
+                     * @prop {Number} id The ID of the shard
+                     */
                     this.client.emit("rawWS", packet, this.id);
                 }
 
-                if(packet.s > this.seq + 1 && this.ws) {
+                if (packet.s > this.seq + 1 && this.ws) {
                     /**
-                    * Fired to warn of something weird but non-breaking happening
-                    * @event Client#warn
-                    * @prop {String} message The warning message
-                    * @prop {Number} id The ID of the shard
-                    */
+                     * Fired to warn of something weird but non-breaking happening
+                     * @event Client#warn
+                     * @prop {String} message The warning message
+                     * @prop {Number} id The ID of the shard
+                     */
                     this.client.emit("warn", "Non-consecutive sequence, requesting resume", this.id);
                     this.resume();
-                } else if(packet.s) {
+                } else if (packet.s) {
                     this.seq = packet.s;
                 }
 
-                switch(packet.op) {
+                switch (packet.op) {
                     case OPCodes.EVENT: {
-                        if(!this.client.options.disableEvents[packet.t]) {
+                        if (!this.client.options.disableEvents[packet.t]) {
                             this.wsEvent(packet);
                         }
                         break;
@@ -1444,8 +1452,8 @@ class Shard extends EventEmitter {
                         break;
                     }
                     case OPCodes.HELLO: {
-                        if(packet.d.heartbeat_interval > 0) {
-                            if(this.heartbeatInterval) {
+                        if (packet.d.heartbeat_interval > 0) {
+                            if (this.heartbeatInterval) {
                                 clearInterval(this.heartbeatInterval);
                             }
                             this.heartbeatInterval = setInterval(() => this.heartbeat(true), packet.d.heartbeat_interval);
@@ -1454,13 +1462,14 @@ class Shard extends EventEmitter {
                         this.discordServerTrace = packet.d._trace;
                         this.connecting = false;
 
-                        if(this.sessionID) {
+                        if (this.sessionID) {
                             this.resume();
                         } else {
                             this.identify();
                         }
                         this.heartbeat();
-                        break; /* eslint-enable no-unreachable */
+                        break;
+                        /* eslint-enable no-unreachable */
                     }
                     case OPCodes.HEARTBEAT_ACK: {
                         this.lastHeartbeatAck = true;
@@ -1472,7 +1481,7 @@ class Shard extends EventEmitter {
                         break;
                     }
                 }
-            } catch(err) {
+            } catch (err) {
                 this.client.emit("error", err, this.id);
             }
         };
@@ -1481,31 +1490,31 @@ class Shard extends EventEmitter {
         };
         this.ws.onclose = (event) => {
             var err = event.code === 1000 ? null : new Error(event.code + ": " + event.reason);
-            if(event.code) {
+            if (event.code) {
                 this.client.emit("warn", `${event.code === 1000 ? "Clean" : "Unclean"} WS close: ${event.code}: ${event.reason}`, this.id);
-                if(event.code === 4001) {
+                if (event.code === 4001) {
                     err = new Error("Gateway received invalid OP code");
-                } else if(event.code === 4002) {
+                } else if (event.code === 4002) {
                     err = new Error("Gateway received invalid message");
-                } else if(event.code === 4003) {
+                } else if (event.code === 4003) {
                     err = new Error("Not authenticated");
-                } else if(event.code === 4004) {
+                } else if (event.code === 4004) {
                     err = new Error("Authentication failed");
-                } else if(event.code === 4005) {
+                } else if (event.code === 4005) {
                     err = new Error("Already authenticated");
-                } else if(event.code === 4006 || event.code === 4009) {
+                } else if (event.code === 4006 || event.code === 4009) {
                     this.sessionID = null;
                     err = new Error("Invalid session");
-                } else if(event.code === 4007) {
+                } else if (event.code === 4007) {
                     err = new Error("Invalid sequence number: " + this.seq);
                     this.seq = 0;
-                } else if(event.code === 4008) {
+                } else if (event.code === 4008) {
                     err = new Error("Gateway connection was ratelimited");
-                } else if(event.code === 4010) {
+                } else if (event.code === 4010) {
                     err = new Error("Invalid shard key");
-                } else if(event.code === 1006) {
+                } else if (event.code === 1006) {
                     err = new Error("Connection reset by peer");
-                } else if(!event.wasClean && event.reason) {
+                } else if (!event.wasClean && event.reason) {
                     err = new Error(event.code + ": " + event.reason);
                 }
             } else {
@@ -1517,7 +1526,7 @@ class Shard extends EventEmitter {
         };
 
         setTimeout(() => {
-            if(this.connecting) {
+            if (this.connecting) {
                 this.disconnect({
                     reconnect: "auto"
                 }, new Error("Connection timeout"));
@@ -1526,7 +1535,7 @@ class Shard extends EventEmitter {
     }
 
     heartbeat(normal) {
-        if(normal && !this.lastHeartbeatAck) {
+        if (normal && !this.lastHeartbeatAck) {
             return this.disconnect({
                 reconnect: "auto"
             }, new Error("Server didn't acknowledge previous heartbeat, possible lost connection"));
@@ -1537,17 +1546,17 @@ class Shard extends EventEmitter {
     }
 
     sendWS(op, data) {
-        if(this.ws && this.ws.readyState === WebSocket.OPEN) {
+        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
             var i = 0;
             var waitFor = 1;
             var func = () => {
-                if(++i >= waitFor && this.ws && this.ws.readyState === WebSocket.OPEN) {
+                if (++i >= waitFor && this.ws && this.ws.readyState === WebSocket.OPEN) {
                     data = JSON.stringify({op: op, d: data});
                     this.ws.send(data);
                     this.client.emit("debug", data, this.id);
                 }
             };
-            if(op === OPCodes.STATUS_UPDATE) {
+            if (op === OPCodes.STATUS_UPDATE) {
                 ++waitFor;
                 this.presenceUpdateBucket.queue(func);
             }
@@ -1556,22 +1565,22 @@ class Shard extends EventEmitter {
     }
 
     /**
-    * Updates the bot's status on all guilds the shard is in
-    * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
-    * @arg {Object} [game] Sets the bot's active game, null to clear
-    * @arg {String} game.name Sets the name of the bot's active game
-    * @arg {Number} [game.type] The type of game. 0 is default, 1 is streaming (Twitch only)
-    * @arg {String} [game.url] Sets the url of the shard's active game
-    */
+     * Updates the bot's status on all guilds the shard is in
+     * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
+     * @arg {Object} [game] Sets the bot's active game, null to clear
+     * @arg {String} game.name Sets the name of the bot's active game
+     * @arg {Number} [game.type] The type of game. 0 is default, 1 is streaming (Twitch only)
+     * @arg {String} [game.url] Sets the url of the shard's active game
+     */
     editStatus(status, game) {
-        if(game === undefined && typeof status === "object") {
+        if (game === undefined && typeof status === "object") {
             game = status;
             status = undefined;
         }
-        if(status) {
+        if (status) {
             this.presence.status = status;
         }
-        if(game !== undefined) {
+        if (game !== undefined) {
             this.presence.game = game;
         }
 
@@ -1583,7 +1592,7 @@ class Shard extends EventEmitter {
         });
 
         this.client.guilds.forEach((guild) => {
-            if(guild.shard.id === this.id) {
+            if (guild.shard.id === this.id) {
                 guild.members.get(this.client.user.id).update(this.presence);
             }
         });

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1018,7 +1018,7 @@ class Shard extends EventEmitter {
                 /**
                  * Fired when discord sends members on startup
                  * @event Client#guildMemberChunk
-                 * @prop {Guild} The guild the members were loaded from
+                 * @prop {Guild} guild The guild the members were loaded from
                  * @prop {Array<Member>} members The newly added members
                  */
                 this.client.emit("guildMemberChunk", guild, packet.d.members.map((member) => {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1016,7 +1016,7 @@ class Shard extends EventEmitter {
                 }
 
                 /**
-                 * Fired when discord sends members on startup
+                 * Fired when Discord sends member chunks
                  * @event Client#guildMemberChunk
                  * @prop {Guild} guild The guild the members were loaded from
                  * @prop {Array<Member>} members The newly added members

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1018,8 +1018,8 @@ class Shard extends EventEmitter {
                 /**
                  * Fired when Discord sends member chunks
                  * @event Client#guildMemberChunk
-                 * @prop {Guild} guild The guild the members were loaded from
-                 * @prop {Array<Member>} members The newly added members
+                 * @prop {Guild} guild The guild the chunked members are in
+                 * @prop {Array<Member>} members The members in the chunk
                  */
                 this.client.emit("guildMemberChunk", guild, packet.d.members.map((member) => {
                     member.id = member.user.id;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -12,29 +12,29 @@ const Zlib = require("zlib");
 var EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
-} catch (err) {
+} catch(err) {
     EventEmitter = require("events").EventEmitter;
 }
 var Pako;
 try {
     Pako = require("pako");
-} catch (err) { // eslint-disable no-empty
+} catch(err) { // eslint-disable no-empty
 }
 var Inflator = typeof window !== "undefined" && Pako ? Pako.inflate : Zlib.inflateSync;
 
 /**
- * Represents a shard
- * @extends EventEmitter
- * @prop {Number} id The ID of the shard
- * @prop {Boolean} connecting Whether the shard is connecting
- * @prop {Boolean} ready Whether the shard is ready
- * @prop {Number} guildCount The number of guilds this shard should be handling
- * @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
- * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
- * @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
- * @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
- * @prop {Number} latency Current latency between shard and Discord
- */
+* Represents a shard
+* @extends EventEmitter
+* @prop {Number} id The ID of the shard
+* @prop {Boolean} connecting Whether the shard is connecting
+* @prop {Boolean} ready Whether the shard is ready
+* @prop {Number} guildCount The number of guilds this shard should be handling
+* @prop {Array<String>?} discordServerTrace Debug trace of Discord servers
+* @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
+* @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
+* @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
+* @prop {Number} latency Current latency between shard and Discord
+*/
 class Shard extends EventEmitter {
     constructor(id, client) {
         super();
@@ -50,10 +50,10 @@ class Shard extends EventEmitter {
     }
 
     /**
-     * Tells the shard to connect
-     */
+    * Tells the shard to connect
+    */
     connect() {
-        if (this.ws && this.ws.readyState != WebSocket.CLOSED) {
+        if(this.ws && this.ws.readyState != WebSocket.CLOSED) {
             this.client.emit("error", new Error("Existing connection detected"), this.id);
             return;
         }
@@ -63,59 +63,59 @@ class Shard extends EventEmitter {
     }
 
     /**
-     * Disconnects the shard
-     * @arg {Object?} [options] Shard disconnect options
-     * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
-     */
+    * Disconnects the shard
+    * @arg {Object?} [options] Shard disconnect options
+    * @arg {String | Boolean} [options.reconnect] false means destroy everything, true means you want to reconnect in the future, "auto" will autoreconnect
+    */
     disconnect(options, error) {
-        if (!this.ws) {
+        if(!this.ws) {
             return;
         }
         options = options || {};
-        if (this.heartbeatInterval) {
+        if(this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
         }
-        if (this.ws) {
+        if(this.ws) {
             this.ws.onclose = undefined;
             try {
-                if (options.reconnect && this.sessionID) {
+                if(options.reconnect && this.sessionID) {
                     this.ws.terminate();
                 } else {
                     this.ws.close();
                 }
-            } catch (err) {
+            } catch(err) {
                 /**
-                 * Fired when the shard encounters an error
-                 * @event Client#error
-                 * @prop {Error} err The error
-                 * @prop {Number} id The ID of the shard
-                 */
+                * Fired when the shard encounters an error
+                * @event Client#error
+                * @prop {Error} err The error
+                * @prop {Number} id The ID of the shard
+                */
                 this.client.emit("error", err, this.id);
             }
             /**
-             * Fired when the shard disconnects
-             * @event Shard#disconnect
-             * @prop {Error?} err The error, if any
-             */
+            * Fired when the shard disconnects
+            * @event Shard#disconnect
+            * @prop {Error?} err The error, if any
+            */
             this.emit("disconnect", error || null);
             this.ws = null;
         }
         this.status = "disconnected";
         this.reset();
-        if (options.reconnect === "auto" && this.client.options.autoreconnect) {
+        if(options.reconnect === "auto" && this.client.options.autoreconnect) {
             /**
-             * Fired when stuff happens and gives more info
-             * @event Client#debug
-             * @prop {String} message The debug message
-             * @prop {Number} id The ID of the shard
-             */
+            * Fired when stuff happens and gives more info
+            * @event Client#debug
+            * @prop {String} message The debug message
+            * @prop {Number} id The ID of the shard
+            */
             this.client.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
             setTimeout(() => {
                 this.client.shards.connect(this);
             }, this.reconnectInterval);
             this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
-        } else if (!options.reconnect) {
+        } else if(!options.reconnect) {
             this.hardReset();
         }
     }
@@ -172,10 +172,10 @@ class Shard extends EventEmitter {
                 "device": "Eris"
             }
         };
-        if (this.client.options.maxShards > 1) {
+        if(this.client.options.maxShards > 1) {
             identify.shard = [this.id, this.client.options.maxShards];
         }
-        if (this.presence.status) {
+        if(this.presence.status) {
             identify.presence = this.presence;
         }
         this.sendWS(OPCodes.IDENTIFY, identify, true);
@@ -184,36 +184,36 @@ class Shard extends EventEmitter {
     wsEvent(packet) {
         // var startTime = Date.now();
         // var debugStr = "";
-        switch (packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
+        switch(packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
             case "PRESENCE_UPDATE": {
-                if (packet.d.user.username !== undefined) {
+                if(packet.d.user.username !== undefined) {
                     var user = this.client.users.get(packet.d.user.id);
                     var oldUser = null;
-                    if (user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar)) {
+                    if(user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
                             username: user.username,
                             discriminator: user.discriminator,
                             avatar: user.avatar
                         };
                     }
-                    if (!user || oldUser) {
+                    if(!user || oldUser) {
                         user = this.client.users.update(packet.d.user);
                         /**
-                         * Fired when a user's username or avatar changes
-                         * @event Client#userUpdate
-                         * @prop {User} user The updated user
-                         * @prop {Object?} oldUser The old user data
-                         * @prop {String} oldUser.username The username of the user
-                         * @prop {String} oldUser.discriminator The discriminator of the user
-                         * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
-                         */
+                        * Fired when a user's username or avatar changes
+                        * @event Client#userUpdate
+                        * @prop {User} user The updated user
+                        * @prop {Object?} oldUser The old user data
+                        * @prop {String} oldUser.username The username of the user
+                        * @prop {String} oldUser.discriminator The discriminator of the user
+                        * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
+                        */
                         this.client.emit("userUpdate", user, oldUser);
                     }
                 }
-                if (!packet.d.guild_id) {
+                if(!packet.d.guild_id) {
                     packet.d.id = packet.d.user.id;
                     var relationship = this.client.relationships.get(packet.d.id);
-                    if (!relationship) { // Removing relationships
+                    if(!relationship) { // Removing relationships
                         return;
                     }
                     var oldPresence = {
@@ -221,66 +221,66 @@ class Shard extends EventEmitter {
                         status: relationship.status
                     };
                     /**
-                     * Fired when a guild member or relationship's status or game changes
-                     * @event Client#presenceUpdate
-                     * @prop {Member | Relationship} other The updated member or relationship
-                     * @prop {Object?} oldPresence The old presence data. If the user was offline when the bot started and the client option getAllUsers is not true, this will be null
-                     * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
-                     * @prop {Object?} oldPresence.game The old game the other user was playing
-                     * @prop {String} oldPresence.game.name The name of the active game
-                     * @prop {Number} oldPresence.game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
-                     * @prop {String} oldPresence.game.url The url of the active game
-                     */
+                    * Fired when a guild member or relationship's status or game changes
+                    * @event Client#presenceUpdate
+                    * @prop {Member | Relationship} other The updated member or relationship
+                    * @prop {Object?} oldPresence The old presence data. If the user was offline when the bot started and the client option getAllUsers is not true, this will be null
+                    * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
+                    * @prop {Object?} oldPresence.game The old game the other user was playing
+                    * @prop {String} oldPresence.game.name The name of the active game
+                    * @prop {Number} oldPresence.game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
+                    * @prop {String} oldPresence.game.url The url of the active game
+                    */
                     this.client.emit("presenceUpdate", this.client.relationships.update(packet.d), oldPresence);
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if (!guild) {
+                if(!guild) {
                     this.client.emit("warn", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
                 }
                 var member = guild.members.get(packet.d.id = packet.d.user.id);
                 var oldPresence = null;
-                if (member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url)))) {
+                if(member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url)))) {
                     oldPresence = {
                         game: member.game,
                         status: member.status
                     };
                 }
-                if ((!member && packet.d.user.username) || oldPresence) {
+                if((!member && packet.d.user.username) || oldPresence) {
                     member = guild.members.update(packet.d, guild);
                     this.client.emit("presenceUpdate", member, oldPresence);
                 }
                 break;
             }
             case "VOICE_STATE_UPDATE": { // (╯°□°）╯︵ ┻━┻
-                if (packet.d.guild_id === undefined) {
+                if(packet.d.guild_id === undefined) {
                     packet.d.id = packet.d.user_id;
-                    if (packet.d.channel_id === null) {
+                    if(packet.d.channel_id === null) {
                         var flag = false;
-                        for (var groupChannel of this.client.groupChannels) {
+                        for(var groupChannel of this.client.groupChannels) {
                             var call = (groupChannel[1].call || groupChannel[1].lastCall);
-                            if (call && call.voiceStates.remove(packet.d)) {
+                            if(call && call.voiceStates.remove(packet.d)) {
                                 flag = true;
                                 break;
                             }
                         }
-                        if (!flag) {
-                            for (var privateChannel of this.client.privateChannels) {
+                        if(!flag) {
+                            for(var privateChannel of this.client.privateChannels) {
                                 var call = (privateChannel[1].call || privateChannel[1].lastCall);
-                                if (call && call.voiceStates.remove(packet.d)) {
+                                if(call && call.voiceStates.remove(packet.d)) {
                                     flag = true;
                                     break;
                                 }
                             }
-                            if (!flag) {
+                            if(!flag) {
                                 this.client.emit("error", new Error("VOICE_STATE_UPDATE for user leaving call not found"));
                                 break;
                             }
                         }
                     } else {
                         var channel = this.client.getChannel(packet.d.channel_id);
-                        if (!channel.call && !channel.lastCall) {
+                        if(!channel.call && !channel.lastCall) {
                             this.client.emit("error", new Error("VOICE_STATE_UPDATE for untracked call"));
                             break;
                         }
@@ -289,17 +289,17 @@ class Shard extends EventEmitter {
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if (!guild) {
+                if(!guild) {
                     break;
                 }
-                if (guild.pendingVoiceStates) {
+                if(guild.pendingVoiceStates) {
                     guild.pendingVoiceStates.push(packet.d);
                     break;
                 }
                 var member = guild.members.get(packet.d.id = packet.d.user_id);
-                if (!member) {
+                if(!member) {
                     var channel = guild.channels.find((channel) => channel.type === 2 && channel.voiceMembers.get(packet.d.id));
-                    if (channel) {
+                    if(channel) {
                         channel.voiceMembers.remove(packet.d);
                         this.client.emit("warn", "VOICE_STATE_UPDATE member null but in channel: " + packet.d.id, this.id);
                         break;
@@ -314,83 +314,83 @@ class Shard extends EventEmitter {
                 };
                 var oldChannelID = member.voiceState.channelID;
                 member.update(packet.d, this.client);
-                if (member.user.id === this.client.user.id) {
+                if(member.user.id === this.client.user.id) {
                     var voiceConnection = this.client.voiceConnections.guilds[packet.d.guild_id];
-                    if (voiceConnection && voiceConnection.channelID !== packet.d.channel_id) {
+                    if(voiceConnection && voiceConnection.channelID !== packet.d.channel_id) {
                         voiceConnection.switchChannel(packet.d.channel_id, true);
                     }
                 }
-                if (oldChannelID != packet.d.channel_id) {
+                if(oldChannelID != packet.d.channel_id) {
                     var oldChannel, newChannel;
-                    if (oldChannelID) {
+                    if(oldChannelID) {
                         oldChannel = guild.channels.get(oldChannelID);
                     }
-                    if (packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && newChannel.type === 2) { // Welcome to Discord, where one can "join" text channels
-                        if (oldChannel) {
+                    if(packet.d.channel_id && (newChannel = guild.channels.get(packet.d.channel_id)) && newChannel.type === 2) { // Welcome to Discord, where one can "join" text channels
+                        if(oldChannel) {
                             /**
-                             * Fired when a guild member switches voice channels
-                             * @event Client#voiceChannelSwitch
-                             * @prop {Member} member The member
-                             * @prop {GuildChannel} newChannel The new voice channel
-                             * @prop {GuildChannel} oldChannel The old voice channel
-                             */
+                            * Fired when a guild member switches voice channels
+                            * @event Client#voiceChannelSwitch
+                            * @prop {Member} member The member
+                            * @prop {GuildChannel} newChannel The new voice channel
+                            * @prop {GuildChannel} oldChannel The old voice channel
+                            */
                             oldChannel.voiceMembers.remove(member);
                             this.client.emit("voiceChannelSwitch", newChannel.voiceMembers.add(member, guild), newChannel, oldChannel);
                         } else {
                             /**
-                             * Fired when a guild member joins a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
-                             * @event Client#voiceChannelJoin
-                             * @prop {Member} member The member
-                             * @prop {GuildChannel} newChannel The voice channel
-                             */
+                            * Fired when a guild member joins a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
+                            * @event Client#voiceChannelJoin
+                            * @prop {Member} member The member
+                            * @prop {GuildChannel} newChannel The voice channel
+                            */
                             this.client.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
-                    } else if (oldChannel) {
+                    } else if(oldChannel) {
                         /**
-                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
-                         * @event Client#voiceChannelLeave
-                         * @prop {Member} member The member
-                         * @prop {GuildChannel} oldChannel The voice channel
-                         */
+                        * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
+                        * @event Client#voiceChannelLeave
+                        * @prop {Member} member The member
+                        * @prop {GuildChannel} oldChannel The voice channel
+                        */
                         this.client.emit("voiceChannelLeave", oldChannel.voiceMembers.remove(member), oldChannel);
                     }
                 }
-                if (oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf) {
+                if(oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf) {
                     /**
-                     * Fired when a guild member's voice state changes
-                     * @event Client#voiceStateUpdate
-                     * @prop {Member} member The member
-                     * @prop {Object} oldState The old voice state
-                     * @prop {Boolean} oldState.mute The previous server mute status
-                     * @prop {Boolean} oldState.deaf The previous server deaf status
-                     * @prop {Boolean} oldState.selfMute The previous self mute status
-                     * @prop {Boolean} oldState.selfDeaf The previous self deaf status
-                     */
+                    * Fired when a guild member's voice state changes
+                    * @event Client#voiceStateUpdate
+                    * @prop {Member} member The member
+                    * @prop {Object} oldState The old voice state
+                    * @prop {Boolean} oldState.mute The previous server mute status
+                    * @prop {Boolean} oldState.deaf The previous server deaf status
+                    * @prop {Boolean} oldState.selfMute The previous self mute status
+                    * @prop {Boolean} oldState.selfDeaf The previous self deaf status
+                    */
                     this.client.emit("voiceStateUpdate", member, oldState);
                 }
                 break;
             }
             case "TYPING_START": {
-                if (this.client.listeners("typingStart").length > 0) {
+                if(this.client.listeners("typingStart").length > 0) {
                     /**
-                     * Fired when a user begins typing
-                     * @event Client#typingStart
-                     * @prop {Channel} channel The text channel the user is typing in
-                     * @prop {User} user The user
-                     */
+                    * Fired when a user begins typing
+                    * @event Client#typingStart
+                    * @prop {Channel} channel The text channel the user is typing in
+                    * @prop {User} user The user
+                    */
                     this.client.emit("typingStart", this.client.getChannel(packet.d.channel_id), this.client.users.get(packet.d.user_id));
                 }
                 break;
             }
             case "MESSAGE_CREATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (channel) { // MESSAGE_CREATE just when deleting o.o
+                if(channel) { // MESSAGE_CREATE just when deleting o.o
                     channel.lastMessageID = packet.d.id;
                     /**
-                     * Fired when a message is created
-                     * @event Client#messageCreate
-                     * @prop {Message} message The message
-                     */
+                    * Fired when a message is created
+                    * @event Client#messageCreate
+                    * @prop {Message} message The message
+                    */
                     this.client.emit("messageCreate", channel.messages.add(packet.d, this.client));
                 } else {
                     this.client.emit("debug", "MESSAGE_CREATE but channel not found (OK if deleted channel)", this.id);
@@ -399,14 +399,14 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.id);
                 var oldMessage = {
                     id: packet.d.id
                 };
-                if (message) {
+                if(message) {
                     oldMessage = {
                         attachments: message.attachments,
                         content: message.content,
@@ -420,50 +420,50 @@ class Shard extends EventEmitter {
                     };
                 }
                 /**
-                 * Fired when a message is updated
-                 * @event Client#messageUpdate
-                 * @prop {Message} message The updated message. If oldMessage was undefined, it is not recommended to use this since it will be very incomplete
-                 * @prop {Object?} oldMessage The old message data, if the message was cached
-                 * @prop {Object[]} oldMessage.id The ID of the message
-                 * @prop {Object[]?} oldMessage.attachments Array of attachments
-                 * @prop {Object[]?} oldMessage.embeds Array of embeds
-                 * @prop {String?} oldMessage.content Message content
-                 * @prop {Number?} oldMessage.editedTimestamp Timestamp of latest message edit
-                 * @prop {Object?} oldMessage.mentionedBy Object of if different things mention the bot user
-                 * @prop {Boolean?} oldMessage.tts Whether to play the message using TTS or not
-                 * @prop {String[]?} oldMessage.mentions Array of mentioned users' ids
-                 * @prop {String[]?} oldMessage.roleMentions Array of mentioned roles' ids.
-                 * @prop {String[]?} oldMessage.channelMentions Array of mentions channels' ids.
-                 */
+                * Fired when a message is updated
+                * @event Client#messageUpdate
+                * @prop {Message} message The updated message. If oldMessage was undefined, it is not recommended to use this since it will be very incomplete
+                * @prop {Object?} oldMessage The old message data, if the message was cached
+                * @prop {Object[]} oldMessage.id The ID of the message
+                * @prop {Object[]?} oldMessage.attachments Array of attachments
+                * @prop {Object[]?} oldMessage.embeds Array of embeds
+                * @prop {String?} oldMessage.content Message content
+                * @prop {Number?} oldMessage.editedTimestamp Timestamp of latest message edit
+                * @prop {Object?} oldMessage.mentionedBy Object of if different things mention the bot user
+                * @prop {Boolean?} oldMessage.tts Whether to play the message using TTS or not
+                * @prop {String[]?} oldMessage.mentions Array of mentioned users' ids
+                * @prop {String[]?} oldMessage.roleMentions Array of mentioned roles' ids.
+                * @prop {String[]?} oldMessage.channelMentions Array of mentions channels' ids.
+                */
                 this.client.emit("messageUpdate", channel.messages.update(packet.d, this.client), oldMessage);
                 break;
             }
             case "MESSAGE_DELETE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
                 /**
-                 * Fired when a cached message is deleted
-                 * @event Client#messageDelete
-                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                 */
+                * Fired when a cached message is deleted
+                * @event Client#messageDelete
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                */
                 this.client.emit("messageDelete", channel.messages.remove(packet.d) || {
-                        id: packet.d.id,
-                        channel: channel
-                    });
+                    id: packet.d.id,
+                    channel: channel
+                });
                 break;
             }
             case "MESSAGE_DELETE_BULK": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
 
                 /**
                  * Fired when a bulk delete occurs
                  * @event Client#messageDeleteBulk
-                 * @prop {Message[] | Object[]} messages An array of (potentially partial) message objects. If a message is not cached, it will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Message[] | Object[]} messages An array of (potentially partial) message objects. If a message is not cached, it will be an object with `id` and `channel` keys. No other property is guaranteed
                  */
                 this.client.emit("messageDeleteBulk", packet.d.ids.map((id) => (channel.messages.remove({
                     id
@@ -475,15 +475,15 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_REACTION_ADD": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.message_id);
-                if (message) {
+                if(message) {
                     var reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if (message.reactions[reaction]) {
+                    if(message.reactions[reaction]) {
                         ++message.reactions[reaction].count;
-                        if (packet.d.user_id === this.client.user.id) {
+                        if(packet.d.user_id === this.client.user.id) {
                             message.reactions[reaction].me = true;
                         }
                     } else {
@@ -494,68 +494,68 @@ class Shard extends EventEmitter {
                     }
                 }
                 /**
-                 * Fired when someone adds a reaction to a message
-                 * @event Client#messageReactionAdd
-                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                 * @prop {Object} emoji The reaction emoji object
-                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
-                 * @prop {String} emoji.name The emoji name
-                 * @prop {String} userID The ID of the user that added the reaction
-                 */
+                * Fired when someone adds a reaction to a message
+                * @event Client#messageReactionAdd
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Object} emoji The reaction emoji object
+                * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
+                * @prop {String} emoji.name The emoji name
+                * @prop {String} userID The ID of the user that added the reaction
+                */
                 this.client.emit("messageReactionAdd", message || {
-                        id: packet.d.message_id,
-                        channel: channel
-                    }, packet.d.emoji, packet.d.user_id);
+                    id: packet.d.message_id,
+                    channel: channel
+                }, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
                 var message = channel.messages.get(packet.d.message_id);
-                if (message) {
+                if(message) {
                     var reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if (message.reactions[reaction]) {
+                    if(message.reactions[reaction]) {
                         --message.reactions[reaction].count;
-                        if (packet.d.user_id === this.client.user.id) {
+                        if(packet.d.user_id === this.client.user.id) {
                             message.reactions[reaction].me = false;
                         }
                     }
                 }
                 /**
-                 * Fired when someone removes a reaction from a message
-                 * @event Client#messageReactionRemove
-                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                 * @prop {Object} emoji The reaction emoji object
-                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
-                 * @prop {String} emoji.name The emoji name
-                 * @prop {String} userID The ID of the user that removed the reaction
-                 */
+                * Fired when someone removes a reaction from a message
+                * @event Client#messageReactionRemove
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Object} emoji The reaction emoji object
+                * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
+                * @prop {String} emoji.name The emoji name
+                * @prop {String} userID The ID of the user that removed the reaction
+                */
                 this.client.emit("messageReactionRemove", message || {
-                        id: packet.d.message_id,
-                        channel: channel
-                    }, packet.d.emoji, packet.d.user_id);
+                    id: packet.d.message_id,
+                    channel: channel
+                }, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTIONS_REMOVE_ALL": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     break;
                 }
                 /**
-                 * Fired when someone removes a reaction from a message
-                 * @event Client#messageReactionRemove
-                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
-                 * @prop {Object} emoji The reaction emoji object
-                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
-                 * @prop {String} emoji.name The emoji name
-                 * @prop {String} userID The ID of the user that removed the reaction
-                 */
+                * Fired when someone removes a reaction from a message
+                * @event Client#messageReactionRemove
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Object} emoji The reaction emoji object
+                * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
+                * @prop {String} emoji.name The emoji name
+                * @prop {String} userID The ID of the user that removed the reaction
+                */
                 this.client.emit("messageReactionRemoveAll", channel.messages.get(packet.d.message_id) || {
-                        id: packet.d.message_id,
-                        channel: channel
-                    });
+                    id: packet.d.message_id,
+                    channel: channel
+                });
                 break;
             }
             case "GUILD_MEMBER_ADD": {
@@ -563,11 +563,11 @@ class Shard extends EventEmitter {
                 packet.d.id = packet.d.user.id;
                 ++guild.memberCount;
                 /**
-                 * Fired when a member joins a server
-                 * @event Client#guildMemberAdd
-                 * @prop {Guild} guild The guild
-                 * @prop {Member} member The member
-                 */
+                * Fired when a member joins a server
+                * @event Client#guildMemberAdd
+                * @prop {Guild} guild The guild
+                * @prop {Member} member The member
+                */
                 this.client.emit("guildMemberAdd", guild, guild.members.add(packet.d, guild));
                 break;
             }
@@ -575,7 +575,7 @@ class Shard extends EventEmitter {
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 var member = guild.members.get(packet.d.id = packet.d.user.id);
                 var oldMember = null;
-                if (member) {
+                if(member) {
                     oldMember = {
                         roles: member.roles,
                         nick: member.nick
@@ -583,53 +583,53 @@ class Shard extends EventEmitter {
                 }
                 member = guild.members.update(packet.d, guild);
                 /**
-                 * Fired when a member's roles or nickname are updated
-                 * @event Client#guildMemberUpdate
-                 * @prop {Guild} guild The guild
-                 * @prop {Member} member The updated member
-                 * @prop {Object?} oldMember The old member data
-                 * @prop {String[]} oldMember.roles An array of role IDs this member is a part of
-                 * @prop {String?} oldMember.nick The server nickname of the member
-                 */
+                * Fired when a member's roles or nickname are updated
+                * @event Client#guildMemberUpdate
+                * @prop {Guild} guild The guild
+                * @prop {Member} member The updated member
+                * @prop {Object?} oldMember The old member data
+                * @prop {String[]} oldMember.roles An array of role IDs this member is a part of
+                * @prop {String?} oldMember.nick The server nickname of the member
+                */
                 this.client.emit("guildMemberUpdate", guild, member, oldMember);
                 break;
             }
             case "GUILD_MEMBER_REMOVE": {
-                if (packet.d.user.id === this.client.user.id) { // The bot is probably leaving
+                if(packet.d.user.id === this.client.user.id) { // The bot is probably leaving
                     break;
                 }
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 --guild.memberCount;
                 packet.d.id = packet.d.user.id;
                 /**
-                 * Fired when a member leaves a server
-                 * @event Client#guildMemberRemove
-                 * @prop {Guild} guild The guild
-                 * @prop {Member | Object} member The member. If the member is not cached, this will be an object with `id` and `user` key
-                 */
+                * Fired when a member leaves a server
+                * @event Client#guildMemberRemove
+                * @prop {Guild} guild The guild
+                * @prop {Member | Object} member The member. If the member is not cached, this will be an object with `id` and `user` key
+                */
                 this.client.emit("guildMemberRemove", guild, guild.members.remove(packet.d) || {
-                        id: packet.d.id,
-                        user: new User(packet.d.user)
-                    });
+                    id: packet.d.id,
+                    user: new User(packet.d.user)
+                });
                 break;
             }
             case "GUILD_CREATE": {
-                if (!packet.d.unavailable) {
+                if(!packet.d.unavailable) {
                     var guild = this.createGuild(packet.d);
-                    if (this.ready) {
-                        if (this.client.unavailableGuilds.remove(packet.d)) {
+                    if(this.ready) {
+                        if(this.client.unavailableGuilds.remove(packet.d)) {
                             /**
-                             * Fired when an guild becomes available
-                             * @event Client#guildAvailable
-                             * @prop {Guild} guild The guild
-                             */
+                            * Fired when an guild becomes available
+                            * @event Client#guildAvailable
+                            * @prop {Guild} guild The guild
+                            */
                             this.client.emit("guildAvailable", guild);
                         } else {
                             /**
-                             * Fired when an guild is created
-                             * @event Client#guildCreate
-                             * @prop {Guild} guild The guild
-                             */
+                            * Fired when an guild is created
+                            * @event Client#guildCreate
+                            * @prop {Guild} guild The guild
+                            */
                             this.client.emit("guildCreate", guild);
                         }
                     } else {
@@ -639,10 +639,10 @@ class Shard extends EventEmitter {
                 } else {
                     this.client.guilds.remove(packet.d);
                     /**
-                     * Fired when an unavailable guild is created
-                     * @event Client#unavailableGuildCreate
-                     * @prop {UnavailableGuild} guild The unavailable guild
-                     */
+                    * Fired when an unavailable guild is created
+                    * @event Client#unavailableGuildCreate
+                    * @prop {UnavailableGuild} guild The unavailable guild
+                    */
                     this.client.emit("unavailableGuildCreate", this.client.unavailableGuilds.add(packet.d, this.client));
                 }
                 break;
@@ -663,78 +663,78 @@ class Shard extends EventEmitter {
                     afkTimeout: guild.afk_timeout
                 };
                 /**
-                 * Fired when an guild is updated
-                 * @event Client#guildUpdate
-                 * @prop {Guild} guild The guild
-                 * @prop {Object} oldGuild The old guild data
-                 * @prop {String} oldGuild.name The name of the guild
-                 * @prop {Number} oldGuild.verificationLevel The guild verification level
-                 * @prop {String} oldGuild.region The region of the guild
-                 * @prop {String?} oldGuild.icon The hash of the guild icon, or null if no icon
-                 * @prop {String} oldGuild.afkChannelID The ID of the AFK voice channel
-                 * @prop {Number} oldGuild.afkTimeout The AFK timeout in seconds
-                 * @prop {String} oldGuild.ownerID The ID of the user that is the guild owner
-                 * @prop {String?} oldGuild.splash The hash of the guild splash image, or null if no splash (VIP only)
-                 * @prop {Object[]} oldGuild.features An array of guild features
-                 * @prop {Object[]} oldGuild.emojis An array of guild emojis
-                 */
+                * Fired when an guild is updated
+                * @event Client#guildUpdate
+                * @prop {Guild} guild The guild
+                * @prop {Object} oldGuild The old guild data
+                * @prop {String} oldGuild.name The name of the guild
+                * @prop {Number} oldGuild.verificationLevel The guild verification level
+                * @prop {String} oldGuild.region The region of the guild
+                * @prop {String?} oldGuild.icon The hash of the guild icon, or null if no icon
+                * @prop {String} oldGuild.afkChannelID The ID of the AFK voice channel
+                * @prop {Number} oldGuild.afkTimeout The AFK timeout in seconds
+                * @prop {String} oldGuild.ownerID The ID of the user that is the guild owner
+                * @prop {String?} oldGuild.splash The hash of the guild splash image, or null if no splash (VIP only)
+                * @prop {Object[]} oldGuild.features An array of guild features
+                * @prop {Object[]} oldGuild.emojis An array of guild emojis
+                */
                 this.client.emit("guildUpdate", this.client.guilds.update(packet.d, this.client), oldGuild);
                 break;
             }
             case "GUILD_DELETE": {
                 delete this.client.guildShardMap[packet.d.id];
                 var guild = this.client.guilds.remove(packet.d);
-                if (guild) { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
+                if(guild) { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
                     guild.channels.forEach((channel) => {
                         delete this.client.channelGuildMap[channel.id];
                     });
                 }
-                if (packet.d.unavailable) {
+                if(packet.d.unavailable) {
                     /**
-                     * Fired when an guild becomes unavailable
-                     * @event Client#guildUnavailable
-                     * @prop {Guild} guild The guild
-                     */
+                    * Fired when an guild becomes unavailable
+                    * @event Client#guildUnavailable
+                    * @prop {Guild} guild The guild
+                    */
                     this.client.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
                 } else {
                     /**
-                     * Fired when an guild is deleted
-                     * @event Client#guildDelete
-                     * @prop {Guild} guild The guild
-                     */
+                    * Fired when an guild is deleted
+                    * @event Client#guildDelete
+                    * @prop {Guild} guild The guild
+                    */
                     this.client.emit("guildDelete", guild || {
-                            id: packet.d.id
-                        });
+                        id: packet.d.id
+                    });
                 }
                 break;
             }
             case "GUILD_BAN_ADD": {
                 /**
-                 * Fired when a user is banned from a guild
-                 * @event Client#guildBanAdd
-                 * @prop {Guild} guild The guild
-                 * @prop {User} user The banned user
-                 */
+                * Fired when a user is banned from a guild
+                * @event Client#guildBanAdd
+                * @prop {Guild} guild The guild
+                * @prop {User} user The banned user
+                */
                 this.client.emit("guildBanAdd", this.client.guilds.get(packet.d.guild_id), this.client.users.add(packet.d.user, this.client));
                 break;
             }
             case "GUILD_BAN_REMOVE": {
                 /**
-                 * Fired when a user is unbanned from a guild
-                 * @event Client#guildBanRemove
-                 * @prop {Guild} guild The guild
-                 * @prop {User} user The banned user
-                 */
+                * Fired when a user is unbanned from a guild
+                * @event Client#guildBanRemove
+                * @prop {Guild} guild The guild
+                * @prop {User} user The banned user
+                */
                 this.client.emit("guildBanRemove", this.client.guilds.get(packet.d.guild_id), this.client.users.add(packet.d.user, this.client));
                 break;
             }
             case "GUILD_ROLE_CREATE": {
                 /**
-                 * Fired when a guild role is created
-                 * @event Client#guildRoleCreate
-                 * @prop {Guild} guild The guild
-                 * @prop {Role} role The role
-                 */
+                * Fired when a guild role is created
+                * @event Client#guildRoleCreate
+                * @prop {Guild} guild The guild
+                * @prop {Role} role The role
+                */
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 this.client.emit("guildRoleCreate", guild, guild.roles.add(packet.d.role, guild));
                 break;
@@ -743,7 +743,7 @@ class Shard extends EventEmitter {
                 var guild = this.client.guilds.get(packet.d.guild_id);
                 var role = guild.roles.add(packet.d.role, guild);
                 var oldRole = null;
-                if (role) {
+                if(role) {
                     oldRole = {
                         color: role.color,
                         hoist: role.hoist,
@@ -754,55 +754,55 @@ class Shard extends EventEmitter {
                     };
                 }
                 /**
-                 * Fired when a guild role is updated
-                 * @event Client#guildRoleUpdate
-                 * @prop {Guild} guild The guild
-                 * @prop {Role} role The updated role
-                 * @prop {Object} oldRole The old role data
-                 * @prop {String} oldRole.name The name of the role
-                 * @prop {Boolean} oldRole.managed Whether a guild integration manages this role or not
-                 * @prop {Boolean} oldRole.hoist Whether users with this role are hoisted in the user list or not
-                 * @prop {Number} oldRole.color The hex color of the role in base 10
-                 * @prop {Number} oldRole.position The position of the role
-                 * @prop {Number} oldRole.permissions The permissions number of the role
-                 */
+                * Fired when a guild role is updated
+                * @event Client#guildRoleUpdate
+                * @prop {Guild} guild The guild
+                * @prop {Role} role The updated role
+                * @prop {Object} oldRole The old role data
+                * @prop {String} oldRole.name The name of the role
+                * @prop {Boolean} oldRole.managed Whether a guild integration manages this role or not
+                * @prop {Boolean} oldRole.hoist Whether users with this role are hoisted in the user list or not
+                * @prop {Number} oldRole.color The hex color of the role in base 10
+                * @prop {Number} oldRole.position The position of the role
+                * @prop {Number} oldRole.permissions The permissions number of the role
+                */
                 this.client.emit("guildRoleUpdate", guild, guild.roles.update(packet.d.role, guild), oldRole);
                 break;
             }
             case "GUILD_ROLE_DELETE": {
                 /**
-                 * Fired when a guild role is deleted
-                 * @event Client#guildRoleDelete
-                 * @prop {Guild} guild The guild
-                 * @prop {Role} role The role
-                 */
+                * Fired when a guild role is deleted
+                * @event Client#guildRoleDelete
+                * @prop {Guild} guild The guild
+                * @prop {Role} role The role
+                */
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if (guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
+                if(guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
                     this.client.emit("guildRoleDelete", guild, guild.roles.remove({id: packet.d.role_id}));
                 }
                 break;
             }
             case "CHANNEL_CREATE": {
-                if (packet.d.type === undefined || packet.d.type === 1) {
-                    if (this.id === 0) {
+                if(packet.d.type === undefined || packet.d.type === 1) {
+                    if(this.id === 0) {
                         /**
-                         * Fired when a channel is created
-                         * @event Client#channelCreate
-                         * @prop {Channel} channel The channel
-                         */
+                        * Fired when a channel is created
+                        * @event Client#channelCreate
+                        * @prop {Channel} channel The channel
+                        */
                         this.client.privateChannelMap[packet.d.recipients[0].id] = packet.d.id;
                         this.client.emit("channelCreate", this.client.privateChannels.add(packet.d, this.client));
                     }
-                } else if (packet.d.type === 0 || packet.d.type === 2) {
+                } else if(packet.d.type === 0 || packet.d.type === 2) {
                     var guild = this.client.guilds.get(packet.d.guild_id);
-                    if (!guild) {
+                    if(!guild) {
                         break;
                     }
                     var channel = guild.channels.add(packet.d, guild);
                     this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
                     this.client.emit("channelCreate", channel);
-                } else if (packet.d.type === 3) {
-                    if (this.id === 0) {
+                } else if(packet.d.type === 3) {
+                    if(this.id === 0) {
                         this.client.emit("channelCreate", this.client.groupChannels.add(packet.d, this.client));
                     }
                 } else {
@@ -812,11 +812,11 @@ class Shard extends EventEmitter {
             }
             case "CHANNEL_UPDATE": {
                 var channel = this.client.getChannel(packet.d.id);
-                if (!channel) {
+                if(!channel) {
                     return;
                 }
-                if (channel.type === 3) {
-                    if (this.id !== 0) {
+                if(channel.type === 3) {
+                    if(this.id !== 0) {
                         break;
                     }
                     var oldChannel = {
@@ -825,7 +825,7 @@ class Shard extends EventEmitter {
                         icon: channel.icon
                     };
                 }
-                if (channel.type === 0 || channel.type === 2) {
+                if(channel.type === 0 || channel.type === 2) {
                     var oldChannel = {
                         name: channel.name,
                         topic: channel.topic,
@@ -836,47 +836,47 @@ class Shard extends EventEmitter {
                 }
                 channel.update(packet.d);
                 /**
-                 * Fired when a channel is updated
-                 * @event Client#channelUpdate
-                 * @prop {Channel} channel The updated channel
-                 * @prop {Object} oldChannel The old channel data
-                 * @prop {String} oldChannel.name The name of the channel
-                 * @prop {Number} oldChannel.position The position of the channel
-                 * @prop {String?} oldChannel.topic The topic of the channel (text channels only)
-                 * @prop {Number?} oldChannel.bitrate The bitrate of the channel (voice channels only)
-                 * @prop {Collection} oldChannel.permissionOverwrites Collection of PermissionOverwrites in this channel
-                 */
+                * Fired when a channel is updated
+                * @event Client#channelUpdate
+                * @prop {Channel} channel The updated channel
+                * @prop {Object} oldChannel The old channel data
+                * @prop {String} oldChannel.name The name of the channel
+                * @prop {Number} oldChannel.position The position of the channel
+                * @prop {String?} oldChannel.topic The topic of the channel (text channels only)
+                * @prop {Number?} oldChannel.bitrate The bitrate of the channel (voice channels only)
+                * @prop {Collection} oldChannel.permissionOverwrites Collection of PermissionOverwrites in this channel
+                */
                 this.client.emit("channelUpdate", channel, oldChannel);
                 break;
             }
             case "CHANNEL_DELETE": {
-                if (packet.d.type === 1 || packet.d.type === undefined) {
-                    if (this.id === 0) {
+                if(packet.d.type === 1 || packet.d.type === undefined) {
+                    if(this.id === 0) {
                         var channel = this.client.privateChannels.remove(packet.d);
-                        if (channel) {
+                        if(channel) {
                             delete this.client.privateChannelMap[channel.recipient.id];
                             /**
-                             * Fired when a channel is deleted
-                             * @event Client#channelDelete
-                             * @prop {Channel} channel The channel
-                             */
+                            * Fired when a channel is deleted
+                            * @event Client#channelDelete
+                            * @prop {Channel} channel The channel
+                            */
                             this.client.emit("channelDelete", channel);
                         }
                     }
-                } else if (packet.d.type === 0 || packet.d.type === 2) {
+                } else if(packet.d.type === 0 || packet.d.type === 2) {
                     delete this.client.channelGuildMap[packet.d.id];
                     var channel = this.client.guilds.get(packet.d.guild_id).channels.remove(packet.d);
-                    if (!channel) {
+                    if(!channel) {
                         return;
                     }
-                    if (channel.type === 2) {
+                    if(channel.type === 2) {
                         channel.voiceMembers.forEach((member) => {
                             this.client.emit("voiceChannelLeave", channel.voiceMembers.remove(member), channel);
                         });
                     }
                     this.client.emit("channelDelete", channel);
-                } else if (packet.d.type === 3) {
-                    if (this.id === 0) {
+                } else if(packet.d.type === 3) {
+                    if(this.id === 0) {
                         this.client.emit("channelDelete", this.client.groupChannels.remove(packet.d));
                     }
                 } else {
@@ -887,41 +887,41 @@ class Shard extends EventEmitter {
             case "CALL_CREATE": {
                 packet.d.id = packet.d.message_id;
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (channel.call) {
+                if(channel.call) {
                     channel.call.update(packet.d);
                 } else {
                     channel.call = new Call(packet.d, channel);
                     var incrementedID = "";
                     var overflow = true;
                     var chunks = packet.d.id.match(/\d{1,9}/g).map((chunk) => parseInt(chunk));
-                    for (var i = chunks.length - 1; i >= 0; --i) {
-                        if (overflow) {
+                    for(var i = chunks.length - 1; i >= 0; --i) {
+                        if(overflow) {
                             ++chunks[i];
                             overflow = false;
                         }
-                        if (chunks[i] > 999999999) {
+                        if(chunks[i] > 999999999) {
                             overflow = true;
                             incrementedID = "000000000" + incrementedID;
                         } else {
                             incrementedID = chunks[i] + incrementedID;
                         }
                     }
-                    if (overflow) {
+                    if(overflow) {
                         incrementedID = overflow + incrementedID;
                     }
                     this.client.getMessages(channel.id, 1, incrementedID);
                 }
                 /**
-                 * Fired when a call is created
-                 * @event Client#callCreate
-                 * @prop {Call} call The call
-                 */
+                * Fired when a call is created
+                * @event Client#callCreate
+                * @prop {Call} call The call
+                */
                 this.client.emit("callCreate", channel.call);
                 break;
             }
             case "CALL_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel.call) {
+                if(!channel.call) {
                     throw new Error("CALL_UPDATE but channel has no call");
                 }
                 var oldCall = {
@@ -932,82 +932,82 @@ class Shard extends EventEmitter {
                     unavailable: channel.call.unavailable,
                 };
                 /**
-                 * Fired when a call is updated
-                 * @event Client#callUpdate
-                 * @prop {Call} call The updated call
-                 * @prop {Object} oldCall The old call data
-                 * @prop {String[]} oldCall.participants The IDs of the call participants
-                 * @prop {Number?} oldCall.endedTimestamp The timestamp of the call end
-                 * @prop {String[]?} oldCall.ringing The IDs of people that were being rung
-                 * @prop {String?} oldCall.region The region of the call server
-                 * @prop {Boolean} oldCall.unavailable Whether the call was unavailable or not
-                 */
+                * Fired when a call is updated
+                * @event Client#callUpdate
+                * @prop {Call} call The updated call
+                * @prop {Object} oldCall The old call data
+                * @prop {String[]} oldCall.participants The IDs of the call participants
+                * @prop {Number?} oldCall.endedTimestamp The timestamp of the call end
+                * @prop {String[]?} oldCall.ringing The IDs of people that were being rung
+                * @prop {String?} oldCall.region The region of the call server
+                * @prop {Boolean} oldCall.unavailable Whether the call was unavailable or not
+                */
                 this.client.emit("callUpdate", channel.call.update(packet.d), oldCall);
                 break;
             }
             case "CALL_DELETE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel.call) {
+                if(!channel.call) {
                     throw new Error("CALL_DELETE but channel has no call");
                 }
                 channel.lastCall = channel.call;
                 channel.call = null;
                 /**
-                 * Fired when a call is deleted
-                 * @event Client#callDelete
-                 * @prop {Call} call The call
-                 */
+                * Fired when a call is deleted
+                * @event Client#callDelete
+                * @prop {Call} call The call
+                */
                 this.client.emit("callDelete", channel.lastCall);
                 break;
             }
             case "CHANNEL_RECIPIENT_ADD": {
                 var channel = this.client.groupChannels.get(packet.d.channel_id);
-                /**
-                 * Fired when a user joins a group channel
-                 * @event Client#channelRecipientAdd
-                 * @prop {GroupChannel} channel The channel
-                 * @prop {User} user The user
-                 */
+                    /**
+                    * Fired when a user joins a group channel
+                    * @event Client#channelRecipientAdd
+                    * @prop {GroupChannel} channel The channel
+                    * @prop {User} user The user
+                    */
                 this.client.emit("channelRecipientAdd", channel, channel.recipients.add(this.client.users.add(packet.d.user, this.client)));
                 break;
             }
             case "CHANNEL_RECIPIENT_REMOVE": {
                 var channel = this.client.groupChannels.get(packet.d.channel_id);
-                /**
-                 * Fired when a user leaves a group channel
-                 * @event Client#channelRecipientRemove
-                 * @prop {GroupChannel} channel The channel
-                 * @prop {User} user The user
-                 */
+                    /**
+                    * Fired when a user leaves a group channel
+                    * @event Client#channelRecipientRemove
+                    * @prop {GroupChannel} channel The channel
+                    * @prop {User} user The user
+                    */
                 this.client.emit("channelRecipientRemove", channel, channel.recipients.remove(packet.d.user));
                 break;
             }
             case "FRIEND_SUGGESTION_CREATE": {
                 /**
-                 * Fired when a client receives a friend suggestion
-                 * @event Client#friendSuggestionCreate
-                 * @prop {User} user The suggested user
-                 * @prop {String[]} reasons Array of reasons why this suggestion was made
-                 * @prop {Number} reasons.type Type of reason?
-                 * @prop {String} reasons.platform_type Platform you share with the user
-                 * @prop {String} reasons.name Username of suggested user on that platform
-                 */
-                this.client.emit("friendSuggestionCreate", new User(packet.d.suggested_user), packet.d.reasons);
+                * Fired when a client receives a friend suggestion
+                * @event Client#friendSuggestionCreate
+                * @prop {User} user The suggested user
+                * @prop {String[]} reasons Array of reasons why this suggestion was made
+                * @prop {Number} reasons.type Type of reason?
+                * @prop {String} reasons.platform_type Platform you share with the user
+                * @prop {String} reasons.name Username of suggested user on that platform
+                */
+                this.client.emit("friendSuggestionCreate",new User(packet.d.suggested_user), packet.d.reasons);
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {
                 /**
-                 * Fired when a client's friend suggestion is removed for any reason
-                 * @event Client#friendSuggestionDelete
-                 * @prop {User} user The suggested user
-                 */
+                * Fired when a client's friend suggestion is removed for any reason
+                * @event Client#friendSuggestionDelete
+                * @prop {User} user The suggested user
+                */
                 this.client.emit("friendSuggestionDelete", this.client.users.get(packet.d.suggested_user_id));
                 break;
             }
             case "GUILD_MEMBERS_CHUNK": {
                 var guild = this.client.guilds.get(packet.d.guild_id);
-                if (this.getAllUsersCount.hasOwnProperty(guild.id)) {
-                    if (this.getAllUsersCount[guild.id] <= 1) {
+                if(this.getAllUsersCount.hasOwnProperty(guild.id)) {
+                    if(this.getAllUsersCount[guild.id] <= 1) {
                         delete this.getAllUsersCount[guild.id];
                         this.checkReady();
                     } else {
@@ -1018,7 +1018,7 @@ class Shard extends EventEmitter {
                 /**
                  * Fired when discord sends members on startup
                  * @event Client#guildMemberChunk
-                 * @prop {Guild} guild The guild the members were loaded from
+                 * @prop {Guild} The guild the members were loaded from
                  * @prop {Array<Member>} members The newly added members
                  */
                 this.client.emit("guildMemberChunk", guild, packet.d.members.map((member) => {
@@ -1034,14 +1034,14 @@ class Shard extends EventEmitter {
             }
             case "GUILD_SYNC": {// (╯°□°）╯︵ ┻━┻ thx Discord devs
                 var guild = this.client.guilds.get(packet.d.id);
-                for (var member of packet.d.members) {
+                for(var member of packet.d.members) {
                     member.id = member.user.id;
                     guild.members.add(member, guild);
                 }
-                for (var presence of packet.d.presences) {
-                    if (!guild.members.get(presence.user.id)) {
+                for(var presence of packet.d.presences) {
+                    if(!guild.members.get(presence.user.id)) {
                         var userData = this.client.users.get(presence.user.id);
-                        if (userData) {
+                        if(userData) {
                             userData = `{username: ${userData.username}, id: ${userData.id}, discriminator: ${userData.discriminator}}`;
                         }
                         this.client.emit("debug", `Presence without member. ${presence.user.id}. In global user cache: ${userData}. ` + JSON.stringify(presence), this.id);
@@ -1050,16 +1050,16 @@ class Shard extends EventEmitter {
                     presence.id = presence.user.id;
                     guild.members.update(presence);
                 }
-                if (guild.pendingVoiceStates && guild.pendingVoiceStates.length > 0) {
-                    for (var voiceState of guild.pendingVoiceStates) {
-                        if (!guild.members.get(voiceState.user_id)) {
+                if(guild.pendingVoiceStates && guild.pendingVoiceStates.length > 0) {
+                    for(var voiceState of guild.pendingVoiceStates) {
+                        if(!guild.members.get(voiceState.user_id)) {
                             continue;
                         }
                         voiceState.id = voiceState.user_id;
                         var channel = guild.channels.get(voiceState.channel_id);
-                        if (channel) {
+                        if(channel) {
                             channel.voiceMembers.add(guild.members.update(voiceState));
-                            if (this.client.options.seedVoiceConnections && voiceState.id === this.client.user.id && !this.client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
+                            if(this.client.options.seedVoiceConnections && voiceState.id === this.client.user.id && !this.client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
                                 this.client.joinVoiceChannel(channel.id, false);
                             }
                         } else { // Phantom voice states from connected users in deleted channels (╯°□°）╯︵ ┻━┻
@@ -1082,37 +1082,37 @@ class Shard extends EventEmitter {
                 this.presence.status = "online";
                 this.client.shards._readyPacketCB();
 
-                if (packet.t === "RESUMED") {
+                if(packet.t === "RESUMED") {
                     this.preReady = true;
                     this.ready = true;
 
                     /**
-                     * Fired when a shard finishes resuming
-                     * @event Shard#resume
-                     * @prop {Number} id The ID of the shard
-                     */
+                    * Fired when a shard finishes resuming
+                    * @event Shard#resume
+                    * @prop {Number} id The ID of the shard
+                    */
                     this.emit("resume");
                     break;
                 }
 
                 this.client.user = this.client.users.add(new ExtendedUser(packet.d.user), this.client);
-                if (this.client.user.bot) {
+                if(this.client.user.bot) {
                     this.client.bot = true;
-                    if (!this.client.token.startsWith("Bot ")) {
+                    if(!this.client.token.startsWith("Bot ")) {
                         this.client.token = "Bot " + this.client.token;
                     }
                 } else {
                     this.client.bot = false;
                 }
 
-                if (packet.d._trace) {
+                if(packet.d._trace) {
                     this.discordServerTrace = packet.d._trace;
                 }
 
                 this.sessionID = packet.d.session_id;
 
                 packet.d.guilds.forEach((guild) => {
-                    if (guild.unavailable) {
+                    if(guild.unavailable) {
                         this.client.guilds.remove(guild);
                         this.client.unavailableGuilds.add(guild, this.client, true);
                     } else {
@@ -1122,25 +1122,25 @@ class Shard extends EventEmitter {
                 this.guildCount = packet.d.guilds.length;
 
                 packet.d.private_channels.forEach((channel) => {
-                    if (channel.type === undefined || channel.type === 1) {
+                    if(channel.type === undefined || channel.type === 1) {
                         this.client.privateChannelMap[channel.recipients[0].id] = channel.id;
                         this.client.privateChannels.add(channel, this.client, true);
-                    } else if (channel.type === 3) {
+                    } else if(channel.type === 3) {
                         this.client.groupChannels.add(channel, this.client, true);
                     } else {
                         this.emit("error", new Error("Unhandled READY private_channel type: " + JSON.stringify(channel, null, 2)));
                     }
                 });
 
-                if (packet.d.relationships) {
+                if(packet.d.relationships) {
                     packet.d.relationships.forEach((relationship) => {
                         this.client.relationships.add(relationship, this.client, true);
                     });
                 }
 
-                if (packet.d.presences) {
+                if(packet.d.presences) {
                     packet.d.presences.forEach((presence) => {
-                        if (this.client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
+                        if(this.client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
                             presence.id = presence.user.id;
                             this.client.relationships.update(presence, null, true);
                         }
@@ -1149,13 +1149,13 @@ class Shard extends EventEmitter {
 
                 this.preReady = true;
                 /**
-                 * Fired when a shard finishes processing the ready packet
-                 * @event Client#shardPreReady
-                 * @prop {Number} id The ID of the shard
-                 */
+                * Fired when a shard finishes processing the ready packet
+                * @event Client#shardPreReady
+                * @prop {Number} id The ID of the shard
+                */
                 this.client.emit("shardPreReady", this.id);
 
-                if (this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
+                if(this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
                     this.restartGuildCreateTimeout();
                 } else {
                     this.checkReady();
@@ -1178,41 +1178,41 @@ class Shard extends EventEmitter {
                 break;
             }
             case "RELATIONSHIP_ADD": {
-                if (this.client.bot) {
+                if(this.client.bot) {
                     break;
                 }
                 var relationship = this.client.relationships.get(packet.d.id);
-                if (relationship) {
+                if(relationship) {
                     var oldRelationship = {
                         type: relationship.type
                     };
                     /**
-                     * Fired when a relationship is updated
-                     * @event Client#relationshipUpdate
-                     * @prop {Relationship} relationship The relationship
-                     * @prop {Object} oldRelationship The old relationship data
-                     * @prop {Number} oldRelationship.type The old type of the relationship
-                     */
+                    * Fired when a relationship is updated
+                    * @event Client#relationshipUpdate
+                    * @prop {Relationship} relationship The relationship
+                    * @prop {Object} oldRelationship The old relationship data
+                    * @prop {Number} oldRelationship.type The old type of the relationship
+                    */
                     this.client.emit("relationshipUpdate", this.client.relationships.update(packet.d), oldRelationship);
                 } else {
                     /**
-                     * Fired when a relationship is added
-                     * @event Client#relationshipAdd
-                     * @prop {Relationship} relationship The relationship
-                     */
+                    * Fired when a relationship is added
+                    * @event Client#relationshipAdd
+                    * @prop {Relationship} relationship The relationship
+                    */
                     this.client.emit("relationshipAdd", this.client.relationships.add(packet.d, this.client));
                 }
                 break;
             }
             case "RELATIONSHIP_REMOVE": {
-                if (this.client.bot) {
+                if(this.client.bot) {
                     break;
                 }
                 /**
-                 * Fired when a relationship is removed
-                 * @event Client#relationshipRemove
-                 * @prop {Relationship} relationship The relationship
-                 */
+                * Fired when a relationship is removed
+                * @event Client#relationshipRemove
+                * @prop {Relationship} relationship The relationship
+                */
                 this.client.emit("relationshipRemove", this.client.relationships.remove(packet.d));
                 break;
             }
@@ -1221,42 +1221,42 @@ class Shard extends EventEmitter {
                 var oldEmojis = guild.emojis;
                 guild.update(packet.d);
                 /**
-                 * Fired when a guild's emojis are updated
-                 * @event Client#guildEmojisUpdate
-                 * @prop {Guild} guild The guild
-                 * @prop {Array} emojis The updated emojis of the guild
-                 * @prop {Array} oldEmojis The old emojis of the guild
-                 */
+                * Fired when a guild's emojis are updated
+                * @event Client#guildEmojisUpdate
+                * @prop {Guild} guild The guild
+                * @prop {Array} emojis The updated emojis of the guild
+                * @prop {Array} oldEmojis The old emojis of the guild
+                */
                 this.client.emit("guildEmojisUpdate", guild, guild.emojis, oldEmojis);
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
                 var channel = this.client.getChannel(packet.d.channel_id);
-                if (!channel) {
+                if(!channel) {
                     this.client.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;
                 }
                 var oldTimestamp = channel.lastPinTimestamp;
                 channel.lastPinTimestamp = Date.parse(packet.d.timestamp);
                 /**
-                 * Fired when a channel pin timestamp is updated
-                 * @event Client#channelPinUpdate
-                 * @prop {Channel} channel The channel
-                 * @prop {Number} timestamp The new timestamp
-                 * @prop {Number} oldTimestamp The old timestamp
-                 */
+                * Fired when a channel pin timestamp is updated
+                * @event Client#channelPinUpdate
+                * @prop {Channel} channel The channel
+                * @prop {Number} timestamp The new timestamp
+                * @prop {Number} oldTimestamp The old timestamp
+                */
                 this.client.emit("channelPinUpdate", channel, channel.lastPinTimestamp, oldTimestamp);
                 break;
             }
             case "PRESENCES_REPLACE": {
-                for (var presence of packet.d) {
+                for(var presence of packet.d) {
                     var guild = this.client.guilds.get(presence.guild_id);
-                    if (!guild) {
+                    if(!guild) {
                         this.client.emit("warn", "Rogue presences replace: " + JSON.stringify(presence), this.id);
                         continue;
                     }
                     var member = guild.members.get(presence.user.id);
-                    if (!member && presence.user.username) {
+                    if(!member && presence.user.username) {
                         presence.id = presence.user.id;
                         member.update(presence);
                     }
@@ -1271,25 +1271,24 @@ class Shard extends EventEmitter {
             }
             default: {
                 /**
-                 * Fired when the shard encounters an unknown packet
-                 * @event Client#unknown
-                 * @prop {Object} packet The unknown packet
-                 * @prop {Number} id The ID of the shard
-                 */
+                * Fired when the shard encounters an unknown packet
+                * @event Client#unknown
+                * @prop {Object} packet The unknown packet
+                * @prop {Number} id The ID of the shard
+                */
                 this.client.emit("unknown", packet, this.id);
                 break;
             }
-        }
-        /* eslint-enable no-redeclare */
+        } /* eslint-enable no-redeclare */
         // this.client.emit("debug", packet.t + ": " + (Date.now() - startTime) + "ms" + debugStr, this.id);
     }
 
     syncGuild(guildID) {
-        if (this.guildSyncQueueLength + 3 + guildID.length > 4081) { // 4096 - "{\"op\":12,\"d\":[]}".length + 1 for lazy comma offset
+        if(this.guildSyncQueueLength + 3 + guildID.length > 4081) { // 4096 - "{\"op\":12,\"d\":[]}".length + 1 for lazy comma offset
             this.requestGuildSync(this.guildSyncQueue);
             this.guildSyncQueue = [guildID];
             this.guildSyncQueueLength = 1 + guildID.length + 3;
-        } else if (this.ready) {
+        } else if(this.ready) {
             this.requestGuildSync([guildID]);
         } else {
             this.guildSyncQueue.push(guildID);
@@ -1304,23 +1303,23 @@ class Shard extends EventEmitter {
     createGuild(_guild) {
         this.client.guildShardMap[_guild.id] = this.id;
         var guild = this.client.guilds.add(_guild, this.client, true);
-        if (this.client.bot === false) {
+        if(this.client.bot === false) {
             ++this.unsyncedGuilds;
             this.syncGuild(guild.id);
         }
-        if (this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
+        if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
             guild.fetchAllMembers();
         }
         return guild;
     }
 
     restartGuildCreateTimeout() {
-        if (this.guildCreateTimeout) {
+        if(this.guildCreateTimeout) {
             clearTimeout(this.guildCreateTimeout);
             this.guildCreateTimeout = null;
         }
-        if (!this.ready) {
-            if (this.client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
+        if(!this.ready) {
+            if(this.client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
@@ -1331,11 +1330,11 @@ class Shard extends EventEmitter {
 
     getGuildMembers(guildID, chunkCount) {
         this.getAllUsersCount[guildID] = chunkCount;
-        if (this.getAllUsersLength + 3 + guildID.length > 4048) { // 4096 - "{\"op\":8,\"d\":{\"guild_id\":[],\"query\":\"\",\"limit\":0}}".length + 1 for lazy comma offset
+        if(this.getAllUsersLength + 3 + guildID.length > 4048) { // 4096 - "{\"op\":8,\"d\":{\"guild_id\":[],\"query\":\"\",\"limit\":0}}".length + 1 for lazy comma offset
             this.requestGuildMembers(this.getAllUsersQueue);
             this.getAllUsersQueue = [guildID];
             this.getAllUsersLength = 1 + guildID.length + 3;
-        } else if (this.ready) {
+        } else if(this.ready) {
             this.requestGuildMembers([guildID]);
         } else {
             this.getAllUsersQueue.push(guildID);
@@ -1352,28 +1351,28 @@ class Shard extends EventEmitter {
     }
 
     checkReady() {
-        if (!this.ready) {
-            if (this.guildSyncQueue.length > 0) {
+        if(!this.ready) {
+            if(this.guildSyncQueue.length > 0) {
                 this.requestGuildSync(this.guildSyncQueue);
                 this.guildSyncQueue = [];
                 this.guildSyncQueueLength = 1;
                 return;
             }
-            if (this.unsyncedGuilds > 0) {
+            if(this.unsyncedGuilds > 0) {
                 return;
             }
-            if (this.getAllUsersQueue.length > 0) {
+            if(this.getAllUsersQueue.length > 0) {
                 this.requestGuildMembers(this.getAllUsersQueue);
                 this.getAllUsersQueue = [];
                 this.getAllUsersLength = 1;
                 return;
             }
-            if (Object.keys(this.getAllUsersCount).length === 0) {
+            if(Object.keys(this.getAllUsersCount).length === 0) {
                 this.ready = true;
                 /**
-                 * Fired when the shard turns ready
-                 * @event Shard#ready
-                 */
+                * Fired when the shard turns ready
+                * @event Shard#ready
+                */
                 this.emit("ready");
             }
         }
@@ -1383,53 +1382,53 @@ class Shard extends EventEmitter {
         this.status = "connecting";
         this.ws = new WebSocket(this.client.gatewayURL);
         this.ws.onopen = () => {
-            if (!this.client.token) {
+            if(!this.client.token) {
                 return this.disconnect(null, new Error("Token not specified"));
             }
             this.status = "handshaking";
             /**
-             * Fired when the shard establishes a connection
-             * @event Client#connect
-             * @prop {Number} id The ID of the shard
-             */
+            * Fired when the shard establishes a connection
+            * @event Client#connect
+            * @prop {Number} id The ID of the shard
+            */
             this.client.emit("connect", this.id);
             this.lastHeartbeatAck = true;
         };
         this.ws.onmessage = (m) => {
             try {
                 m = m.data;
-                if (typeof m !== "string") {
+                if(typeof m !== "string") {
                     m = Inflator(m).toString();
                 }
 
                 var packet = JSON.parse(m);
 
-                if (this.client.listeners("rawWS").length > 0) {
+                if(this.client.listeners("rawWS").length > 0) {
                     /**
-                     * Fired when the shard receives a websocket packet
-                     * @event Client#rawWS
-                     * @prop {Object} packet The packet
-                     * @prop {Number} id The ID of the shard
-                     */
+                    * Fired when the shard receives a websocket packet
+                    * @event Client#rawWS
+                    * @prop {Object} packet The packet
+                    * @prop {Number} id The ID of the shard
+                    */
                     this.client.emit("rawWS", packet, this.id);
                 }
 
-                if (packet.s > this.seq + 1 && this.ws) {
+                if(packet.s > this.seq + 1 && this.ws) {
                     /**
-                     * Fired to warn of something weird but non-breaking happening
-                     * @event Client#warn
-                     * @prop {String} message The warning message
-                     * @prop {Number} id The ID of the shard
-                     */
+                    * Fired to warn of something weird but non-breaking happening
+                    * @event Client#warn
+                    * @prop {String} message The warning message
+                    * @prop {Number} id The ID of the shard
+                    */
                     this.client.emit("warn", "Non-consecutive sequence, requesting resume", this.id);
                     this.resume();
-                } else if (packet.s) {
+                } else if(packet.s) {
                     this.seq = packet.s;
                 }
 
-                switch (packet.op) {
+                switch(packet.op) {
                     case OPCodes.EVENT: {
-                        if (!this.client.options.disableEvents[packet.t]) {
+                        if(!this.client.options.disableEvents[packet.t]) {
                             this.wsEvent(packet);
                         }
                         break;
@@ -1452,8 +1451,8 @@ class Shard extends EventEmitter {
                         break;
                     }
                     case OPCodes.HELLO: {
-                        if (packet.d.heartbeat_interval > 0) {
-                            if (this.heartbeatInterval) {
+                        if(packet.d.heartbeat_interval > 0) {
+                            if(this.heartbeatInterval) {
                                 clearInterval(this.heartbeatInterval);
                             }
                             this.heartbeatInterval = setInterval(() => this.heartbeat(true), packet.d.heartbeat_interval);
@@ -1462,14 +1461,13 @@ class Shard extends EventEmitter {
                         this.discordServerTrace = packet.d._trace;
                         this.connecting = false;
 
-                        if (this.sessionID) {
+                        if(this.sessionID) {
                             this.resume();
                         } else {
                             this.identify();
                         }
                         this.heartbeat();
-                        break;
-                        /* eslint-enable no-unreachable */
+                        break; /* eslint-enable no-unreachable */
                     }
                     case OPCodes.HEARTBEAT_ACK: {
                         this.lastHeartbeatAck = true;
@@ -1481,7 +1479,7 @@ class Shard extends EventEmitter {
                         break;
                     }
                 }
-            } catch (err) {
+            } catch(err) {
                 this.client.emit("error", err, this.id);
             }
         };
@@ -1490,31 +1488,31 @@ class Shard extends EventEmitter {
         };
         this.ws.onclose = (event) => {
             var err = event.code === 1000 ? null : new Error(event.code + ": " + event.reason);
-            if (event.code) {
+            if(event.code) {
                 this.client.emit("warn", `${event.code === 1000 ? "Clean" : "Unclean"} WS close: ${event.code}: ${event.reason}`, this.id);
-                if (event.code === 4001) {
+                if(event.code === 4001) {
                     err = new Error("Gateway received invalid OP code");
-                } else if (event.code === 4002) {
+                } else if(event.code === 4002) {
                     err = new Error("Gateway received invalid message");
-                } else if (event.code === 4003) {
+                } else if(event.code === 4003) {
                     err = new Error("Not authenticated");
-                } else if (event.code === 4004) {
+                } else if(event.code === 4004) {
                     err = new Error("Authentication failed");
-                } else if (event.code === 4005) {
+                } else if(event.code === 4005) {
                     err = new Error("Already authenticated");
-                } else if (event.code === 4006 || event.code === 4009) {
+                } else if(event.code === 4006 || event.code === 4009) {
                     this.sessionID = null;
                     err = new Error("Invalid session");
-                } else if (event.code === 4007) {
+                } else if(event.code === 4007) {
                     err = new Error("Invalid sequence number: " + this.seq);
                     this.seq = 0;
-                } else if (event.code === 4008) {
+                } else if(event.code === 4008) {
                     err = new Error("Gateway connection was ratelimited");
-                } else if (event.code === 4010) {
+                } else if(event.code === 4010) {
                     err = new Error("Invalid shard key");
-                } else if (event.code === 1006) {
+                } else if(event.code === 1006) {
                     err = new Error("Connection reset by peer");
-                } else if (!event.wasClean && event.reason) {
+                } else if(!event.wasClean && event.reason) {
                     err = new Error(event.code + ": " + event.reason);
                 }
             } else {
@@ -1526,7 +1524,7 @@ class Shard extends EventEmitter {
         };
 
         setTimeout(() => {
-            if (this.connecting) {
+            if(this.connecting) {
                 this.disconnect({
                     reconnect: "auto"
                 }, new Error("Connection timeout"));
@@ -1535,7 +1533,7 @@ class Shard extends EventEmitter {
     }
 
     heartbeat(normal) {
-        if (normal && !this.lastHeartbeatAck) {
+        if(normal && !this.lastHeartbeatAck) {
             return this.disconnect({
                 reconnect: "auto"
             }, new Error("Server didn't acknowledge previous heartbeat, possible lost connection"));
@@ -1546,17 +1544,17 @@ class Shard extends EventEmitter {
     }
 
     sendWS(op, data) {
-        if (this.ws && this.ws.readyState === WebSocket.OPEN) {
+        if(this.ws && this.ws.readyState === WebSocket.OPEN) {
             var i = 0;
             var waitFor = 1;
             var func = () => {
-                if (++i >= waitFor && this.ws && this.ws.readyState === WebSocket.OPEN) {
+                if(++i >= waitFor && this.ws && this.ws.readyState === WebSocket.OPEN) {
                     data = JSON.stringify({op: op, d: data});
                     this.ws.send(data);
                     this.client.emit("debug", data, this.id);
                 }
             };
-            if (op === OPCodes.STATUS_UPDATE) {
+            if(op === OPCodes.STATUS_UPDATE) {
                 ++waitFor;
                 this.presenceUpdateBucket.queue(func);
             }
@@ -1565,22 +1563,22 @@ class Shard extends EventEmitter {
     }
 
     /**
-     * Updates the bot's status on all guilds the shard is in
-     * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
-     * @arg {Object} [game] Sets the bot's active game, null to clear
-     * @arg {String} game.name Sets the name of the bot's active game
-     * @arg {Number} [game.type] The type of game. 0 is default, 1 is streaming (Twitch only)
-     * @arg {String} [game.url] Sets the url of the shard's active game
-     */
+    * Updates the bot's status on all guilds the shard is in
+    * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
+    * @arg {Object} [game] Sets the bot's active game, null to clear
+    * @arg {String} game.name Sets the name of the bot's active game
+    * @arg {Number} [game.type] The type of game. 0 is default, 1 is streaming (Twitch only)
+    * @arg {String} [game.url] Sets the url of the shard's active game
+    */
     editStatus(status, game) {
-        if (game === undefined && typeof status === "object") {
+        if(game === undefined && typeof status === "object") {
             game = status;
             status = undefined;
         }
-        if (status) {
+        if(status) {
             this.presence.status = status;
         }
-        if (game !== undefined) {
+        if(game !== undefined) {
             this.presence.game = game;
         }
 
@@ -1592,7 +1590,7 @@ class Shard extends EventEmitter {
         });
 
         this.client.guilds.forEach((guild) => {
-            if (guild.shard.id === this.id) {
+            if(guild.shard.id === this.id) {
                 guild.members.get(this.client.user.id).update(this.presence);
             }
         });


### PR DESCRIPTION
This adds an event when discord sends new members on startup or while caching new guilds.

This is especially useful if you want to add the users to a database. Since guildCreate is able to fire before all users are cached, it can lead to errors on new guilds when not all users are passed in guild.members and, after you added them to your database, you try to query for non-existent users.