### PR TITLE
Fix CommandClient cooldowns for DM messages

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -218,7 +218,7 @@ class Command {
     cooldownExclusionCheck(msg) {
         if(this.cooldownExclusions.channelIDs.indexOf(msg.channel.id) > -1) return true;
         if(this.cooldownExclusions.userIDs.indexOf(msg.author.id) > -1) return true;
-        if(this.cooldownExclusions.guildIDs.indexOf(msg.channel.guild.id) > -1) return true;
+        if(msg.channel.guild && this.cooldownExclusions.guildIDs.indexOf(msg.channel.guild.id) > -1) return true;
         
         return false;
     }


### PR DESCRIPTION
https://sentry.io/share/issue/1c5f5e1ed03a48d3bcf88b3cc83e3f43/

`msg.channel.guild` is undefined when the message is sent in DM. This throw a `Cannot read property 'id' of undefined` exception.

So, this commit check if the message was sent in a guild to not try to get the guild id on a DM channel.