### PR TITLE
Fix channel.lastPinTimestamp

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1279,7 +1279,7 @@ class Shard extends EventEmitter {
                     break;
                 }
                 var oldTimestamp = channel.lastPinTimestamp;
-                channel.lastPinTimestamp = Date.parse(packet.d.timestamp);
+                channel.lastPinTimestamp = Date.parse(packet.d.last_pin_timestamp);
                 /**
                 * Fired when a channel pin timestamp is updated
                 * @event Client#channelPinUpdate


### PR DESCRIPTION
You had the wrong property for the pin timestamp.

Also worth noting that the timestamp is absent if you remove the penultimate or ultimate channel pin. Not sure if you want to handle that.

Ex:
```js
{ last_pin_timestamp: '2017-06-01T20:42:38.930000+00:00', channel_id: '149206227455311873' }
```