### PR TITLE
Several CommandClient changes

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -22,8 +22,8 @@ class Command {
     * @arg {String} [options.fullDescription="No full description"] A detailed description of the command to show in the default help command
     * @arg {String} [options.usage] Details on how to call the command to show in the default help command
     * @arg {Object} [options.requirements] A set of factors that limit who can call the command
-    * @arg {Array<String>} [options.requirements.userIDs] An array of user IDs representing users that can call the command
-    * @arg {Object} [options.requirements.permissions] An object containing permission keys the user must match to use the command
+    * @arg {Function | Array<String>} [options.requirements.userIDs] An array or a function that returns an array of user IDs representing users that can call the command.  The function is passed the Message object as a parameter.
+    * @arg {Function | Object} [options.requirements.permissions] An object or a function that returns an object containing permission keys the user must match to use the command.  The function is passed the Message object as a parameter.
     * i.e.:
     * ```
     * {
@@ -32,13 +32,15 @@ class Command {
     * }
     * ```
     * In the above example, the user must not have administrator permissions, but must have manageMessages to use the command
-    * @arg {Array<String>} [options.requirements.roleIDs] An array of role IDs that would allow a user to use the command
-    * @arg {Array<String>} [options.requirements.roleNames] An array of role names that would allow a user to use the command
+    * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
+    * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
-    * @arg {String} [options.cooldownMessage] A message to show when the command is on cooldown
-    * @arg {String} [options.invalidUsageMessage] A message to show when a command was improperly used
-    * @arg {String} [options.permissionMessage] A message to show when the user doesn't have permissions to use the command
-    * @arg {String} [options.errorMessage] A message to show if the execution of the command handler somehow fails.
+    * @arg {Boolean} [option.restartCooldown=false] Whether or not to restart a command's cooldown every time it's used.
+    * @arg {Number} [option.cooldownReturns=0] Number of times to return a message when the command is used during it's cooldown.  Once the cooldown expires this is reset.  Set this to 0 to always return a message.
+    * @arg {Function | String} [options.cooldownMessage] A string or a function that returns a string to show when the command is on cooldown.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.invalidUsageMessage] A string or a function that returns a string to show when a command was improperly used.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.permissionMessage] A string or a function that returns a string to show when the user doesn't have permissions to use the command.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.errorMessage] A string or a function that returns a string to show if the execution of the command handler somehow fails.  The function is passed the Message object as a parameter.
     * @arg {Array<{emoji: String, type: String, response: Function | String | Array<Function | String>}>} [options.reactionButtons] An array of objects specifying reaction buttons
     * `emoji` specifies the button emoji. Custom emojis should be in format `emojiName:emojiID`
     * `type` specifies the type of the reaction button, either "edit" or "cancel"
