### PR TITLE
Fix doc string on guildRoleUpdate

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -770,7 +770,7 @@ class Shard extends EventEmitter {
                 * @prop {Boolean} oldRole.hoist Whether users with this role are hoisted in the user list or not
                 * @prop {Number} oldRole.color The hex color of the role in base 10
                 * @prop {Number} oldRole.position The position of the role
-                * @prop {Number} oldRole.permissions The permissions number of the role
+                * @prop {Permission} oldRole.permissions The permissions number of the role
                 */
                 this.client.emit("guildRoleUpdate", guild, guild.roles.update(packet.d.role, guild), oldRole);
                 break;


### PR DESCRIPTION
Update guildRoleUpdate docstring to refer to oldRole.permissions as a permissions object