### PR TITLE
Fix for crash when getting an error from Discord's API

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -275,7 +275,7 @@ class RequestHandler {
                             }
 
                             var stack = _stackHolder.stack;
-                            if(stack.startsWith("Error\n")) {
+                            if(typeof stack === "string" && stack.startsWith("Error\n")) {
                                 stack = stack.substring(6);
                             }
                             var err;


### PR DESCRIPTION
Whenever Eris recieves a Discord API error, it crashes (atleast every time I've gotten one with the dev branch). This fixes it. 

First pull request so this might be a complete mess, but this keeps on annoying me so here I am.