### PR TITLE
Define the units of the latency between shard and discord

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -38,7 +38,7 @@ try {
 * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
 * @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
 * @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} latency The current latency in milliseconds between shard and Discord
+* @prop {Number} latency The current latency between the shard and Discord, in milliseconds
 */
 class Shard extends EventEmitter {
     constructor(id, client) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -38,7 +38,7 @@ try {
 * @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"connected"
 * @prop {Number} lastHeartbeatReceived Last time Discord acknowledged a heartbeat, null if shard has not sent heartbeat yet
 * @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
-* @prop {Number} latency Current latency between shard and Discord
+* @prop {Number} latency The current latency in milliseconds between shard and Discord
 */
 class Shard extends EventEmitter {
     constructor(id, client) {


### PR DESCRIPTION
I added the **The** to bring the documentation in line with the latency notation for  the voice websocket.