### PR TITLE
add method Channel.removeMessageReactions

### DIFF
--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -132,6 +132,15 @@ class Channel extends Base {
     }
 
     /**
+    * Remove all reactions from a message
+    * @arg {String} messageID The ID of the message
+    * @returns {Promise}
+    */
+    removeMessageReactions(messageID) {
+        return (this._client || this.guild.shard.client).removeMessageReactions.call((this._client || this.guild.shard.client), this.id, messageID);
+    }
+
+    /**
     * Delete a message
     * @arg {String} messageID The ID of the message
     * @returns {Promise}


### PR DESCRIPTION
In #184 I added that method to Message class (to bring it in par with the way removeMessageReaction is in multiple places) but I missed that there's the same functionality available on Channel class as well.

Now I have grepped for other usages of Client.removeMessageReaction to be sure it's not used anywhere else.