### PR TITLE
Change Audit Log Processes

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1316,7 +1316,7 @@ class Client extends EventEmitter {
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
             "delete-message-days": deleteMessageDays || 0,
-            queryReason: reason
+            reason
         });
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1316,7 +1316,7 @@ class Client extends EventEmitter {
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
             "delete-message-days": deleteMessageDays || 0,
-            reason
+            queryReason: reason
         });
     }
 

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -84,9 +84,6 @@ class RequestHandler {
                         headers.Authorization = this._client.token;
                     }
                     if(body && body.reason) { // Audit log reason sniping
-                        if(body.reason === decodeURI(body.reason)) {
-                            body.reason = encodeURIComponent(body.reason);
-                        }
                         headers["X-Audit-Log-Reason"] = body.reason;
                         delete body.reason;
                     }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -87,6 +87,10 @@ class RequestHandler {
                         headers["X-Audit-Log-Reason"] = body.reason;
                         delete body.reason;
                     }
+                    if(body && body.queryReason) {
+                        body.reason = body.queryReason;
+                        delete body.queryReason;
+                    }
                     if(file) {
                         if(Array.isArray(file)) {
                             data = new MultipartData();

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -90,10 +90,6 @@ class RequestHandler {
                         headers["X-Audit-Log-Reason"] = body.reason;
                         delete body.reason;
                     }
-                    if(body && body.queryReason) {
-                        body.reason = body.queryReason;
-                        delete body.queryReason;
-                    }
                     if(file) {
                         if(Array.isArray(file)) {
                             data = new MultipartData();


### PR DESCRIPTION
This PR does the following:
1. Change the banGuildMember request to use the `reason` option instead of `queryReason`
    - While the ban request still accepts the reason queryString, this is for backwards compatibility. Bans, like other requests, accept the `X-Audit-Log-Reason` header
2. Change the RequestHandler to remove the URI encoding/decoding, which creates problems when you use % in your audit reason. See: #420 