### PR TITLE
Allow null as well as undefined for game in editStatus

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1699,6 +1699,9 @@ class Shard extends EventEmitter {
     * @arg {String} [game.url] Sets the url of the shard's active game
     */
     editStatus(status, game) {
+        if (game === null) {
+            game = undefined;
+        }
         if(game === undefined && typeof status === "object") {
             game = status;
             status = undefined;


### PR DESCRIPTION
Fixes issue when setting the status to null as described in the docs.

https://abal.moe/Eris/docs/Client#function-editStatus

If this is to be changed requiring users to use a status of undefined this should be done in a major change as it changes the api.