### PR TITLE
Implement CommandClient Command Hooks

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -23,12 +23,10 @@ class Command {
     * @arg {String} [options.fullDescription="No full description"] A detailed description of the command to show in the default help command
     * @arg {String} [options.usage] Details on how to call the command to show in the default help command
     * @arg {Object} [options.hooks] A set of functions to be executed at different times throughout the command's processing
-    * @arg {Function} [options.hooks.beforeCheck] A function that is executed before any permission or cooldown checks is made
-    * @arg {Function} [options.hooks.beforeExecute] A function that is executed after all checks have cleared, but before the command is executed
-    * @arg {Function} [options.hooks.afterExecute] A function that is executed after the command is executed, regardless of the final failed state of the command
-    * @arg {Function} [options.hooks.afterSuccess] A function that is executed after the command has successfully executed, but before any response is posted
-    * @arg {Function} [options.hooks.afterFailedCheck] A function that is executed after any check has failed
-    * @arg {Function} [options.hooks.postProcess] A function that is executed after a response has been posted, and the command has finished processing
+    * @arg {Function} [options.hooks.preCommand] A function that is executed before any permission or cooldown checks is made. The function is passed the command message and arguments as parameters.
+    * @arg {Function} [options.hooks.postCheck] A function that is executed after all checks have cleared, but before the command is executed. The function is passed the command message, arguments, and if command checks were passed as parameters.
+    * @arg {Function} [options.hooks.postExecution] A function that is executed after the command is executed, regardless of the final failed state of the command. The function is passed the command message, arguments, and if execution succeeded as parameters.
+    * @arg {Function} [options.hooks.postCommand] A function that is executed after a response has been posted, and the command has finished processing. The function is passed the command message, arguments, and the response message (if applicable) as parameters.
     * @arg {Object} [options.requirements] A set of factors that limit who can call the command
     * @arg {Function | Array<String>} [options.requirements.userIDs] An array or a function that returns an array of user IDs representing users that can call the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Object} [options.requirements.permissions] An object or a function that returns an object containing permission keys the user must match to use the command.  The function is passed the Message object as a parameter.
