### PR TITLE
Custom Command Requirements

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -35,7 +35,7 @@ class Command {
     * In the above example, the user must not have administrator permissions, but must have manageMessages to use the command
     * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
-    * @arg {Function} [options.requirements.custom] A function that accepts a message, and returns a boolean defining whether or not the command should be run
+    * @arg {Function} [options.requirements.custom] A function that accepts a message and returns true if the command should be run
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
     * @arg {Object} [options.cooldownExclusions={}] A set of factors that limit where cooldowns are active
     * @arg {Array<String>} [options.cooldownExclusions.userIDs] An array of user IDs representing users that are not affected by cooldowns.

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -35,6 +35,7 @@ class Command {
     * In the above example, the user must not have administrator permissions, but must have manageMessages to use the command
     * @arg {Function | Array<String>} [options.requirements.roleIDs] An array or a function that returns an array of role IDs that would allow a user to use the command.  The function is passed the Message object as a parameter.
     * @arg {Function | Array<String>} [options.requirements.roleNames] An array or a function that returns an array of role names that would allow a user to use the command.  The function is passed the Message object as a parameter.
+    * @arg {Function} [options.requirements.custom] A function that accepts a message, and returns a boolean defining whether or not the command should be run
     * @arg {Number} [options.cooldown] The cooldown between command usage in milliseconds
     * @arg {Object} [options.cooldownExclusions={}] A set of factors that limit where cooldowns are active
     * @arg {Array<String>} [options.cooldownExclusions.userIDs] An array of user IDs representing users that are not affected by cooldowns.

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -154,7 +154,7 @@ class Command {
 
     permissionCheck(msg) {
         var req = false;
-        if(this.requirements.custom) {
+        if(this.requirements.custom && typeof this.requirements.custom === "function") {
             req = true;
             if(this.requirements.custom(msg)){
                 return true;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -153,6 +153,12 @@ class Command {
 
     permissionCheck(msg) {
         var req = false;
+        if(this.requirements.custom) {
+            req = true;
+            if(this.requirements.custom(msg)){
+                return true;
+            }
+        }
         if(typeof this.requirements.userIDs === "function") {
             req = true;
             if(~this.requirements.userIDs(msg).indexOf(msg.author.id)) {


### PR DESCRIPTION
As requested by @aequasi , a property within a Command's requirements object, `custom`, that allows you to specify a custom requirement function. If it returns true, the command can be run, if it does not, then other requirements can still allow the command to run.