### PR TITLE
Remove global reaction ratelimit

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -47,9 +47,6 @@ class RequestHandler {
         if(method === "DELETE" && route.endsWith("/messages/:id")) { // Delete Messsage endpoint has its own ratelimit
             route = method + route;
         }
-        if(~route.indexOf("/reactions/:id")) { // PUT/DELETE one/all reactions is shared across the entire account
-            route = "/channels/:id/messages/:id/reactions";
-        }
         return route;
     }
 


### PR DESCRIPTION
Not needed anymore after https://github.com/discordapp/discord-api-docs/issues/395 was closed. On bigger bots / reaction-heavy bots, this would cause requests to be queued when they shouldn't be.