### PR TITLE
Updated for loops over Objects to check hasOwnProperty

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -449,7 +449,7 @@ class Command {
         options = options || {};
         options.defaultSubcommandOptions = options.defaultSubcommandOptions || {};
         for(var key in this.defaultSubcommandOptions) {
-            if(options[key] === undefined) {
+            if(this.defaultSubcommandOptions.hasOwnProperty(key) && options[key] === undefined) {
                 options[key] = this.defaultSubcommandOptions[key];
                 options.defaultSubcommandOptions[key] = this.defaultSubcommandOptions[key];
             }

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -59,6 +59,9 @@ class CommandClient extends Client {
                 this.commandOptions.prefix = this.commandOptions.prefix.replace(/@mention/g, this.user.mention);
             }
             for(var key in this.guildPrefixes) {
+                if(!this.guildPrefixes.hasOwnProperty(key)) {
+                    continue;
+                }
                 if(Array.isArray(this.guildPrefixes[key])){
                     for(let i in this.guildPrefixes[key]){
                         this.guildPrefixes[key][i] = this.guildPrefixes[key][i].replace(/@mention/g, this.user.mention);
@@ -97,7 +100,7 @@ class CommandClient extends Client {
                     if(Object.keys(cur.subcommands).length > 0) {
                         result += "\n\n**Subcommands:**";
                         for(var subLabel in cur.subcommands) {
-                            if(cur.subcommands[subLabel].permissionCheck(msg)) {
+                            if(cur.subcommands.hasOwnProperty(subLabel) && cur.subcommands[subLabel].permissionCheck(msg)) {
                                 result += `\n  **${subLabel}** - ${cur.subcommands[subLabel].description}`;
                             }
                         }
@@ -110,7 +113,7 @@ class CommandClient extends Client {
                     result += "\n";
                     result += "**Commands:**\n";
                     for(label in this.commands) {
-                        if(this.commands[label] && this.commands[label].permissionCheck(msg) && !this.commands[label].hidden) {
+                        if(this.commands.hasOwnProperty(label) && this.commands[label] && this.commands[label].permissionCheck(msg) && !this.commands[label].hidden) {
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
                         }
                     }
@@ -369,7 +372,7 @@ class CommandClient extends Client {
         options = options || {};
         options.defaultSubcommandOptions = options.defaultSubcommandOptions || {};
         for(var key in this.commandOptions.defaultCommandOptions) {
-            if(options[key] === undefined) {
+            if(this.commandOptions.defaultCommandOptions.hasOwnProperty(key) && options[key] === undefined) {
                 options[key] = this.commandOptions.defaultCommandOptions[key];
                 options.defaultSubcommandOptions[key] = this.commandOptions.defaultCommandOptions[key];
             }

--- a/lib/errors/DiscordHTTPError.js
+++ b/lib/errors/DiscordHTTPError.js
@@ -53,7 +53,7 @@ class DiscordHTTPError extends Error {
 
         var messages = [];
         for(var fieldName in errors) {
-            if(fieldName === "message" || fieldName === "code") {
+            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
             if(Array.isArray(errors[fieldName])) {

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -58,7 +58,7 @@ class DiscordRESTError extends Error {
 
         var messages = [];
         for(var fieldName in errors) {
-            if(fieldName === "message" || fieldName === "code") {
+            if(!errors.hasOwnProperty(fieldName) || fieldName === "message" || fieldName === "code") {
                 continue;
             }
             if(errors[fieldName]._errors) {


### PR DESCRIPTION
Discovered problem with how the eris handles `for ... in` loops for `Object` once a custom `Object.prototype` has been defined. Solution was to verify `Object.hasOwnProperty()`.

All `for` loops in the library were examined and, if needed, corrected. There were a couple of exceptions, which I did not modify, that used `Object.keys()` method to "automatically" correct this issue.

Credit to Notice Me on Discord for figuring this one out.