### PR TITLE
Don't send bot auth when webhook token is supplied

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -554,7 +554,7 @@ class Client extends EventEmitter {
         if(options.content && (options.disableEveryone !== undefined ? options.disableEveryone : this.options.disableEveryone)) {
             options.content = options.content.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
         }
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), true, {
+        return this.requestHandler.request("POST", (token ? Endpoints.WEBHOOK_TOKEN(webhookID, token) : Endpoints.WEBHOOK(webhookID)) + (options.wait ? "?wait=true" : ""), !token, {
             content: options.content,
             embeds: options.embeds,
             username: options.username,
@@ -574,7 +574,7 @@ class Client extends EventEmitter {
     executeSlackWebhook(webhookID, token, options) {
         var wait = !!options.wait;
         options.wait = undefined;
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), true, options);
+        return this.requestHandler.request("POST", (token ? Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) : Endpoints.WEBHOOK_SLACK(webhookID)) + (wait ? "?wait=true" : ""), !token, options);
     }
 
     /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -70,4 +70,5 @@ module.exports.USERS =                                                          
 module.exports.VOICE_REGIONS =                                                      "/voice/regions";
 module.exports.WEBHOOK =                                                (hookID) => `/webhooks/${hookID}`;
 module.exports.WEBHOOK_TOKEN =                                   (hookID, token) => `/webhooks/${hookID}/${token}`;
+module.exports.WEBHOOK_SLACK =                                          (hookID) => `/webhooks/${hookID}/slack`;
 module.exports.WEBHOOK_TOKEN_SLACK =                             (hookID, token) => `/webhooks/${hookID}/${token}/slack`;


### PR DESCRIPTION
I tested either the slack one or the non slack one, not sure which. 

Thank you to @briantanner and Discord Jake for figuring out that eris is sending the bot's token with webhook executions.