### PR TITLE
Added functions to allow voice channel leave without channelID (and fixed some related things)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -512,7 +512,7 @@ declare module "eris" {
       options?: { shared?: boolean, opusOnly?: boolean },
     ): Promise<VoiceConnection>;
     public leaveVoiceChannel(channelID: string): void;
-    public leaveVoiceGuild(guildID: string): void;
+    public closeVoiceConnection(guildID: string): void;
     public editAFK(afk: boolean): void;
     public editStatus(status?: string, game?: GamePresence): void;
     public getChannel(channelID: string): AnyChannel;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1039,7 +1039,7 @@ declare module "eris" {
     public getRESTMember(memberID: string): Promise<Member>;
     public getRESTRoles(): Promise<Role[]>;
     public getEmbed(): Promise<GuildEmbed>;
-	public getVoiceRegions(): Promise<VoiceRegion[]>;
+    public getVoiceRegions(): Promise<VoiceRegion[]>;
     public leaveVoiceChannel(): void;
     public editRole(roleID: string, options: RoleOptions): Promise<Role>;
     public deleteRole(roleID: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -512,6 +512,7 @@ declare module "eris" {
       options?: { shared?: boolean, opusOnly?: boolean },
     ): Promise<VoiceConnection>;
     public leaveVoiceChannel(channelID: string): void;
+    public leaveVoiceGuild(guildID: string): void;
     public editAFK(afk: boolean): void;
     public editStatus(status?: string, game?: GamePresence): void;
     public getChannel(channelID: string): AnyChannel;
@@ -1038,7 +1039,8 @@ declare module "eris" {
     public getRESTMember(memberID: string): Promise<Member>;
     public getRESTRoles(): Promise<Role[]>;
     public getEmbed(): Promise<GuildEmbed>;
-    public getVoiceRegions(): Promise<VoiceRegion[]>;
+	public getVoiceRegions(): Promise<VoiceRegion[]>;
+    public leaveVoiceChannel(): void;
     public editRole(roleID: string, options: RoleOptions): Promise<Role>;
     public deleteRole(roleID: string): Promise<void>;
     public getAuditLogs(limit?: number, before?: string, actionType?: number): Promise<GuildAuditLog>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -342,7 +342,11 @@ class Client extends EventEmitter {
         if(!channelID) {
             throw new Error(`Invalid channel ID: ${channelID}`);
         }
-        return this.channelGuildMap[channelID] ? this.guilds.get(this.channelGuildMap[channelID]).channels.get(channelID) : this.privateChannels.get(channelID) || this.groupChannels.get(channelID);
+    
+        if (this.channelGuildMap[channelID] && this.guilds.get(this.channelGuildMap[channelID])) {
+            return this.guilds.get(this.channelGuildMap[channelID]).channels.get(channelID);
+        }
+        return this.privateChannels.get(channelID) || this.groupChannels.get(channelID);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -279,13 +279,22 @@ class Client extends EventEmitter {
         if(!channel) {
             return;
         }
-        this.shards.get(this.guildShardMap[this.channelGuildMap[channelID]] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
-            guild_id: this.channelGuildMap[channelID] || null,
+        this.leaveVoiceGuild(this.channelGuildMap[channelID]);
+    }
+
+    /**
+     * Leaves the voice channel in a guild
+     * 
+     * @arg {String} guildID The ID of the guild
+     */
+    leaveVoiceGuild(guildID) {
+        this.shards.get(this.guildShardMap[guildID] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
+            guild_id: guildID || null,
             channel_id: null,
             self_mute: false,
             self_deaf: false
         });
-        this.voiceConnections.leave(this.channelGuildMap[channelID] || "call");
+        this.voiceConnections.leave(guildID || "call");
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -275,8 +275,7 @@ class Client extends EventEmitter {
         if(!channelID) {
             return;
         }
-        var channel = this.getChannel(channelID);
-        if(!channel) {
+        if(!this.channelGuildMap[channelID]) {
             return;
         }
         this.leaveVoiceGuild(this.channelGuildMap[channelID]);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -278,15 +278,15 @@ class Client extends EventEmitter {
         if(!this.channelGuildMap[channelID]) {
             return;
         }
-        this.leaveVoiceGuild(this.channelGuildMap[channelID]);
+        this.closeVoiceConnection(this.channelGuildMap[channelID]);
     }
 
     /**
-     * Leaves the voice channel in a guild
+     * Closes a voice connection with a guild ID
      * 
      * @arg {String} guildID The ID of the guild
      */
-    leaveVoiceGuild(guildID) {
+    closeVoiceConnection(guildID) {
         this.shards.get(this.guildShardMap[guildID] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
             guild_id: guildID || null,
             channel_id: null,

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -324,7 +324,7 @@ class Guild extends Base {
      * Leaves the voice channel in this guild
      */
     leaveVoiceChannel() {
-        this.shard.client.leaveVoiceGuild.call(this.shard.client, this.id);
+        this.shard.client.closeVoiceConnection.call(this.shard.client, this.id);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -321,6 +321,13 @@ class Guild extends Base {
     }
 
     /**
+     * Leaves the voice channel in this guild
+     */
+    leaveVoiceChannel() {
+        this.shard.client.leaveVoiceGuild.call(this.shard.client, this.id);
+    }
+
+    /**
     * Edit the guild role
     * @arg {String} roleID The ID of the role
     * @arg {Object} options The properties to edit


### PR DESCRIPTION
The title says it all. Newly added functions are Client.prototype.leaveVoiceGuild(guildID) and Guild.prototype.leaveVoiceChannel(). Functionality has been tested and TypeScript typings were also added. Feel free to adjust the function names as I was not 100% sure how to call them.