### PR TITLE
Added tag property to Member and User

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -93,9 +93,13 @@ class Member extends Base {
     get username() {
         return this.user.username;
     }
-
+    
     get discriminator() {
         return this.user.discriminator;
+    }
+        
+    get tag() {
+        return `${this.user.username}#${this.user.discriminator}`;
     }
 
     get avatar() {

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -34,6 +34,7 @@ class User extends Base {
         this.avatar = data.avatar !== undefined ? data.avatar : this.avatar;
         this.username = data.username !== undefined ? data.username : this.username;
         this.discriminator = data.discriminator !== undefined ? data.discriminator : this.discriminator;
+        this.tag = `${this.username}#${this.discriminator}`;
     }
 
     get mention() {


### PR DESCRIPTION
The `.tag` property is used to show the full username and discriminator of a user. For example, if you wanted to get `Username#1337`, you could simply use `User.tag` or `Member.tag` instead of `User.username + "#" + User.discriminator`. This is mostly for ease of use. I have kept the same style of your code, but simply added this property.