### PR TITLE
Corrected messageUpdate to return the old message id if cached

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -418,6 +418,7 @@ class Shard extends EventEmitter {
                         content: message.content,
                         embeds: message.embeds,
                         editedTimestamp: message.editedTimestamp,
+                        id: message.id,
                         mentionedBy: message.mentionedBy,
                         mentions: message.mentions,
                         roleMentions: message.roleMentions,


### PR DESCRIPTION
Should resolve situation 2 of https://github.com/abalabahaha/eris/issues/204