### PR TITLE
Member class updates

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -271,7 +271,9 @@ class Shard extends EventEmitter {
                 if(member) {
                     oldPresence = {
                         game: member.game,
-                        status: member.status
+                        status: member.status,
+                        clientStatus: member.clientStatus,
+                        activities: member.activities
                     };
                 }
                 if((!member && packet.d.user.username) || oldPresence) {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -12,13 +12,13 @@ const VoiceState = require("./VoiceState");
 * @prop {String} mention A string that mentions the member
 * @prop {Guild} guild The guild the member is in
 * @prop {Number} joinedAt Timestamp of when the member joined the guild
-* @prop {String} status The member's status. Either "online", "idle", or "offline"
+* @prop {String} status The member's status. Either "online", "idle", "dnd", or "offline"
 * @prop {Object?} game The active game the member is playing
 * @prop {String} game.name The name of the active game
 * @prop {Object} clientStatus The member's per-client status
-* @prop {String} clientStatus.web The member's status on web. Either "online", "idle", or "offline". Will be "online" for bots
-* @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", or "offline". Will be "offline" for bots
-* @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", or "offline". Will be "offline" for bots
+* @prop {String} clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
+* @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+* @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
 * @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
 * @prop {String?} game.url The url of the active game
 * @prop {VoiceState} voiceState The voice state of the member

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -61,7 +61,7 @@ class Member extends Base {
         this.status = data.status !== undefined ? data.status : this.status || "offline";
         this.game = data.game !== undefined ? data.game : this.game || null;
         this.joinedAt = data.joined_at !== undefined ? Date.parse(data.joined_at) : this.joinedAt;
-        this.clientStatus = Object.assign({}, { web: "offline", desktop: "offline", mobile: "offline" }, data.client_status);
+        this.clientStatus = data.client_status !== undefined ? Object.assign({ web: "offline", desktop: "offline", mobile: "offline" }, data.client_status) : this.clientStatus;
         this.activities = data.activities;
 
         if(data.mute !== undefined) {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -19,6 +19,7 @@ const VoiceState = require("./VoiceState");
 * @prop {String} clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
 * @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
 * @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+* @prop {Object[]} activities The member's current activities
 * @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
 * @prop {String?} game.url The url of the active game
 * @prop {VoiceState} voiceState The voice state of the member
@@ -61,6 +62,7 @@ class Member extends Base {
         this.game = data.game !== undefined ? data.game : this.game || null;
         this.joinedAt = data.joined_at !== undefined ? Date.parse(data.joined_at) : this.joinedAt;
         this.clientStatus = Object.assign({}, { web: "offline", desktop: "offline", mobile: "offline" }, data.client_status);
+        this.activities = data.activities;
 
         if(data.mute !== undefined) {
             this.voiceState.update(data);

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -15,6 +15,10 @@ const VoiceState = require("./VoiceState");
 * @prop {String} status The member's status. Either "online", "idle", or "offline"
 * @prop {Object?} game The active game the member is playing
 * @prop {String} game.name The name of the active game
+* @prop {Object} clientStatus The member's per-client status
+* @prop {String} clientStatus.web The member's status on web. Either "online", "idle", or "offline". Will be "online" for bots
+* @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", or "offline". Will be "offline" for bots
+* @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", or "offline". Will be "offline" for bots
 * @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
 * @prop {String?} game.url The url of the active game
 * @prop {VoiceState} voiceState The voice state of the member
@@ -56,6 +60,7 @@ class Member extends Base {
         this.status = data.status !== undefined ? data.status : this.status || "offline";
         this.game = data.game !== undefined ? data.game : this.game || null;
         this.joinedAt = data.joined_at !== undefined ? Date.parse(data.joined_at) : this.joinedAt;
+        this.clientStatus = Object.assign({}, { web: "offline", desktop: "offline", mobile: "offline" }, data.client_status);
 
         if(data.mute !== undefined) {
             this.voiceState.update(data);


### PR DESCRIPTION
Added two things, `Member.clientStatus` and `Member.activities`. Also adds the `"dnd"` status to `Member#status` docs, fixing #456.

## Member.clientStatus
The raw packet data includes `packet.d.client_status`, which is an object whose property names are the clients that user is not offline on, and whose property values are their respective statuses on those platforms.

### Examples
`{ mobile: 'dnd', desktop: 'dnd' }`
User is offline on the web client, and Do Not Disturb on mobile and desktop
`{ desktop: 'idle' }`
User is offline on mobile and web clients, and idle on the desktop client
`{}`
User is offline on all clients.

### Implementation
`Member.clientStatus` defaults all three clients to offline, then uses the data in the packet to overwrite the property values.

## Member.activities
The raw packet data also includes `packet.d.activities`, which is an array of activity objects. Since the included properties of each object is very variable, no formatting has been done for now, and no documentation of activity properties has been made. Figured we should probably discuss this to see what works best for the lib and the docs.