### PR TITLE
Fix inspect/toJSON methods on structures to only omit undefined values, not all falsy ones

### DIFF
--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -58,7 +58,7 @@ class Base {
         // http://stackoverflow.com/questions/5905492/dynamic-function-name-in-javascript
         var copy = new (new Function(`return function ${this.constructor.name}(){}`)());
         for(var key in this) {
-            if(this.hasOwnProperty(key) && !key.startsWith("_") && this[key]) {
+            if(this.hasOwnProperty(key) && !key.startsWith("_") && this[key] !== undefined) {
                 copy[key] = this[key];
             }
         }

--- a/lib/structures/Call.js
+++ b/lib/structures/Call.js
@@ -51,7 +51,7 @@ class Call extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["endedTimestamp", "participants", "region", "ringing", "unavailable", "voiceStates"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -36,7 +36,7 @@ class CategoryChannel extends GuildChannel {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["channels"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -22,7 +22,7 @@ class Channel extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["type"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/ExtendedUser.js
+++ b/lib/structures/ExtendedUser.js
@@ -26,7 +26,7 @@ class ExtendedUser extends User {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["email", "mfaEnabled", "premium" ,"verified"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -87,7 +87,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["icon", "name", "ownerID", "recipients"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -543,7 +543,7 @@ class Guild extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["afkChannelID", "afkTimeout", "channels", "defaultNotifications", "emojis", "explicitContentFilter", "features", "icon", "joinedAt", "large", "maxPresences", "memberCount", "members", "mfaLevel", "name", "ownerID", "region", "roles", "splash", "unavailable", "verificationLevel"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -118,7 +118,7 @@ class GuildAuditLogEntry extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["actionType", "after", "before", "channel", "count", "deleteMemberDays", "member", "membersRemoved", "reason", "role", "targetID", "user"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -136,7 +136,7 @@ class GuildChannel extends Channel {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["name", "nsfw", "parentID", "permissionOverwrites", "position"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/GuildIntegration.js
+++ b/lib/structures/GuildIntegration.js
@@ -74,7 +74,7 @@ class GuildIntegration extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["account", "enabled", "enableEmoticons", "expireBehavior", "expireGracePeriod", "name", "roleID", "subscriberCount", "syncedAt", "syncing", "type", "user"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Invite.js
+++ b/lib/structures/Invite.js
@@ -70,7 +70,7 @@ class Invite extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["channel", "code", "createdAt", "guild", "maxAge", "maxUses", "memberCount", "presenceCount", "revoked", "temporary", "uses"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -196,7 +196,7 @@ class Member extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["game", "joinedAt", "nick", "roles", "status", "user", "voiceState"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -108,7 +108,7 @@ class Message extends Base {
         }
 
         this.pinned = data.pinned !== undefined ? !!data.pinned : this.pinned;
-        this.editedTimestamp = data.edited_timestamp !== undefined ? Date.parse(data.edited_timestamp) : this.editedTimestamp;
+        this.editedTimestamp = data.edited_timestamp !== null ? Date.parse(data.edited_timestamp) : this.editedTimestamp;
         this.tts = data.tts !== undefined ? data.tts : this.tts;
         this.attachments = data.attachments !== undefined ? data.attachments : this.attachments;
         this.embeds = data.embeds !== undefined ? data.embeds : this.embeds;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -260,8 +260,8 @@ class Message extends Base {
 
     toJSON() {
         var base = super.toJSON(true);
-        for(var prop of ["attachments", "author", "content", "editTimestamp", "embeds", "hit", "mentionEveryone", "mentions", "pinned", "reactions", "roleMentions", "timestamp", "tts", "type"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+        for(var prop of ["attachments", "author", "content", "editedTimestamp", "embeds", "hit", "mentionEveryone", "mentions", "pinned", "reactions", "roleMentions", "timestamp", "tts", "type"]) {
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Permission.js
+++ b/lib/structures/Permission.js
@@ -58,7 +58,7 @@ class Permission extends Base {
             delete base.id;
         }
         for(var prop of ["allow", "deny"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -18,7 +18,7 @@ class PermissionOverwrite extends Permission {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["type"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -207,7 +207,7 @@ class PrivateChannel extends Channel {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["call", "lastCall", "lastMessageID", "messages", "recipient"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Relationship.js
+++ b/lib/structures/Relationship.js
@@ -29,7 +29,7 @@ class Relationship extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["game", "status", "type", "user"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -83,7 +83,7 @@ class Role extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["color", "hoist", "managed", "mentionable", "name", "permissions", "position"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -253,7 +253,7 @@ class TextChannel extends GuildChannel {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["lastMessageID", "lastPinTimestamp", "messages", "topic"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/UnavailableGuild.js
+++ b/lib/structures/UnavailableGuild.js
@@ -18,7 +18,7 @@ class UnavailableGuild extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["unavailable"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -133,7 +133,7 @@ class User extends Base {
     toJSON() {
         var base = super.toJSON(true);
         for(var prop of ["avatar", "bot", "discriminator", "username"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -77,7 +77,7 @@ class VoiceChannel extends GuildChannel {
     toJSON() {
         var base = super.toJSON();
         for(var prop of ["bitrate", "userLimit", "voiceMembers"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }

--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -36,7 +36,7 @@ class VoiceState extends Base {
     toJSON() {
         var base = super.toJSON();
         for(var prop of ["channelID", "deaf", "mute", "selfMute", "selfDeaf", "sessionID", "suppress"]) {
-            base[prop] = this[prop] && this[prop].toJSON ? this[prop].toJSON() : this[prop];
+            base[prop] = this[prop] !== undefined && this[prop].toJSON ? this[prop].toJSON() : this[prop];
         }
         return base;
     }


### PR DESCRIPTION
Should be self-explanatory. Also:
- Fixed a typo which would prevent `editedTimestamp` from showing up in the output of `Message#toJSON()`.
- Fixed `Message#editedTimestamp` being `NaN` instead of `null` on unedited messages