### PR TITLE
Fix TypeScript issue where editChannel is unusable.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -536,7 +536,7 @@ declare module "eris" {
       topic?: string,
       bitrate?: number,
       userLimit?: number,
-      rateLimitPerUser: number,
+      rateLimitPerUser?: number,
       nsfw?: boolean,
       parentID?: string,
     },                 reason?: string): Promise<GroupChannel | AnyGuildChannel>;
@@ -1112,7 +1112,7 @@ declare module "eris" {
         topic?: string,
         bitrate?: number,
         userLimit?: number,
-        rateLimitPerUser: number,
+        rateLimitPerUser?: number,
         nsfw?: boolean,
       },
       reason?: string,


### PR DESCRIPTION
editChannel can only be properly used when rateLimitPerUser is provided because TypeScript believes it is not optional when using Eris with TypeScript.

Really small patch but well..