### PR TITLE
Fix docs for emoji endpoints

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -679,7 +679,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Create a guild emoji object (not for bot accounts)
+    * Create a guild emoji object
     * @arg {String} guildID The ID of the guild to create the emoji in
     * @arg {Object} options Emoji options
     * @arg {String} options.name The name of emoji
@@ -694,7 +694,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edit a guild emoji object (not for bot accounts)
+    * Edit a guild emoji object
     * @arg {String} guildID The ID of the guild to edit the emoji in
     * @arg {String} emojiID The ID of the emoji you want to modify
     * @arg {Object} options Emoji options
@@ -709,7 +709,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Delete a guild emoji object (not for bot accounts)
+    * Delete a guild emoji object
     * @arg {String} guildID The ID of the guild to delete the emoji in
     * @arg {String} emojiID The ID of the emoji
     * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -183,7 +183,7 @@ class Guild extends Base {
     }
 
     /**
-    * Create a emoji in the guild (not for bot accounts)
+    * Create a emoji in the guild
     * @arg {Object} options Emoji options
     * @arg {String} options.name The name of emoji
     * @arg {String} options.image The base 64 encoded string
@@ -196,7 +196,7 @@ class Guild extends Base {
     }
 
     /**
-    * Edit a emoji in the guild (not for bot accounts)
+    * Edit a emoji in the guild
     * @arg {String} emojiID The ID of the emoji you want to modify
     * @arg {Object} options Emoji options
     * @arg {String} [options.name] The name of emoji
@@ -209,7 +209,7 @@ class Guild extends Base {
     }
 
     /**
-    * Delete a emoji in the guild (not for bot accounts)
+    * Delete a emoji in the guild
     * @arg {String} emojiID The ID of the emoji
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise}


### PR DESCRIPTION
Second attempt of #411, sorry

The docs say that bot accounts are unable to use the emoji create/edit/delete endpoints, but this is no longer the case. This PR updates the documentation.

Proof:
![image showing an eval which adds an emote](https://blargbot.needs-to-s.top/2140d0.png)