### PR TITLE
Possibly fixes voice clients disconnecting, may break other things.

### DIFF
--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -77,7 +77,6 @@ class VoiceConnectionManager extends Collection {
             }
             this.pendingGuilds[data.guild_id].res(connection);
             delete this.pendingGuilds[data.guild_id];
-            connection.removeListener("disconnect", disconnectHandler);
         };
         connection.once("ready", readyHandler).once("disconnect", disconnectHandler);
     }

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -57,15 +57,15 @@ class VoiceConnectionManager extends Collection {
         this.pendingGuilds[data.guild_id].waiting = true;
         var disconnectHandler = () => {
             connection = this.get(data.guild_id);
-            if(!this.pendingGuilds[data.guild_id]) {
+            if(this.pendingGuilds[data.guild_id]) {
                 if(connection) {
                     connection.removeListener("ready", readyHandler);
+                    this.pendingGuilds[data.guild_id].rej(new Error("Disconnected"));
+                    delete this.pendingGuilds[data.guild_id];
                 }
                 return;
             }
-            this.pendingGuilds[data.guild_id].rej(new Error("Disconnected"));
-            delete this.pendingGuilds[data.guild_id];
-            connection.removeListener("ready", readyHandler);
+            this.leave(data.guild_id);
         };
         var readyHandler = () => {
             connection = this.get(data.guild_id);


### PR DESCRIPTION
This fixes the issue shown in this gif [here](https://pvpcraft.ca/i/57deh.gif)
Steps to reproduce:
1. have eris join a voice channel
2. call disconnect on the voice connection
3. remove the bot's permission to connect to that channel
4. have the bot attempt to join again
5. The bot will resolve the promise as if it joined, and pass back the original voice connection while in fact it has not, calling .play on this voice connection will fail.
(must be attempted without https://github.com/abalabahaha/eris/pull/199 having been merged, as this fixed a bug required to have the library attempt a voice connection that will fail)

Note that this very possibly breaks other things.