### PR TITLE
Only use gif if a format is not provided

### DIFF
--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -61,12 +61,12 @@ class User extends Base {
     */
     dynamicAvatarURL(format, size) {
         if(format === undefined || !~Constants.ImageFormats.indexOf(format.toLowerCase())) {
-            format = this._client.options.defaultImageFormat;
+            format = this.avatar.startsWith("a_") ? "gif" : this._client.options.defaultImageFormat;
         }
         if(size === undefined || !~Constants.ImageSizes.indexOf(size)) {
             size = this._client.options.defaultImageSize;
         }
-        return this.avatar ? `${CDN_URL}/avatars/${this.id}/${this.avatar}.${this.avatar.startsWith("a_") ? "gif" : format}?size=${size}` : this.defaultAvatarURL;
+        return this.avatar ? `${CDN_URL}/avatars/${this.id}/${this.avatar}.${format}?size=${size}` : this.defaultAvatarURL;
     }
 
     /**


### PR DESCRIPTION
I sincerely apologize for not catching this sooner. In the dynamicAvatarURL function, we should only be checking for a `a_` hash if the provided format is not specified. Otherwise, gif avatars are forced on anyone who has an animated avatars, which defeats the purpose of dynamic urls.