### PR TITLE
Fix Message.cleanContent breaking when deleted role mentions are involved

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -143,7 +143,9 @@ class Message extends Base {
 
         if(this.channel.guild && this.roleMentions) {
             for(var roleID of this.roleMentions) {
-                this._cleanContent = this._cleanContent.replace(new RegExp(`<@&${roleID}>`, "g"), "@" + this.channel.guild.roles.get(roleID).name);
+                var role = this.channel.guild.roles.get(roleID);
+                var roleName = role ? role.name : "deleted-role";
+                this._cleanContent = this._cleanContent.replace(new RegExp(`<@&${roleID}>`, "g"), "@" + roleName);
             }
         }
 


### PR DESCRIPTION
**Steps to Reproduce**  
1. Create mentionable role  
2. Mention the role in a message  
3. Delete the role  
4. Delete the message

**Expected Result**  
Role name is replaced with placeholder

**Actual Result**  
It breaks.