### PR TITLE
Allow return from command hooks

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -279,17 +279,29 @@ class Command {
         return true;
     }
 
-    process(args, msg) {
+    async process(args, msg) {
         var shouldDelete = this.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(msg._client.user.id).has("manageMessages");
 
         if(this.hooks.preCommand) {
-            this.hooks.preCommand(msg, args);
+            if (this.hooks.preCommand(msg, args) !== undefined) {
+                const response = await this.hooks.preCommand(msg, args);
+                msg = response.msg ? response.msg : msg;
+                args = response.args ? response.args : args;    
+            } else {
+                this.hooks.preCommand(msg, args);
+            }
         }
 
         var reply;
         if(!this.permissionCheck(msg)) {
             if(this.hooks.postCheck) {
-                this.hooks.postCheck(msg, args, false);
+                if (this.hooks.postCheck(msg, args, false) !== undefined) {
+                    const response = await this.hooks.postCheck(msg, args, false);
+                    msg = response.msg ? response.msg : msg;
+                    args = response.args ? response.args : args;    
+                } else {
+                    this.hooks.postCheck(msg, args, false);
+                }
             }
 
             if(shouldDelete) {
@@ -307,7 +319,13 @@ class Command {
             }
             if(this.argsRequired) {
                 if(this.hooks.postCheck) {
-                    this.hooks.postCheck(msg, args, false);
+                    if (this.hooks.postCheck(msg, args, true) !== undefined) {
+                        const response = await this.hooks.postCheck(msg, args, true);
+                        msg = response.msg ? response.msg : msg;
+                        args = response.args ? response.args : args;    
+                    } else {
+                        this.hooks.postCheck(msg, args, true);
+                    }
                 }
                 reply = typeof this.invalidUsageMessage === "function" ? this.invalidUsageMessage(msg) : this.invalidUsageMessage;
                 if(reply) {
@@ -317,7 +335,13 @@ class Command {
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.hooks.postCheck) {
-                    this.hooks.postCheck(msg, args, false);
+                    if (this.hooks.postCheck(msg, args, true) !== undefined) {
+                        const response = await this.hooks.postCheck(msg, args, true);
+                        msg = response.msg ? response.msg : msg;
+                        args = response.args ? response.args : args;    
+                    } else {
+                        this.hooks.postCheck(msg, args, true);
+                    }
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
@@ -340,7 +364,13 @@ class Command {
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.hooks.postCheck) {
-                    this.hooks.postCheck(msg, args, false);
+                    if (this.hooks.postCheck(msg, args, false) !== undefined) {
+                        const response = await this.hooks.postCheck(msg, args, false);
+                        msg = response.msg ? response.msg : msg;
+                        args = response.args ? response.args : args;    
+                    } else {
+                        this.hooks.postCheck(msg, args, false);
+                    }
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
                     reply = typeof this.cooldownMessage === "function" ? this.cooldownMessage(msg) : this.cooldownMessage;
@@ -354,15 +384,27 @@ class Command {
         }
     }
 
-    executeCommand(msg, args) {
+    async executeCommand(msg, args) {
         if(this.hooks.postCheck) {
-            this.hooks.postCheck(msg, args, true);
+            if (this.hooks.postCheck(msg, args, true) !== undefined) {
+                const response = await this.hooks.postCheck(msg, args, true);
+                msg = response.msg ? response.msg : msg;
+                args = response.args ? response.args : args;    
+            } else {
+                this.hooks.postCheck(msg, args, true);
+            }
         }
 
         let ret = this.execute(msg, args);
 
         if(this.hooks.postExecution) {
-            this.hooks.postExecution(msg, args, true);
+            if (this.hooks.postExecution(msg, args, true) !== undefined) {
+                const response = await this.hooks.postExecution(msg, args, true);
+                msg = response.msg ? response.msg : msg;
+                args = response.args ? response.args : args;    
+            } else {
+                this.hooks.postExecution(msg, args, true);
+            }
         }
 
         return ret;

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -283,24 +283,20 @@ class Command {
         var shouldDelete = this.deleteCommand && msg.channel.guild && msg.channel.permissionsOf(msg._client.user.id).has("manageMessages");
 
         if(this.hooks.preCommand) {
-            if (this.hooks.preCommand(msg, args) !== undefined) {
-                const response = await this.hooks.preCommand(msg, args);
-                msg = response.msg ? response.msg : msg;
-                args = response.args ? response.args : args;    
-            } else {
-                this.hooks.preCommand(msg, args);
+            const response = await Promise.resolve(this.hooks.preCommand(msg, args));
+            if (response) {
+                msg = response.msg || msg;
+                args = response.args || args;    
             }
         }
 
         var reply;
         if(!this.permissionCheck(msg)) {
             if(this.hooks.postCheck) {
-                if (this.hooks.postCheck(msg, args, false) !== undefined) {
-                    const response = await this.hooks.postCheck(msg, args, false);
-                    msg = response.msg ? response.msg : msg;
-                    args = response.args ? response.args : args;    
-                } else {
-                    this.hooks.postCheck(msg, args, false);
+                const response = await Promise.resolve(this.hooks.postCheck(msg, args, false));
+                if (response) {
+                    msg = response.msg || msg;
+                    args = response.args || args;    
                 }
             }
 
@@ -319,12 +315,10 @@ class Command {
             }
             if(this.argsRequired) {
                 if(this.hooks.postCheck) {
-                    if (this.hooks.postCheck(msg, args, true) !== undefined) {
-                        const response = await this.hooks.postCheck(msg, args, true);
-                        msg = response.msg ? response.msg : msg;
-                        args = response.args ? response.args : args;    
-                    } else {
-                        this.hooks.postCheck(msg, args, true);
+                    const response = await Promise.resolve(this.hooks.postCheck(msg, args, true));
+                    if (response) {
+                        msg = response.msg || msg;
+                        args = response.args || args;    
                     }
                 }
                 reply = typeof this.invalidUsageMessage === "function" ? this.invalidUsageMessage(msg) : this.invalidUsageMessage;
@@ -335,12 +329,10 @@ class Command {
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.hooks.postCheck) {
-                    if (this.hooks.postCheck(msg, args, true) !== undefined) {
-                        const response = await this.hooks.postCheck(msg, args, true);
-                        msg = response.msg ? response.msg : msg;
-                        args = response.args ? response.args : args;    
-                    } else {
-                        this.hooks.postCheck(msg, args, true);
+                    const response = await Promise.resolve(this.hooks.postCheck(msg, args, true));
+                    if (response) {
+                        msg = response.msg || msg;
+                        args = response.args || args;    
                     }
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
@@ -364,12 +356,10 @@ class Command {
             }
             if(this.cooldown !== 0 && !this.cooldownCheck(msg)) {
                 if(this.hooks.postCheck) {
-                    if (this.hooks.postCheck(msg, args, false) !== undefined) {
-                        const response = await this.hooks.postCheck(msg, args, false);
-                        msg = response.msg ? response.msg : msg;
-                        args = response.args ? response.args : args;    
-                    } else {
-                        this.hooks.postCheck(msg, args, false);
+                    const response = await Promise.resolve(this.hooks.postCheck(msg, args, false));
+                    if (response) {
+                        msg = response.msg || msg;
+                        args = response.args || args;    
                     }
                 }
                 if(this.cooldownMessage && (!this.cooldownReturns || this.cooldownAmounts[msg.author.id] <= this.cooldownReturns)) {
@@ -386,25 +376,17 @@ class Command {
 
     async executeCommand(msg, args) {
         if(this.hooks.postCheck) {
-            if (this.hooks.postCheck(msg, args, true) !== undefined) {
-                const response = await this.hooks.postCheck(msg, args, true);
-                msg = response.msg ? response.msg : msg;
-                args = response.args ? response.args : args;    
-            } else {
-                this.hooks.postCheck(msg, args, true);
+            const response = await Promise.resolve(this.hooks.postCheck(msg, args, true));
+            if (response) {
+                msg = response.msg || msg;
+                args = response.args || args;    
             }
         }
 
         let ret = this.execute(msg, args);
 
         if(this.hooks.postExecution) {
-            if (this.hooks.postExecution(msg, args, true) !== undefined) {
-                const response = await this.hooks.postExecution(msg, args, true);
-                msg = response.msg ? response.msg : msg;
-                args = response.args ? response.args : args;    
-            } else {
-                this.hooks.postExecution(msg, args, true);
-            }
+            this.hooks.postExecution(msg, args, true);
         }
 
         return ret;


### PR DESCRIPTION
This would allow for a advanced hooks

example of a good use
```javascript
bot.registerCommand('test2', (msg, args) => {
    console.log(args);
}, {
    hooks: {
        preCommand: (msg, args) => {
            if (args && args.length > 0) {
                return { args: args.join(' ').replace(/ {2,}/gmi, ' ').split(' ') };
            }
        }
    }
});
```
this would remove extra spaces but this would be set as a global hook tho not just a single command as there would be no point to that

What it does / changes
- Checks for a return
- if so waits for it, if not continue
- set values if they are present in the return

Possible suggestions:
Check for a var Continue from the return, then continue if its true?