@@ -71,6 +73,8 @@ class Command {
         this.guildOnly = !!options.guildOnly;
         this.dmOnly = !!options.dmOnly;
         this.cooldown = options.cooldown || 0;
+        this.restartCooldown = !!options.restartCooldown;
+        this.cooldownReturns = options.cooldownReturns || 0;
         this.cooldownMessage = options.cooldownMessage || false;
         this.invalidUsageMessage = options.invalidUsageMessage || false;
         this.permissionMessage = options.permissionMessage || false;
@@ -103,6 +107,12 @@ class Command {
         this.reactionButtonTimeout = options.reactionButtonTimeout || 60000;
         if(this.cooldown !== 0) {
             this.usersOnCooldown = new Set();
+            if(this.restartCooldown) {
+                this.cooldownTimeouts = {};
+            }
+            if(this.cooldownReturns) {
+                this.cooldownAmounts = {};
+            }
         }
         if(typeof generator === "string") {
             this.response = generator;
@@ -131,7 +141,12 @@ class Command {
 
     permissionCheck(msg) {
         var req = false;
-        if(this.requirements.userIDs.length > 0) {
+        if(typeof this.requirements.userIDs === "function") {
+            req = true;
+            if(~this.requirements.userIDs(msg).indexOf(msg.author.id)) {
+                return true;
+            }
+        }else if(this.requirements.userIDs.length > 0) {
             req = true;
             if(~this.requirements.userIDs.indexOf(msg.author.id)) {
                 return true;
@@ -142,7 +157,7 @@ class Command {
         } else if(this.dmOnly) {
             return false;
         }
-        var keys = Object.keys(this.requirements.permissions);
+        var keys = typeof this.requirements.permissions === "function" ? Object.keys(this.requirements.permissions(msg)) : Object.keys(this.requirements.permissions);
         if(keys.length > 0) {
             req = true;
             var permissions = msg.channel.permissionsOf(msg.author.id).json;
@@ -159,7 +174,14 @@ class Command {
         }
         if(msg.member) {
             var roles = msg.member.roles || [];
-            if(this.requirements.roleIDs.length > 0) {
+            if(typeof this.requirements.roleIDs === "function") {
+                req = true;
+                for(var roleID of this.requirements.roleIDs(msg)) {
+                    if(~roles.indexOf(roleID)) {
+                        return true;
+                    }
+                }
+            }else if(this.requirements.roleIDs.length > 0) {
                 req = true;
                 for(var roleID of this.requirements.roleIDs) {
                     if(~roles.indexOf(roleID)) {
@@ -167,7 +189,15 @@ class Command {
                     }
                 }
             }
-            if(this.requirements.roleNames.length > 0) {
+            if(typeof this.requirements.roleNames === "function") {
+                req = true;
+                roles = roles.map((roleID) => msg.channel.guild.roles.get(roleID).name);
+                for(var roleName of this.requirements.roleNames(msg)) {
+                    if(~roles.indexOf(roleName)) {
+                        return true;
+                    }
+                }
+            }else if(this.requirements.roleNames.length > 0) {
                 req = true;
                 roles = roles.map((roleID) => msg.channel.guild.roles.get(roleID).name);
                 for(var roleName of this.requirements.roleNames) {
@@ -182,20 +212,45 @@ class Command {
 
     cooldownCheck(userID) {
         if(this.usersOnCooldown.has(userID)) {
+            if(this.cooldownReturns) {
+                this.cooldownAmounts[userID]++;
+            }
+            if(this.restartCooldown) {
+                clearTimeout(this.cooldownTimeouts[userID]);
+                this.cooldownTimeouts[userID] = setTimeout(() => {
+                    this.usersOnCooldown.delete(userID);
+                }, this.cooldown);
+            }
             return false;
         }
+        if(this.cooldownReturns) {
+            this.cooldownAmounts[userID] = 0;
+        }
         this.usersOnCooldown.add(userID);
-        setTimeout(() => {
-            this.usersOnCooldown.delete(userID);
-        }, this.cooldown);
+        if(this.restartCooldown) {
+            this.cooldownTimeouts[userID] = setTimeout(() => {
+                this.usersOnCooldown.delete(userID);
+            }, this.cooldown);
+        }else{
+            setTimeout(() => {
+                this.usersOnCooldown.delete(userID);
+            }, this.cooldown);
+        }
         return true;
     }
 
-    process(args, msg) {
+    process(args, msg, mainCommand) {
         var shouldDelete = this.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(msg._client.user.id).has("manageMessages");
         if(!this.permissionCheck(msg)) {
             if(this.permissionMessage) {
-                msg.channel.createMessage(this.permissionMessage);
+                if(typeof this.permissionMessage === "function") {
+                    var reply = this.permissionMessage(msg);
+                    if(reply !== undefined) {
+                        msg.channel.createMessage(reply);
+                    }
+                }else{
+                    msg.channel.createMessage(this.permissionMessage);
+                }
             }
             if(shouldDelete) {
                 msg.delete();
@@ -205,8 +260,14 @@ class Command {
         if(args.length === 0) {
             if(this.argsRequired) {
                 if(this.invalidUsageMessage) {
-                    var invalidUsageMessage = this.invalidUsageMessage.replace(/%prefix%/g, msg.prefix).replace(/%label%/g, this.label);
-                    msg.channel.createMessage(invalidUsageMessage);
+                    if(typeof this.invalidUsageMessage === "function") {
+                        var reply = this.invalidUsageMessage(msg);
+                        if(reply !== undefined) {
+                            msg.channel.createMessage(reply.replace(/%prefix%/g, msg.prefix).replace(/%label%/g, (mainCommand ? mainCommand.label + " " : "") + this.label));
+                        }
+                    }else{
+                        msg.channel.createMessage(this.invalidUsageMessage.replace(/%prefix%/g, msg.prefix).replace(/%label%/g, (mainCommand ? mainCommand.label + " " : "") + this.label));
+                    }
                 }
                 if(shouldDelete) {
                     msg.delete();
@@ -214,8 +275,15 @@ class Command {
                 return;
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg.author.id)) {
-                if(this.cooldownMessage) {
-                    msg.channel.createMessage(this.cooldownMessage);
+                if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
+                    if(typeof this.cooldownMessage === "function") {
+                        var reply = this.cooldownMessage(msg);
+                        if(reply !== undefined) {
+                            msg.channel.createMessage(reply);
+                        }
+                    }else{
+                        msg.channel.createMessage(this.cooldownMessage);
+                    }
                 }
                 if(shouldDelete) {
                     msg.delete();
@@ -230,11 +298,18 @@ class Command {
         var label = this.subcommandAliases[args[0]] || args[0];
         var subcommand;
         if((subcommand = this.subcommands[label]) !== undefined || ((subcommand = this.subcommands[label.toLowerCase()]) !== undefined && subcommand.caseInsensitive)) {
-            return subcommand.process(args.slice(1), msg);
+            return subcommand.process(args.slice(1), msg, this);
         } else {
             if(this.cooldown !== 0 && !this.cooldownCheck(msg.author.id)) {
-                if(this.cooldownMessage) {
-                    msg.channel.createMessage(this.cooldownMessage);
+                if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
+                    if(typeof this.cooldownMessage === "function") {
+                        var reply = this.cooldownMessage(msg);
+                        if(reply !== undefined) {
+                            msg.channel.createMessage(reply);
+                        }
+                    }else{
+                        msg.channel.createMessage(this.cooldownMessage);
+                    }
                 }
                 return;
             }
@@ -278,8 +353,8 @@ class Command {
     * @arg {String} [options.fullDescription="No full description"] A detailed description of the subcommand to show in the default help subcommand
     * @arg {String} [options.usage] Details on how to call the subcommand to show in the default help subcommand
     * @arg {Object} [options.requirements] A set of factors that limit who can call the subcommand
-    * @arg {Array<String>} [options.requirements.userIDs] An array of user IDs representing users that can call the subcommand
-    * @arg {Object} [options.requirements.permissions] An object containing permission keys the user must match to use the subcommand
+    * @arg {Function | Array<String>} [options.requirements.userIDs] An array or a function that returns an array of user IDs representing users that can call the subcommand
+    * @arg {Function | Object} [options.requirements.permissions] An object or a function that returns an object containing permission keys the user must match to use the subcommand
     * i.e.:
     * ```
     * {
@@ -287,13 +362,15 @@ class Command {
     *   "manageMessages": true
     * }```
     * In the above example, the user must not have administrator permissions, but must have manageMessages to use the subcommand
-    * @arg {Array<String>} [options.requirements.roleIDs] An array of role IDs that would allow a user to use the subcommand
-    * @arg {Array<String>} [options.requirements.roleNames] An array of role names that would allow a user to use the subcommand
+    * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the subcommand
+    * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the subcommand
     * @arg {Number} [options.cooldown] The cooldown between subcommand usage in milliseconds
-    * @arg {String} [options.cooldownMessage] A message to show when the subcommand is on cooldown
-    * @arg {String} [options.invalidUsageMessage] A message to show when a command was improperly used
-    * @arg {String} [options.permissionMessage] A message to show when the user doesn't have permissions to use the command
-    * @arg {String} [options.errorMessage] A message to show if the execution of the command handler somehow fails.
+    * @arg {Boolean} [option.restartCooldown=false] Whether or not to restart a command's cooldown every time it's used.
+    * @arg {Number} [option.cooldownReturns=0] Number of times to return a message when the command is used during it's cooldown.  Once the cooldown expires this is reset.  Set this to 0 to always return a message.
+    * @arg {Function | String} [options.cooldownMessage] A string or a function that returns a string to show when the command is on cooldown.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.invalidUsageMessage] A string or a function that returns a string to show when a command was improperly used.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.permissionMessage] A string or a function that returns a string to show when the user doesn't have permissions to use the command.  The function is passed the Message object as a parameter.
+    * @arg {Function | String} [options.errorMessage] A string or a function that returns a string to show if the execution of the command handler somehow fails.  The function is passed the Message object as a parameter.
     * @arg {Array<{emoji: String, type: String, response: Function | String | Array<Function | String>}>} [options.reactionButtons] An array of objects specifying reaction buttons
     * `emoji` specifies the button emoji. Custom emojis should be in format `emojiName:emojiID`
     * `type` specifies the type of the reaction button, either "edit" or "cancel"

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -159,9 +159,16 @@ class CommandClient extends Client {
                         });
                     }
                 }).catch((err) => {
-                    this.emit("warn", err);
+                    this.emit("error", err);
                     if(command.errorMessage) {
-                        this.createMessage(msg.channel.id, command.errorMessage);
+                        if(typeof command.errorMessage === "function") {
+                            var reply = command.errorMessage();
+                            if(reply !== undefined) {
+                                this.createMessage(msg.channel.id, reply);
+                            }
+                        }else{
+                            this.createMessage(msg.channel.id, command.errorMessage);
+                        }
                     }
                 });
             }


### PR DESCRIPTION
*Note: I have bug tested all of these new features thoroughly.  I also have valid use cases for all of them and will be using almost all of them.  If there are any issues or you want different behaviors just tell me and I will do my best to fix any problems.*

I implemented all of the suggested changes (by me) in issue #270.  However, I made them optional and didn't change the default behavior.  All existing bots will work the exact same with or without this update.  To recap on these changes:
 * `Command.cooldownMessage` can be optionally set to a function that is passed the Message object and returns a message to send.  I also gave `Command.permissionMessage` and `Command.errorMessage` the same behavior.
 * All the options inside of `Command.requirements` can be optionally set to a function that returns an array/object and is passed the Message object.
 * I added an option to Commands called `restartCooldown`.  When set to true the Command's cooldown will reset every time someone attempts to use it while on cooldown.
 * I added an option to Commands called `cooldownReturns`.  When set to a number other than 0 it will only return a cooldown message x times.  When the cooldown expires this is reset.


I also fixed the bug reported (by me) in issue #269.  The invalid usage message was already fixed to not tell you to use a help command that doesn't exist, but when using `.cmd subcmd` it would still tell you to use `.help subcmd` instead of `.help cmd subcmd` so I fixed that.

**Edit:** I also changed the event emitted when a command generator fails from `warn` to `error`, since logically an error should emit the error event.