### PR TITLE
An option for commands to disable it from displaying in help command

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -143,7 +143,7 @@ class Command {
 
         this.subcommands = {};
         this.subcommandAliases = {};
-        this.displayinhelpcommand = options.displayinhelpcommand || true;
+        this.displayinhelpcommand = (options.displayinhelpcommand == null) ? true : !!options.displayinhelpcommand;
     }
 
     get fullLabel() {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -143,7 +143,7 @@ class Command {
 
         this.subcommands = {};
         this.subcommandAliases = {};
-        this.displayinhelpcommand = !!options.displayinhelpcommand;
+        this.hidden = !!options.hidden;
     }
 
     get fullLabel() {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -53,7 +53,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
-    * @arg {Boolean} [options.hidden=false] Should the command be hidden in the default help command.
+    * @arg {Boolean} [options.hidden=false] Whether or not the command should be hidden from the default help command list.
     */
     constructor(label, generator, options, parentCommand) {
         this.parentCommand = parentCommand;
@@ -379,7 +379,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
-    * @arg {Boolean} [options.hidden=false] Should the command be hidden in the default help command.
+    * @arg {Boolean} [options.hidden=false] Whether or not the command should be hidden from the default help command list.
     * @returns {Command}
     */
     registerSubcommand(label, generator, options) {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -53,6 +53,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
+    * @arg {Boolean} [options.displayinhelpcommand=true] Should the command be displayed in the default help command.
     */
     constructor(label, generator, options, parentCommand) {
         this.parentCommand = parentCommand;
@@ -142,6 +143,7 @@ class Command {
 
         this.subcommands = {};
         this.subcommandAliases = {};
+        this.displayinhelpcommand = options.displayinhelpcommand || true;
     }
 
     get fullLabel() {
@@ -377,6 +379,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
+    * @arg {Boolean} [options.displayinhelpcommand=true] Should the command be displayed in the default help command.
     * @returns {Command}
     */
     registerSubcommand(label, generator, options) {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -53,7 +53,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
-    * @arg {Boolean} [options.displayinhelpcommand=true] Should the command be displayed in the default help command.
+    * @arg {Boolean} [options.hidden=false] Should the command be hidden in the default help command.
     */
     constructor(label, generator, options, parentCommand) {
         this.parentCommand = parentCommand;
@@ -143,7 +143,7 @@ class Command {
 
         this.subcommands = {};
         this.subcommandAliases = {};
-        this.displayinhelpcommand = (options.displayinhelpcommand == null) ? true : !!options.displayinhelpcommand;
+        this.displayinhelpcommand = !!options.displayinhelpcommand;
     }
 
     get fullLabel() {
@@ -379,7 +379,7 @@ class Command {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
-    * @arg {Boolean} [options.displayinhelpcommand=true] Should the command be displayed in the default help command.
+    * @arg {Boolean} [options.hidden=false] Should the command be hidden in the default help command.
     * @returns {Command}
     */
     registerSubcommand(label, generator, options) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -322,6 +322,7 @@ class CommandClient extends Client {
     * `response` specifies the content to edit the message to when the reaction button is pressed. This accepts the same arguments as the `generator` parameter of this function
     * @arg {Number} [options.reactionButtonTimeout=60000] Time (in milliseconds) to wait before invalidating the command's reaction buttons
     * @arg {Object} [options.defaultSubcommandOptions={}] Default subcommand options. This object takes the same options as a normal Command
+    * @arg {Boolean} [options.hidden=false] Whether or not the command should be hidden from the default help command list.
     * @returns {Command}
     */
     registerCommand(label, generator, options) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -110,7 +110,7 @@ class CommandClient extends Client {
                     result += "\n";
                     result += "**Commands:**\n";
                     for(label in this.commands) {
-                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && this.command[label].displayinhelpcommand) {
+                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && this.commands[label].displayinhelpcommand) {
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
                         }
                     }

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -110,7 +110,7 @@ class CommandClient extends Client {
                     result += "\n";
                     result += "**Commands:**\n";
                     for(label in this.commands) {
-                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && this.commands[label].displayinhelpcommand) {
+                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && !this.commands[label].hidden) {
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
                         }
                     }

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -110,7 +110,7 @@ class CommandClient extends Client {
                     result += "\n";
                     result += "**Commands:**\n";
                     for(label in this.commands) {
-                        if(this.commands[label] && this.commands[label].permissionCheck(msg)) {
+                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && this.command[label].displayinhelpcommand) {
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
                         }
                     }


### PR DESCRIPTION
The option would allow creators to disable a command from being displayed in the default help command.
I've tested it and it works.