### PR TITLE
TypeScript typings additions and fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -242,7 +242,7 @@ declare module "eris" {
     permissionMessage?: string | GenericCheckFunction<string>;
     errorMessage?: string | GenericCheckFunction<string>;
   }
-  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | string | void;
+  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | Promise<void> | string | void;
   type CommandGenerator = CommandGeneratorFunction | string | string[] | CommandGeneratorFunction[];
 
   export class Client extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,7 +242,7 @@ declare module "eris" {
     permissionMessage?: string | GenericCheckFunction<string>;
     errorMessage?: string | GenericCheckFunction<string>;
   }
-  type CommandGeneratorFunction = (msg: Message, args: string[]) => string | void;
+  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | string | void;
   type CommandGenerator = CommandGeneratorFunction | string | string[] | CommandGeneratorFunction[];
 
   export class Client extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1136,7 +1136,7 @@ declare module "eris" {
     public onMessageCreate(msg: Message): void;
     public registerGuildPrefix(guildID: string, prefix: string[] | string): void;
     public registerCommandAlias(alias: string, label: string): void;
-    public registerCommand(label: string, generator: CommandGenerator, options?: CommandOptions): void;
+    public registerCommand(label: string, generator: CommandGenerator, options?: CommandOptions): Command;
     public unregisterCommand(label: string): void;
   }
 }


### PR DESCRIPTION
Added a Promise\<string> return type to CommandGeneratorFunction in the typings file. This enables generator functions that use the ES7-style async/await function syntax to specify the required Promise return type for async functions.

Some example code:

```typescript
fakePromise(): Promise<string> {
  return Promise.resolve("Resolved promise");
}
```

```typescript
async generatorFunc(msg: Message, args: string[]): string {
  //                                               ^
  // TS error: The return type of an async function or method must be the global Promise<T> type
  let str: string = await fakePromise();
  return str;
}
```

```typescript
async generatorFunc(msg: Message, args: string[]): Promise<string> {
  // this is correct...
  let str: string = await fakePromise();
  return str;
}

// ...but this doesn't work (this PR fixes this error)
// note: bot is an Eris.CommandClient
bot.registerCommand("test", generatorFunc);
// TS error: Argument of type '(msg: Message, args: string[]) => Promise<string>' is not
// assignable to parameter of type 'CommandGenerator'
```