### PR TITLE
fix missing user in Member when using rest methods

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -42,6 +42,8 @@ class Member extends Base {
             if(!this.user) {
                 throw new Error("User associated with Member not found: " + data.id);
             }
+        } else if(data.user) {
+            this.user = new User(data.user);
         } else {
             this.user = null;
         }


### PR DESCRIPTION
The user property was missing from Member when using rest methods, and this fixes that.