### PR TITLE
Allow guild-less invites for group DMs

### DIFF
--- a/lib/structures/Invite.js
+++ b/lib/structures/Invite.js
@@ -8,7 +8,7 @@ const Base = require("./Base");
 * @prop {Object} channel Info on the invite channel
 * @prop {String} channel.id The ID of the invite's channel
 * @prop {String} channel.name The name of the invite's channel
-* @prop {Object} guild Info on the invite guild
+* @prop {Object?} guild Info on the invite guild
 * @prop {String} guild.id The ID of the invite's guild
 * @prop {String} guild.name The name of the invite's guild
 * @prop {String?} guild.splash The hash of the invite splash screen
@@ -31,14 +31,16 @@ class Invite extends Base {
         this._client = client;
         this.code = data.code;
         this.channel = data.channel;
-        this.guild = {
-            splash: data.guild.splash,
-            icon: data.guild.icon,
-            id: data.guild.id,
-            name: data.guild.name,
-            textChannelCount: data.guild.text_channel_count !== undefined ? data.guild.text_channel_count : null,
-            voiceChannelCount: data.guild.voice_channel_count !== undefined ? data.guild.voice_channel_count : null
-        };
+        if(data.guild) {
+            this.guild = {
+                splash: data.guild.splash,
+                icon: data.guild.icon,
+                id: data.guild.id,
+                name: data.guild.name,
+                textChannelCount: data.guild.text_channel_count !== undefined ? data.guild.text_channel_count : null,
+                voiceChannelCount: data.guild.voice_channel_count !== undefined ? data.guild.voice_channel_count : null
+            };
+        }
         if(data.inviter) {
             this.inviter = client.users.add(data.inviter, client);
         }


### PR DESCRIPTION
Updates the invite structure so guild is an optional property in the case of an invite being from a group DM and therefore not having a guild.

retro-ref discordapp/discord-api-docs#614