### PR TITLE
Add complete emoji and TextChannel#purge typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1029,12 +1029,12 @@ declare module "eris" {
     public createEmoji(
       options: { name: string, image: string, roles?: string[] },
       reason?: string,
-    ): Promise<EmojiOptions>;
+    ): Promise<Emoji>;
     public editEmoji(
       emojiID: string,
       options: { name: string, roles?: string[] },
       reason?: string,
-    ): Promise<EmojiOptions>;
+    ): Promise<Emoji>;
     public deleteEmoji(emojiID: string, reason?: string): Promise<void>;
     public createRole(options: RoleOptions, reason?: string): Promise<Role>;
     public getPruneCount(days: number): Promise<number>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1161,6 +1161,9 @@ declare module "eris" {
     public addMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     public removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     public removeMessageReactions(messageID: string): Promise<void>;
+    public purge(
+      limit: number, filter?: (message: Message) => boolean, before?: string, after?: string
+    ): Promise<number>;
     public deleteMessage(messageID: string, reason?: string): Promise<void>;
     public unsendMessage(messageID: string): Promise<void>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -350,6 +350,11 @@ declare module "eris" {
   } & EmojiBase;
   type Emoji = {
     roles: string[],
+    id: string,
+    require_colons: boolean,
+    animated: boolean,
+    managed: boolean,
+    user: { name: string, discriminator: string, id: string, avatar: string }
   } & EmojiBase;
   interface IntegrationOptions { expireBehavior: string; expireGracePeriod: string; enableEmoticons: string; }
   interface GuildOptions {


### PR DESCRIPTION
I'm not sure about the emoji typings, needs code review since I'm not aware if Eris automatically converts the user in emoji to User classes, and it doesn't cover the entire user object Discord sends either, so not sure about that.

Other than that, the typings for TextChannel#purge was also added and the type returned by Guild#createEmoji/Guild#editEmoji were also fixed according to the new types.