### PR TITLE
Add command error message

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -37,6 +37,7 @@ class Command {
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
     * @arg {String} [options.cooldownMessage] A message to show when the command is on cooldown
     * @arg {String} [options.permissionMessage] A message to show when the user doesn't have permissions to use the command
+    * @arg {String} [options.errorMessage] A message to show if the execution of the command handler somehow fails.
     */
     constructor(label, generator, options) {
         this.label = label;
@@ -65,6 +66,7 @@ class Command {
         this.cooldown = options.cooldown || 0;
         this.cooldownMessage = options.cooldownMessage || false;
         this.permissionMessage = options.permissionMessage || false;
+        this.errorMessage = options.errorMessage || false;
         if(this.cooldown !== 0) {
             this.usersOnCooldown = new Set();
         }

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -66,7 +66,7 @@ class Command {
         this.cooldown = options.cooldown || 0;
         this.cooldownMessage = options.cooldownMessage || false;
         this.permissionMessage = options.permissionMessage || false;
-        this.errorMessage = options.errorMessage || false;
+        this.errorMessage = options.errorMessage || "";
         if(this.cooldown !== 0) {
             this.usersOnCooldown = new Set();
         }

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -140,6 +140,11 @@ class CommandClient extends Client {
                     if(resp != null) {
                         this.createMessage(msg.channel.id, resp);
                     }
+                }).catch((err) => {
+                    this.emit('warn', err);
+                    if(command.errorMessage) {
+                        this.createMessage(msg.channel.id,command.errorMessage);
+                    }
                 });
                 if(command.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(this.user.id).has('manageMessages')) {
                     this.deleteMessage(msg.channel.id, msg.id);
@@ -230,6 +235,7 @@ class CommandClient extends Client {
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
     * @arg {String} [options.cooldownMessage] A message to show when the command is on cooldown
     * @arg {String} [options.permissionMessage] A message to show when the user doesn't have permissions to use the command
+    * @arg {String} [options.errorMessage] A message to show if the execution of the command handler somehow fails.
     * @returns {Command}
     */
     registerCommand(label, generator, options) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -141,9 +141,9 @@ class CommandClient extends Client {
                         this.createMessage(msg.channel.id, resp);
                     }
                 }).catch((err) => {
-                    this.emit('warn', err);
+                    this.emit("warn", err);
                     if(command.errorMessage) {
-                        this.createMessage(msg.channel.id,command.errorMessage);
+                        this.createMessage(msg.channel.id, command.errorMessage);
                     }
                 });
                 if(command.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(this.user.id).has('manageMessages')) {


### PR DESCRIPTION
This adds an error message which is sent if the command generator somehow fails (e.g. if an exception is thrown or if the promise does not resolve).

I do not know if you are still accepting PRs for the CommandClient, however i thought this could be useful for some people. If you are rejecting, please consider this feature for the rewrite.