### PR TITLE
update deprecated bulk_delete endpoint

### DIFF
--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -6,7 +6,7 @@ module.exports.BASE_URL = "/api/v" + Constants.GATEWAY_VERSION;
 module.exports.CDN_URL = "https://cdn.discordapp.com";
 
 module.exports.CHANNEL =                                                (chanID) => `/channels/${chanID}`;
-module.exports.CHANNEL_BULK_DELETE =                                    (chanID) => `/channels/${chanID}/messages/bulk_delete`;
+module.exports.CHANNEL_BULK_DELETE =                                    (chanID) => `/channels/${chanID}/messages/bulk-delete`;
 module.exports.CHANNEL_CALL_RING =                                      (chanID) => `/channels/${chanID}/call/ring`;
 module.exports.CHANNEL_INVITES =                                        (chanID) => `/channels/${chanID}/invites`;
 module.exports.CHANNEL_MESSAGE_REACTION =              (chanID, msgID, reaction) => `/channels/${chanID}/messages/${msgID}/reactions/${reaction}`;


### PR DESCRIPTION
Use bulk-delete instead of bulk_delete
docs: https://discordapp.com/developers/docs/resources/channel#bulk-delete-messages