### PR TITLE
Fix case insensitive aliases

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -140,8 +140,9 @@ class CommandClient extends Client {
             var args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).split(" ");
             var label = args.shift();
             label = this.commandAliases[label] || label;
+            var lowerCaseAlias = this.commandAliases[label.toLowerCase()]
             var command;
-            if((command = this.commands[label]) !== undefined || ((command = this.commands[label.toLowerCase()]) !== undefined && command.caseInsensitive)) {
+            if((command = this.commands[label]) !== undefined || (((command = this.commands[label.toLowerCase()]) !== undefined || (command = this.commands[lowerCaseAlias]) !== undefined)) && command.caseInsensitive) {
                 msg.command = command;
                 Promise.resolve(command.process(args, msg)).then((resp) => {
                     if(resp != null) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -139,10 +139,8 @@ class CommandClient extends Client {
         if((!this.commandOptions.ignoreSelf || msg.author.id !== this.user.id) && (!this.commandOptions.ignoreBots || !msg.author.bot) && (msg.prefix = this.checkPrefix(msg))) {
             var args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).split(" ");
             var label = args.shift();
-            label = this.commandAliases[label] || label;
-            var lowerCaseAlias = this.commandAliases[label.toLowerCase()]
-            var command;
-            if((command = this.commands[label]) !== undefined || (((command = this.commands[label.toLowerCase()]) !== undefined || (command = this.commands[lowerCaseAlias]) !== undefined)) && command.caseInsensitive) {
+            var command = this.resolveCommand(label);
+            if(command !== undefined) {
                 msg.command = command;
                 Promise.resolve(command.process(args, msg)).then((resp) => {
                     if(resp != null) {
@@ -174,6 +172,22 @@ class CommandClient extends Client {
                 });
             }
         }
+    }
+
+    resolveCommand(label) {
+        label = this.commandAliases[label] || label;
+        var command = this.commands[label];
+
+        // caseInsensitive checks
+        if(command === undefined) {
+            var lowerCaseLabel = label.toLowerCase();
+            command = this.commands[lowerCaseLabel] || this.commands[this.commandAliases[lowerCaseLabel]];
+            if(command !== undefined && !command.caseInsensitive) {
+                return undefined;
+            }
+        }
+
+        return command;
     }
 
     onMessageReactionEvent(msg, emoji, userID) {


### PR DESCRIPTION
This fixes #286 

I feel this is a rather sloopy way to fix it, but since commandAliases only holds the name of the command, I tried to minimize the checks and keep things the way the are now. If people here feel the right way to go about this is to add the caseInsensitive flag to the commandAlias property, let me know and I'll edit this PR.