### PR TITLE
fix the special handling of days via query string param in /prune

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -116,7 +116,7 @@ class RequestHandler {
                             throw new Error("Invalid file object");
                         }
                     } else if(body) {
-                        if(method === "GET" || (method === "PUT" && url.includes("/bans/"))) { // Special PUT case (╯°□°）╯︵ ┻━┻
+                        if(method === "GET" || (method === "PUT" && url.includes("/bans/")) || (method === "POST" && url.includes("/prune"))) { // Special PUT&POST case (╯°□°）╯︵ ┻━┻
                             var qs = "";
                             Object.keys(body).forEach(function(key) {
                                 if(body[key] != undefined) {


### PR DESCRIPTION
Discord uses query string params for the days to prune in POST /guilds/:id/prune
see [prune docs](https://discordapp.com/developers/docs/resources/guild#begin-guild-prune)