### PR TITLE
Add requestTimeout Client option

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -73,12 +73,13 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
-    * @arg {Number} [options.latencyThreshold=4000] The average request latency at which Eris will start emitting latency errors
+    * @arg {Number} [options.latencyThreshold=30000] The average request latency at which Eris will start emitting latency errors
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number|String} [options.maxShards=1] The total number of shards you want to run. If "auto" Eris will use Discord's recommended shard count.
     * @arg {Number} [options.messageLimit=100] The maximum size of a channel message cache
     * @arg {Boolean} [options.opusOnly=false] Whether to suppress the node-opus not found error or not
     * @arg {Number} [options.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
+    * @arg {Number} [options.requestTimeout=15000] A number of milliseconds before requests should timeout.
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. This should only be enabled if you are not connecting to the gateway. Bot tokens must be prefixed manually in REST mode
     * @arg {Boolean} [options.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
     * @arg {String} [options.defaultImageFormat="jpg"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"
@@ -105,6 +106,7 @@ class Client extends EventEmitter {
             messageLimit: 100,
             opusOnly: false,
             ratelimiterOffset: 0,
+            requestTimeout: 15000,
             restMode: false,
             seedVoiceConnections: false,
             ws: {}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -79,7 +79,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.messageLimit=100] The maximum size of a channel message cache
     * @arg {Boolean} [options.opusOnly=false] Whether to suppress the node-opus not found error or not
     * @arg {Number} [options.ratelimiterOffset=0] A number of milliseconds to offset the ratelimit timing calculations by
-    * @arg {Number} [options.requestTimeout=15000] A number of milliseconds before requests should timeout.
+    * @arg {Number} [options.requestTimeout=15000] A number of milliseconds before requests are considered timed out
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. This should only be enabled if you are not connecting to the gateway. Bot tokens must be prefixed manually in REST mode
     * @arg {Boolean} [options.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
     * @arg {String} [options.defaultImageFormat="jpg"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -17,6 +17,7 @@ class RequestHandler {
         this.baseURL = Endpoints.BASE_URL;
         this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
         this.ratelimits = {};
+        this.requestTimeout = client.options.requestTimeout;
         this.latencyRef = {
             latency: 500,
             offset: client.options.ratelimiterOffset,
@@ -303,8 +304,8 @@ class RequestHandler {
                     });
                 });
 
-                req.setTimeout(15000, function() {
-                    reqError = new Error(`Request timed out (>15000ms) on ${method} ${url}`);
+                req.setTimeout(this.requestTimeout, function() {
+                    reqError = new Error(`Request timed out (>${this.requestTimeout}ms) on ${method} ${url}`);
                     req.abort();
                 });
 


### PR DESCRIPTION
I asked on discord and people seemed to agree this option would be useful, with several stating that they would like it to be added and would use it if added.

I also caught a typo in the docs where the latencyTimeout option defaulted to 4s instead of 30s as it does in the code.