@@ -274,14 +272,14 @@ class Command {
     process(args, msg) {
         var shouldDelete = this.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(msg._client.user.id).has("manageMessages");
 
-        if(this.hooks.beforeCheck) {
-            this.hooks.beforeCheck(msg, args);
+        if(this.hooks.preCommand) {
+            this.hooks.preCommand(msg, args);
         }
 
         var reply;
         if(!this.permissionCheck(msg)) {
-            if(this.hooks.afterFailedCheck) {
-                this.hooks.afterFailedCheck(msg, args);
+            if(this.hooks.postCheck) {
+                this.hooks.postCheck(msg, args, false);
             }
 
             if(shouldDelete) {
@@ -298,8 +296,8 @@ class Command {
                 msg.delete();
             }
             if(this.argsRequired) {
-                if(this.hooks.afterFailedCheck) {
-                    this.hooks.afterFailedCheck(msg, args);
+                if(this.hooks.post) {
+                    this.hooks.postCheck(msg, args, false);
                 }
                 reply = typeof this.invalidUsageMessage === "function" ? this.invalidUsageMessage(msg) : this.invalidUsageMessage;
                 if(reply) {
@@ -308,8 +306,8 @@ class Command {
                 return;
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
-                if(this.hooks.afterFailedCheck) {
-                    this.hooks.afterFailedCheck(msg, args);
+                if(this.hooks.postCheck) {
+                    this.hooks.postCheck(msg, args, false);
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
@@ -347,17 +345,14 @@ class Command {
     }
 
     executeCommand(msg, args) {
-        if(this.hooks.beforeExecute) {
-            this.hooks.beforeExecute(msg, args);
+        if(this.hooks.postCheck) {
+            this.hooks.postCheck(msg, args, true);
         }
 
         let ret = this.execute(msg, args);
 
-        if(this.hooks.afterExecute) {
-            this.hooks.afterExecute(msg, args);
-        }
-        if(this.hooks.afterSuccess) {
-            this.hooks.afterSuccess(msg, args);
+        if(this.hooks.postExecution) {
+            this.hooks.postExecution(msg, args, true);
         }
 
         return ret;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -22,6 +22,13 @@ class Command {
     * @arg {String} [options.description="No description"] A short description of the command to show in the default help command
     * @arg {String} [options.fullDescription="No full description"] A detailed description of the command to show in the default help command
     * @arg {String} [options.usage] Details on how to call the command to show in the default help command
+    * @arg {Object} [options.hooks] A set of functions to be executed at different times throughout the command's processing
+    * @arg {Function} [options.hooks.beforeCheck] A function that is executed before any permission or cooldown checks is made
+    * @arg {Function} [options.hooks.beforeExecute] A function that is executed after all checks have cleared, but before the command is executed
+    * @arg {Function} [options.hooks.afterExecute] A function that is executed after the command is executed, regardless of the final failed state of the command
+    * @arg {Function} [options.hooks.afterSuccess] A function that is executed after the command has successfully executed, but before any response is posted
+    * @arg {Function} [options.hooks.afterFailedCheck] A function that is executed after any check has failed
+    * @arg {Function} [options.hooks.postProcess] A function that is executed after a response has been posted, and the command has finished processing
     * @arg {Object} [options.requirements] A set of factors that limit who can call the command
     * @arg {Function | Array<String>} [options.requirements.userIDs] An array or a function that returns an array of user IDs representing users that can call the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Object} [options.requirements.permissions] An object or a function that returns an object containing permission keys the user must match to use the command.  The function is passed the Message object as a parameter.
@@ -61,6 +68,7 @@ class Command {
         this.usage = options.usage || "";
         this.aliases = options.aliases || [];
         this.caseInsensitive = !!options.caseInsensitive;
+        this.hooks = options.hooks || {};
         this.requirements = options.requirements || {};
         if(!this.requirements.userIDs) {
             this.requirements.userIDs = [];
@@ -258,8 +266,17 @@ class Command {
 
     process(args, msg) {
         var shouldDelete = this.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(msg._client.user.id).has("manageMessages");
+
+        if(this.hooks.beforeCheck) {
+            this.hooks.beforeCheck(msg, args);
+        }
+
         var reply;
         if(!this.permissionCheck(msg)) {
+            if(this.hooks.afterFailedCheck) {
+                this.hooks.afterFailedCheck(msg, args);
+            }
+
             if(shouldDelete) {
                 msg.delete();
             }
@@ -274,6 +291,9 @@ class Command {
                 msg.delete();
             }
             if(this.argsRequired) {
+                if(this.hooks.afterFailedCheck) {
+                    this.hooks.afterFailedCheck(msg, args);
+                }
                 reply = typeof this.invalidUsageMessage === "function" ? this.invalidUsageMessage(msg) : this.invalidUsageMessage;
                 if(reply) {
                     msg.channel.createMessage(reply.replace(/%prefix%/g, msg.prefix).replace(/%label%/g, this.fullLabel));
@@ -281,6 +301,9 @@ class Command {
                 return;
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
+                if(this.hooks.afterFailedCheck) {
+                    this.hooks.afterFailedCheck(msg, args);
+                }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
                     if(reply) {
@@ -289,7 +312,7 @@ class Command {
                 }
                 return;
             }
-            return this.execute(msg, args);
+            return this.executeCommand(msg, args);
         }
         var label = this.subcommandAliases[args[0]] || args[0];
         var subcommand;
@@ -301,6 +324,9 @@ class Command {
                 msg.delete();
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
+                if(this.hooks.afterFailedCheck) {
+                    this.hooks.afterFailedCheck(msg, args);
+                }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
                     if(reply) {
@@ -309,8 +335,25 @@ class Command {
                 }
                 return;
             }
-            return this.execute(msg, args);
+            return this.executeCommand(msg, args);
         }
+    }
+
+    executeCommand(msg, args) {
+        if(this.hooks.beforeExecute) {
+            this.hooks.beforeExecute(msg, args);
+        }
+
+        let ret = this.execute(msg, args);
+
+        if(this.hooks.afterExecute) {
+            this.hooks.afterExecute(msg, args);
+        }
+        if(this.hooks.afterSuccess) {
+            this.hooks.afterSuccess(msg, args);
+        }
+
+        return ret;
     }
 
     /**

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -329,8 +329,8 @@ class Command {
                 msg.delete();
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
-                if(this.hooks.afterFailedCheck) {
-                    this.hooks.afterFailedCheck(msg, args);
+                if(this.hooks.postCheck) {
+                    this.hooks.postCheck(msg, args, false);
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -296,7 +296,7 @@ class Command {
                 msg.delete();
             }
             if(this.argsRequired) {
-                if(this.hooks.post) {
+                if(this.hooks.postCheck) {
                     this.hooks.postCheck(msg, args, false);
                 }
                 reply = typeof this.invalidUsageMessage === "function" ? this.invalidUsageMessage(msg) : this.invalidUsageMessage;

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -161,6 +161,9 @@ class CommandClient extends Client {
                             };
                         }
                     }
+                    if(msg.command.hooks.postProcess) {
+                        msg.command.hooks.postProcess(newMsg, msg, args);
+                    }
                 }).catch((err) => {
                     this.emit("error", err);
                     if(msg.command.errorMessage) {
@@ -172,6 +175,9 @@ class CommandClient extends Client {
                         }else{
                             this.createMessage(msg.channel.id, msg.command.errorMessage);
                         }
+                    }
+                    if(msg.command.hooks.postProcess) {
+                        msg.command.hooks.postProcess(newMsg, msg, args);
                     }
                 });
             }

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -161,11 +161,14 @@ class CommandClient extends Client {
                             };
                         }
                     }
-                    if(msg.command.hooks.postProcess) {
-                        msg.command.hooks.postProcess(newMsg, msg, args);
+                    if(msg.command.hooks.postCommand) {
+                        msg.command.hooks.postCommand(msg, args, newMsg);
                     }
                 }).catch((err) => {
                     this.emit("error", err);
+                    if(msg.command.hooks.postExecution) {
+                        msg.command.hooks.postExecution(msg, args, false);
+                    }
                     if(msg.command.errorMessage) {
                         if(typeof msg.command.errorMessage === "function") {
                             var reply = msg.command.errorMessage();
@@ -176,8 +179,8 @@ class CommandClient extends Client {
                             this.createMessage(msg.channel.id, msg.command.errorMessage);
                         }
                     }
-                    if(msg.command.hooks.postProcess) {
-                        msg.command.hooks.postProcess(newMsg, msg, args);
+                    if(msg.command.hooks.postCommand) {
+                        msg.command.hooks.postCommand(msg, args, newMsg);
                     }
                 });
             }


### PR DESCRIPTION
When working on another feature, I realized I wanted command logic to be applied before the checks were made, but after the command has begun processing. This led me to take a shot at implementing hooks into commands. Hooks are meant to be used by experienced users that want to further modify the behavior of their commands. Each hook and when it's used is detailed below.

`beforeCheck`: Called when the command has begun processing, but has not done any checks.
`beforeExecute`: Called after all checks have passed, but before the command has been executed.
`afterFailedCheck`: Called after any check has failed, but before the command has sent a response.
`afterExecute`: Called after the command has finished executing.
`afterSuccess`: Called after the command has successfully executed, but before the command has sent a response.
`postProcess`: Called after a response has been sent, regardless of whether or not the command failed to execute.

**Sample Hook Execution for Successful Command**
- `beforeCheck`
- `beforeExecute`
- `afterExecute`
- `afterSuccess`
- `postProcess`

**Sample Hook Execution for Failed Command**
- `beforeCheck`
- `afterFailedCheck`
- `postProcess`

This is an initial attempt, and will likely receive further updates to naming, exact timing, and other implementation details, but I'm submitting the PR now to solicit feedback.