### PR TITLE
Fixed overwriting commands or aliases in cmd client

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -356,8 +356,14 @@ class CommandClient extends Client {
         if(label.includes(" ")) {
             throw new Error("Command label may not have spaces");
         }
-        if(this.commands[label]) {
+        if(this.commands[label] || (this.commands[label.toLowerCase()] && this.commands[label.toLowerCase()].caseInsensitive)) {
             throw new Error("You have already registered a command for " + label);
+        }
+        // Aliases are not deleted when deleting commands
+        var command = this.commandAliases[label]; // Just to make the following if statement less messy
+        var lCommand = this.commandAliases[label.toLowerCase()];
+        if (this.commands[command] || (this.commands[lCommand] && this.commands[lCommand].caseInsensitive)) {
+            throw new Error(`Alias ${label} already registered`);
         }
         options = options || {};
         options.defaultSubcommandOptions = options.defaultSubcommandOptions || {};
@@ -368,12 +374,20 @@ class CommandClient extends Client {
             }
         }
         label = options.caseInsensitive === true ? label.toLowerCase() : label;
-        this.commands[label] = new Command(label, generator, options);
         if(options.aliases) {
             options.aliases.forEach((alias) => {
+                if (this.commands[alias] || (this.commands[alias.toLowerCase()] && this.commands[alias.toLowerCase()].caseInsensitive)) {
+                    throw new Error("You have already registered a command for alias " + alias);
+                }
+                command = this.commandAliases[alias];
+                lCommand = this.commandAliases[alias.toLowerCase()];
+                if (this.commands[command] || (this.commands[lCommand] && this.commands[lCommand].caseInsensitive)) {
+                    throw new Error(`Alias ${alias} already registered`);
+                }
                 this.commandAliases[alias] = label;
             });
         }
+        this.commands[label] = new Command(label, generator, options);
         return this.commands[label];
     }
 


### PR DESCRIPTION
Fixed commands possibly being overwritten instead of throwing an error (Derp and dErp both with caseInsensitive true) and the same for aliases (now throws if one of the aliases the user is trying to set already exists regardless of it being an alias or command)