### PR TITLE
Fix spotify presence updates not caching properly

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -265,7 +265,7 @@ class Shard extends EventEmitter {
                 }
                 var member = guild.members.get(packet.d.id = packet.d.user.id);
                 var oldPresence = null;
-                if(member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url)))) {
+                if(member && (member.status !== packet.d.status || (member.game !== packet.d.game && (!member.game || !packet.d.game || member.game.name !== packet.d.game.name || member.game.type !== packet.d.game.type || member.game.url !== packet.d.game.url || member.game.sync_id !== packet.d.game.sync_id)))) {
                     oldPresence = {
                         game: member.game,
                         status: member.status


### PR DESCRIPTION
When a member's game is listed as `Spotify`, the name field is `Spotify`, not the track name, and doesn't change song by song. This causes the game to not be updated unless the member stops listening to Spotify entirely, and starts again. This adds an additional check that *does* change.