### PR TITLE
Fix deprecation: Use symbol method for custom inspection

### DIFF
--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -68,7 +68,7 @@ class Base {
 
 // Node 6+ util.custom.inspect symbol support - https://github.com/nodejs/node/issues/15549
 if(util.inspect.custom) {
-    Base.prototype[util.inspect.custom] = Base.prototype.inspect
+    Base.prototype[util.inspect.custom] = Base.prototype.inspect;
 }
 
 module.exports = Base;

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const util = require('util');
+
 class Base {
     constructor(id) {
         if(id) {
@@ -52,7 +54,7 @@ class Base {
         return base;
     }
 
-    inspect() {
+    [util.inspect.custom]() {
         // http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         var copy = new (new Function(`return function ${this.constructor.name}(){}`)());
         for(var key in this) {

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -54,7 +54,7 @@ class Base {
         return base;
     }
 
-    [util.inspect.custom]() {
+    inspect() {
         // http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         var copy = new (new Function(`return function ${this.constructor.name}(){}`)());
         for(var key in this) {
@@ -64,6 +64,11 @@ class Base {
         }
         return copy;
     }
+}
+
+// Node 6+ util.custom.inspect symbol support - https://github.com/nodejs/node/issues/15549
+if(util.inspect.custom) {
+    Base.prototype[util.inspect.custom] = Base.prototype.inspect
 }
 
 module.exports = Base;


### PR DESCRIPTION
Setting `inspect()` on objects in order to modify the behavior of `util.insect(obj)` is deprecated and prints a warning as of Node 10. The alternative, `[util.inspect.custom]()`, has been available since node 6.

Deprecation ref: https://github.com/nodejs/node/issues/15549

This outdates the typescript defs - I don't know how to document symbol methods so I didn't touch them. If anyone else can, let me know and I'll update this PR.