### PR TITLE
Voice Receive Typings Fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -913,9 +913,10 @@ declare module "eris" {
     public stopPlaying(): void;
   }
 
-  class VoiceDataStream {
+  export class VoiceDataStream extends EventEmitter {
     public type: string;
     public constructor(type: string);
+    public on(event: "data", listener: (data: Buffer, userID: string, timestamp: number, sequence: number) => void): this;
   }
 
   // tslint:disable-next-line

--- a/index.d.ts
+++ b/index.d.ts
@@ -889,6 +889,7 @@ declare module "eris" {
     public on(event: "error" | "disconnect", listener: (err: Error) => void): this;
     public on(event: "pong", listener: (latency: number) => void): this;
     public on(event: "speakingStart", listener: (userID: string) => void): this;
+    public on(event: "speakingStop", listener: (userID: string) => void): this;
     public on(event: "end", listener: () => void): this;
     public toJSON(simple?: boolean): JSONCache;
   }


### PR DESCRIPTION
The TS compiler threw a bunch of errors out when I tried to listen in on the `speakingStop` event for a VoiceConnection and the `data` event for a VoiceDataStream. Dug in a little bit, and I think these two commits should resolve the issue:

aca048f - Adding a signature for the `speakingStop` event.
bd5b241 - Update the `VoiceDataStream` declaration. This should extend EventEmitter (since it emits the `data` event) and also include a signature for said event. 

I ran it through eslint and also tested the changes myself - seems to be good!