### PR TITLE
Fix disconnect() not sending close code

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -101,7 +101,7 @@ class Shard extends EventEmitter {
             if(options.reconnect && this.sessionID) {
                 this.ws.terminate();
             } else {
-                this.ws.close();
+                this.ws.close(1000);
             }
         } catch(err) {
             /**


### PR DESCRIPTION
`client.disconnect()` currently sends Discord an empty buffer instead of a close code, which causes the bot user to not be marked offline by Discord until the gateway connection times out. This fix causes the function to send a close code of `1000` - normal close, which causes Discord to immediately close the connection and mark the bot offline as expected.