### PR TITLE
Fix 'Cannot read property 'channels' of undefined'

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -880,6 +880,7 @@ class Shard extends EventEmitter {
                 channel.update(packet.d);
 
                 if(packet.d.parent_id) {
+                    var guild = this.client.guilds.get(packet.d.guild_id);
                     if(packet.d.parent_id !== channel.parentID) {
                         var oldParentChannel = guild.channels.get(channel.parentID);
                         if(!oldParentChannel) {


### PR DESCRIPTION
This happens with channels with modified parent IDs.