### PR TITLE
Fix Channel construction on REST mode

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1762,11 +1762,11 @@ class Client extends EventEmitter {
             } else if(channel.type === 1) {
                 return new PrivateChannel(channel, this);
             } else if(channel.type === 2) {
-                return new VoiceChannel(channel, this);
+                return new VoiceChannel(channel, null);
             } else if(channel.type === 3) {
                 return new GroupChannel(channel, this);
             } else if(channel.type === 4) {
-                return new CategoryChannel(channel, this);
+                return new CategoryChannel(channel, null);
             } else {
                 return channel;
             }

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -22,11 +22,13 @@ class CategoryChannel extends GuildChannel {
     constructor(data, guild) {
         super(data, guild);
         this.channels = new Collection(Channel);
-        guild && guild.channels.forEach((channel) => {
-            if(channel.parentID === this.id) {
-                this.channels.add(channel);
-            }
-        });
+        if(guild) {
+            guild.channels.forEach((channel) => {
+                if(channel.parentID === this.id) {
+                    this.channels.add(channel);
+                }
+            });
+        }
 
         this.update(data);
     }

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -22,7 +22,7 @@ class CategoryChannel extends GuildChannel {
     constructor(data, guild) {
         super(data, guild);
         this.channels = new Collection(Channel);
-        guild.channels.forEach((channel) => {
+        guild && guild.channels.forEach((channel) => {
             if(channel.parentID === this.id) {
                 this.channels.add(channel);
             }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -23,7 +23,9 @@ class GuildChannel extends Channel {
     constructor(data, guild) {
         super(data);
         if (!guild && data.guild_id) {
-            this.guild = {id: data.guild_id};
+            this.guild = {
+                id: data.guild_id
+            };
         } else {
             this.guild = guild;
         }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -24,7 +24,9 @@ class GuildChannel extends Channel {
         super(data);
         if (!guild && data.guild_id) {
             this.guild = {id: data.guild_id};
-        } else this.guild = guild;
+        } else {
+            this.guild = guild;
+        }
 
         this.update(data);
     }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -22,7 +22,9 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 class GuildChannel extends Channel {
     constructor(data, guild) {
         super(data);
-        this.guild = guild;
+        if (!guild && data.guild_id) {
+            this.guild = {id: data.guild_id};
+        } else this.guild = guild;
 
         this.update(data);
     }


### PR DESCRIPTION
On `lib/Client.js#1765` and `lib/Client.js#1769` the constructors receive a guild object, not the client.

On `lib/structures/CategoryChannel.js#25` in REST mode `guild` is null, so here we avoid a undefined access error

On `lib/structures/GuildChannel.js#25` If guild is null (always in REST mode) then we store a mock to have access to guild id information.