### PR TITLE
fix bug in converting from UTC to the machine's time when adjusting t…

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -199,7 +199,7 @@ class RequestHandler {
                                 this.ratelimits[route].reset = (+resp.headers["retry-after"] || 1) + now;
                             }
                         } else if(resp.headers["x-ratelimit-reset"]) {
-                            this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * (route.endsWith("/reactions/:id") ? 250 : 1000) + this.latencyRef.timeOffset, now);
+                            this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * (route.endsWith("/reactions/:id") ? 250 : 1000) - this.latencyRef.timeOffset, now);
                         } else {
                             this.ratelimits[route].reset = now;
                         }


### PR DESCRIPTION
I was having a problem with rate limiting on a server whose clock was about 2 days behind and in Japan Standard Time.

On line 69:
```js
this.latencyRef.timeOffset = timeOffset;
```

The offset was getting set to 122403472 (34 hours, positive).

To convert from UTC to the machine's time, 34 hours should be subtracted from the current UTC time, not added.

If I add a line to log (before this change):

```js
} else if(resp.headers["x-ratelimit-reset"]) {
    this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * (route.endsWith("/reactions/:id") ? 250 : 1000) + this.latencyRef.timeOffset, now);
    console.log(`Difference from now: ${this.ratelimits[route].reset - now}`);
} else {
```

I got results like:

```
Difference from now: 244816332
```

If I change the + to a -, it's more like:

```
Difference from now: 2559
```
