### PR TITLE
Fixed editChannelPosition to not take care of category

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -446,11 +446,12 @@ class Client extends EventEmitter {
         }
         const min = Math.min(position, channel.position);
         const max = Math.max(position, channel.position);
-        channels = channels.filter((chan) => chan.type === channel.type 
-            && min <= chan.position 
-            && chan.position <= max 
-            && chan.id !== channelID)
-            .sort((a, b) => a.position - b.position);
+        channels = channels.filter((chan) => {
+            return chan.type === channel.type
+                && min <= chan.position
+                && chan.position <= max
+                && chan.id !== channelID;
+        }).sort((a, b) => a.position - b.position);
         if(position > channel.position) {
             channels.push(channel);
         } else {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -446,7 +446,11 @@ class Client extends EventEmitter {
         }
         const min = Math.min(position, channel.position);
         const max = Math.max(position, channel.position);
-        channels = channels.filter((chan) => chan.type === channel.type && chan.parentID === channel.parentID && min <= chan.position && chan.position <= max && chan.id !== channelID).sort((a, b) => a.position - b.position);
+        channels = channels.filter((chan) => chan.type === channel.type 
+            && min <= chan.position 
+            && chan.position <= max 
+            && chan.id !== channelID)
+            .sort((a, b) => a.position - b.position);
         if(position > channel.position) {
             channels.push(channel);
         } else {


### PR DESCRIPTION
This pull request fixes an issue with editChannelPosition.

Discord doesn't take care of categories when editing channel position.
The old behavior was creating an issue where several channels could have the same position when changing channel position. Therefore when moving channels they weren't moved to the correct place.

This fix simply remove checking to only edit the position of channels within the same category.