### PR TITLE
fix: OggOpusTransformer doesn't work with multiple streams

### DIFF
--- a/lib/voice/streams/OggOpusTransformer.js
+++ b/lib/voice/streams/OggOpusTransformer.js
@@ -8,6 +8,7 @@ class OggOpusTransformer extends BaseTransformer {
         super(options);
 
         this._remainder = null;
+        this._bitstream = null;
     }
 
     process(buffer) {
@@ -23,6 +24,8 @@ class OggOpusTransformer extends BaseTransformer {
         if(typeFlag === 1) {
             return new Error("OGG continued page not supported");
         }
+
+        var bitstream = buffer.readUInt32BE(buffer._index + 14);
 
         buffer._index += 26;
 
@@ -59,13 +62,14 @@ class OggOpusTransformer extends BaseTransformer {
             if(this.head) {
                 if(byte === "OpusTags") {
                     this.emit("debug", segment.toString());
-                } else {
+                } else if(bitstream === this._bitstream) {
                     this.push(segment);
                 }
             } else if(byte === "OpusHead") {
+                this._bitstream = bitstream;
                 this.emit("debug", (this.head = segment.toString()));
             } else {
-                this.emit("error", new Error("Invalid codec: " + byte));
+                this.emit("debug", "Invalid codec: " + byte);
             }
         }
     }


### PR DESCRIPTION
from @hydrabolt:

When trying to play .ogg files with both opus and theora (example can be found here [theora-and-opus.zip](https://github.com/abalabahaha/eris/files/1903822/theora-and-opus.zip)), eris throws an invalid codec error:

```
events.js:136
      throw er; // Unhandled 'error' event
      ^

Error: Invalid codec: �theora
    at OggOpusTransformer.process (/home/hydrabolt/eris/node_modules/eris/lib/voice/streams/OggOpusTransformer.js:68:36)
    at OggOpusTransformer._transform (/home/hydrabolt/eris/node_modules/eris/lib/voice/streams/OggOpusTransformer.js:83:28)
    at OggOpusTransformer.Transform._read (_stream_transform.js:185:10)
    at OggOpusTransformer.Transform._write (_stream_transform.js:173:12)
    at doWrite (_stream_writable.js:399:12)
    at writeOrBuffer (_stream_writable.js:385:5)
    at OggOpusTransformer.Writable.write (_stream_writable.js:292:11)
    at ReadStream.ondata (_stream_readable.js:642:20)
    at ReadStream.emit (events.js:159:13)
    at addChunk (_stream_readable.js:265:12)
```

As an Opus stream is still available, this PR makes sure that the transformer will only to push chunks that come from the Opus stream.