### PR TITLE
Fixed zlib/pako compression issues with uws

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -34,8 +34,10 @@ try {
     } catch(err) { // eslint-disable no-empty
     }
 }
+var uws = false;
 try {
     WebSocket = require("uws");
+    uws = true;
 } catch(err) { // eslint-disable no-empty
 }
 
@@ -1540,7 +1542,7 @@ class Shard extends EventEmitter {
             try {
                 var data = m.data;
                 if(data instanceof ArrayBuffer) {
-                    if(!this.client.options.compress) {
+                    if(!this.client.options.compress || uws) {
                         data = new Buffer(data);
                     }
                 } else if(Array.isArray(data)) { // Fragmented messages


### PR DESCRIPTION
Eris wasn't working with compression set to true and UWS installed. This method I used works with zlib-sync and pako but still has issues with the regular zlib one in combination with UWS but somehow still works but throws weird errors. In addition this change will atm only apply if UWS is actually used and will not affect anything using the regular internal WebSocket library.