### PR TITLE
Don't set speaking indicator before playing something

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -755,8 +755,8 @@ class VoiceConnection extends EventEmitter {
     */
     resume() {
         this.paused = false;
-        this.setSpeaking(true);
         if(this.current) {
+            this.setSpeaking(true);
             if(this.current.pausedTimestamp) {
                 this.current.pausedTime += Date.now() - this.current.pausedTimestamp;
                 this.current.pausedTimestamp = 0;


### PR DESCRIPTION
Makes bots not have speaking indicators on joining a channel if they aren't playing anything yet