### PR TITLE
Fix ban reasons

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1309,7 +1309,7 @@ class Client extends EventEmitter {
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
             "delete-message-days": deleteMessageDays || 0,
-            queryReason: reason
+            reason: reason
         });
     }
 


### PR DESCRIPTION
Currently eris puts the reason for audit log when banning in the query. However, api docs say to include it as a header. This PR fixes that.