### PR TITLE
Add 'unique' property to 'CreateInviteOptions'

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,6 +24,7 @@ declare module "eris" {
     maxAge?: number;
     maxUses?: number;
     temporary?: boolean;
+    unique?: boolean;
   }
 
   interface Invitable {


### PR DESCRIPTION
This adds the `unique` property to the `CreateInviteOptions` structure for typescript which allows forcing Discord to create a new invite code instead of reusing an existing one.

Property is documented here: https://discordapp.com/developers/docs/resources/channel#create-channel-invite