### PR TITLE
Added cooldown exclusions for CommandClient

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -446,7 +446,7 @@ declare module "eris" {
       permissions?: { [s: string]: boolean } | GenericCheckFunction<{ [s: string]: boolean }>,
     };
     cooldown?: number;
-    cooldownExceptions?: number[];
+    cooldownExclusions?: number[];
     restartCooldown?: boolean;
     cooldownReturns?: number;
     cooldownMessage?: string | GenericCheckFunction<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -446,7 +446,11 @@ declare module "eris" {
       permissions?: { [s: string]: boolean } | GenericCheckFunction<{ [s: string]: boolean }>,
     };
     cooldown?: number;
-    cooldownExclusions?: number[];
+    cooldownExclusions?: {
+      userIDs?: string[],
+      guildIDs?: string[],
+      channelIDs?: string[],
+    };
     restartCooldown?: boolean;
     cooldownReturns?: number;
     cooldownMessage?: string | GenericCheckFunction<string>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -446,6 +446,7 @@ declare module "eris" {
       permissions?: { [s: string]: boolean } | GenericCheckFunction<{ [s: string]: boolean }>,
     };
     cooldown?: number;
+    cooldownExceptions?: number[];
     restartCooldown?: boolean;
     cooldownReturns?: number;
     cooldownMessage?: string | GenericCheckFunction<string>;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -36,7 +36,7 @@ class Command {
     * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
-    * @arg {Array<Number>} [options.cooldownExceptions] An array of user IDs that are excluded from cooldowns
+    * @arg {Array<Number>} [options.cooldownExclusions] An array of user IDs that are excluded from cooldowns
     * @arg {Boolean} [option.restartCooldown=false] Whether or not to restart a command's cooldown every time it's used.
     * @arg {Number} [option.cooldownReturns=0] Number of times to return a message when the command is used during it's cooldown.  Once the cooldown expires this is reset.  Set this to 0 to always return a message.
     * @arg {Function | String} [options.cooldownMessage] A string or a function that returns a string to show when the command is on cooldown.  The function is passed the Message object as a parameter.
@@ -70,7 +70,7 @@ class Command {
         this.guildOnly = !!options.guildOnly;
         this.dmOnly = !!options.dmOnly;
         this.cooldown = options.cooldown || 0;
-        this.cooldownExceptions = options.cooldownExceptions || [];
+        this.cooldownExclusions = options.cooldownExclusions || [];
         this.restartCooldown = !!options.restartCooldown;
         this.cooldownReturns = options.cooldownReturns || 0;
         this.cooldownMessage = options.cooldownMessage || false;
@@ -210,7 +210,7 @@ class Command {
     }
 
     cooldownCheck(userID) {
-        if(this.cooldownExceptions.indexOf(userID) > -1) return true;
+        if(this.cooldownExclusions.indexOf(userID) > -1) return true;
         if(this.usersOnCooldown.has(userID)) {
             if(this.cooldownReturns) {
                 this.cooldownAmounts[userID]++;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -216,9 +216,9 @@ class Command {
     }
 
     cooldownExclusionCheck(msg) {
+        if(this.cooldownExclusions.channelIDs.indexOf(msg.channel.id) > -1) return true;
         if(this.cooldownExclusions.userIDs.indexOf(msg.author.id) > -1) return true;
         if(this.cooldownExclusions.guildIDs.indexOf(msg.channel.guild.id) > -1) return true;
-        if(this.cooldownExclusions.channelIDs.indexOf(msg.channel.id) > -1) return true;
         
         return false;
     }

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -36,7 +36,10 @@ class Command {
     * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
-    * @arg {Array<Number>} [options.cooldownExclusions] An array of user IDs that are excluded from cooldowns
+    * @arg {Object} [options.cooldownExclusions={}] A set of factors that limit where cooldowns are active
+    * @arg {Array<String>} [options.cooldownExclusions.userIDs] An array of user IDs representing users that are not affected by cooldowns.
+    * @arg {Array<String>} [options.cooldownExclusions.guildIDs] An array of guild IDs representing guilds that are not affected by cooldowns.
+    * @arg {Array<String>} [options.cooldownExclusions.channelIDs] An array of channel IDs representing channels that are not affected by cooldowns.
     * @arg {Boolean} [option.restartCooldown=false] Whether or not to restart a command's cooldown every time it's used.
     * @arg {Number} [option.cooldownReturns=0] Number of times to return a message when the command is used during it's cooldown.  Once the cooldown expires this is reset.  Set this to 0 to always return a message.
     * @arg {Function | String} [options.cooldownMessage] A string or a function that returns a string to show when the command is on cooldown.  The function is passed the Message object as a parameter.
@@ -70,7 +73,10 @@ class Command {
         this.guildOnly = !!options.guildOnly;
         this.dmOnly = !!options.dmOnly;
         this.cooldown = options.cooldown || 0;
-        this.cooldownExclusions = options.cooldownExclusions || [];
+        this.cooldownExclusions = options.cooldownExclusions || {};
+        if(!this.cooldownExclusions.userIDs) this.cooldownExclusions.userIDs = [];
+        if(!this.cooldownExclusions.guildIDs) this.cooldownExclusions.guildIDs = [];
+        if(!this.cooldownExclusions.channelIDs) this.cooldownExclusions.channelIDs = [];
         this.restartCooldown = !!options.restartCooldown;
         this.cooldownReturns = options.cooldownReturns || 0;
         this.cooldownMessage = options.cooldownMessage || false;
@@ -209,8 +215,19 @@ class Command {
         return !req;
     }
 
-    cooldownCheck(userID) {
-        if(this.cooldownExclusions.indexOf(userID) > -1) return true;
+    cooldownExclusionCheck(msg) {
+        if(this.cooldownExclusions.userIDs.indexOf(msg.author.id) > -1) return true;
+        if(this.cooldownExclusions.guildIDs.indexOf(msg.channel.guild.id) > -1) return true;
+        if(this.cooldownExclusions.channelIDs.indexOf(msg.channel.id) > -1) return true;
+        
+        return false;
+    }
+
+    cooldownCheck(msg) {
+        // Verify the msg isn't excluded from cooldown checks
+        if(this.cooldownExclusionCheck(msg)) return true;
+
+        var userID = msg.author.id;
         if(this.usersOnCooldown.has(userID)) {
             if(this.cooldownReturns) {
                 this.cooldownAmounts[userID]++;
@@ -263,7 +280,7 @@ class Command {
                 }
                 return;
             }
-            if(this.cooldown !== 0 && !this.cooldownCheck(msg.author.id)) {
+            if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
                     if(reply) {
@@ -283,7 +300,7 @@ class Command {
             if(shouldDelete) {
                 msg.delete();
             }
-            if(this.cooldown !== 0 && !this.cooldownCheck(msg.author.id)) {
+            if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
                     if(reply) {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -36,6 +36,7 @@ class Command {
     * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
+    * @arg {Array<Number>} [options.cooldownExceptions] An array of user IDs that are excluded from cooldowns
     * @arg {Boolean} [option.restartCooldown=false] Whether or not to restart a command's cooldown every time it's used.
     * @arg {Number} [option.cooldownReturns=0] Number of times to return a message when the command is used during it's cooldown.  Once the cooldown expires this is reset.  Set this to 0 to always return a message.
     * @arg {Function | String} [options.cooldownMessage] A string or a function that returns a string to show when the command is on cooldown.  The function is passed the Message object as a parameter.
@@ -69,6 +70,7 @@ class Command {
         this.guildOnly = !!options.guildOnly;
         this.dmOnly = !!options.dmOnly;
         this.cooldown = options.cooldown || 0;
+        this.cooldownExceptions = options.cooldownExceptions || [];
         this.restartCooldown = !!options.restartCooldown;
         this.cooldownReturns = options.cooldownReturns || 0;
         this.cooldownMessage = options.cooldownMessage || false;
@@ -208,6 +210,7 @@ class Command {
     }
 
     cooldownCheck(userID) {
+        if(this.cooldownExceptions.indexOf(userID) > -1) return true;
         if(this.usersOnCooldown.has(userID)) {
             if(this.cooldownReturns) {
                 this.cooldownAmounts[userID]++;

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -308,6 +308,10 @@ class CommandClient extends Client {
     * @arg {Array<String>} [options.requirements.roleIDs] An array of role IDs that would allow a user to use the command
     * @arg {Array<String>} [options.requirements.roleNames] An array of role names that would allow a user to use the command
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
+    * @arg {Object} [options.cooldownExclusions={}] A set of factors that limit where cooldowns are active
+    * @arg {Array<String>} [options.cooldownExclusions.userIDs] An array of user IDs representing users that are not affected by cooldowns.
+    * @arg {Array<String>} [options.cooldownExclusions.guildIDs] An array of guild IDs representing guilds that are not affected by cooldowns.
+    * @arg {Array<String>} [options.cooldownExclusions.channelIDs] An array of channel IDs representing channels that are not affected by cooldowns.
     * @arg {String} [options.cooldownMessage] A message to show when the command is on cooldown
     * @arg {String} [options.invalidUsageMessage] A message to show when a command was improperly used
     * @arg {String} [options.permissionMessage] A message to show when the user doesn't have permissions to use the command


### PR DESCRIPTION
When registering a command with a command client, the client now excepts a cooldown exclusions object, which contains an array of user, guild, and channel ids that aren't affected by command cooldowns.