### PR TITLE
Add missing CommandOptions attributes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -235,12 +235,16 @@ declare module "eris" {
       roleNames?: string[] | GenericCheckFunction<string[]>,
       permissions?: { [s: string]: boolean } | GenericCheckFunction<{ [s: string]: boolean }>,
     };
+    cooldown?: number;
     restartCooldown?: boolean;
     cooldownReturns?: number;
     cooldownMessage?: string | GenericCheckFunction<string>;
     invalidUsageMessage?: string | GenericCheckFunction<string>;
     permissionMessage?: string | GenericCheckFunction<string>;
     errorMessage?: string | GenericCheckFunction<string>;
+    reactionButtons?: Array<{ emoji: string, type: string, response: CommandGenerator }>;
+    reactionButtonTimeout?: number;
+    defaultSubcommandOptions?: CommandOptions;
   }
   type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | Promise<void> | string | void;
   type CommandGenerator = CommandGeneratorFunction | string | string[] | CommandGeneratorFunction[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,7 +242,7 @@ declare module "eris" {
     permissionMessage?: string | GenericCheckFunction<string>;
     errorMessage?: string | GenericCheckFunction<string>;
   }
-  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | string | void;
+  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | Promise<void> | string | void;
   type CommandGenerator = CommandGeneratorFunction | string | string[] | CommandGeneratorFunction[];
 
   export class Client extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -242,7 +242,7 @@ declare module "eris" {
     permissionMessage?: string | GenericCheckFunction<string>;
     errorMessage?: string | GenericCheckFunction<string>;
   }
-  type CommandGeneratorFunction = (msg: Message, args: string[]) => string | void;
+  type CommandGeneratorFunction = (msg: Message, args: string[]) => Promise<string> | string | void;
   type CommandGenerator = CommandGeneratorFunction | string | string[] | CommandGeneratorFunction[];
 
   export class Client extends EventEmitter {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1136,7 +1136,7 @@ declare module "eris" {
     public onMessageCreate(msg: Message): void;
     public registerGuildPrefix(guildID: string, prefix: string[] | string): void;
     public registerCommandAlias(alias: string, label: string): void;
-    public registerCommand(label: string, generator: CommandGenerator, options?: CommandOptions): void;
+    public registerCommand(label: string, generator: CommandGenerator, options?: CommandOptions): Command;
     public unregisterCommand(label: string): void;
   }
 }


### PR DESCRIPTION
The CommandOptions interface in the typings file was missing the `cooldown`, `reactionButtons`, `reactionButtonTimeout` and `defaultSubcommandOptions` attributes.

Totally has nothing to do with Hacktoberfest. Maybe.