### PR TITLE
Added support for Node HTTP(S) Agent

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,8 @@ declare module "eris" {
   // TODO good hacktoberfest PR: implement ShardManager, RequestHandler and other stuff
   import { EventEmitter } from "events";
   import { Readable as ReadableStream } from "stream";
+  import { Agent as HTTPAgent } from "http";
+  import { Agent as HTTPSAgent } from "https";
 
   export const VERSION: string;
   interface JSONCache { [s: string]: any; }
@@ -422,6 +424,7 @@ declare module "eris" {
     defaultImageSize?: number;
     ws?: any;
     latencyThreshold?: number;
+    agent?: HTTPAgent | HTTPSAgent
   }
   interface CommandClientOptions {
     defaultHelpCommand?: boolean;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -130,6 +130,11 @@ class Client extends EventEmitter {
         if(defaultImageSize < 16 || defaultImageSize > 1024 || (defaultImageSize & (defaultImageSize - 1))) {
             throw new TypeError("Invalid default image size: " + defaultImageSize);
         }
+        // Set HTTP Agent on Websockets if not already set
+        if (this.options.agent && !(this.options.ws && this.options.ws.agent)) {
+            this.options.ws = this.options.ws || {};
+            this.options.ws.agent = this.options.agent;
+        }
 
         this.token = token;
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -86,6 +86,7 @@ class Client extends EventEmitter {
     * @arg {String} [options.defaultImageFormat="jpg"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"
     * @arg {Number} [options.defaultImageSize=128] The default size to return user avatars, guild icons, and group icons as. Can be 128, 256, 512, 1024, or 2048.
     * @arg {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
+    * @arg {Object} [options.agent] A HTTP Agent used to proxy requests
     */
     constructor(token, options) {
         super();
@@ -111,6 +112,7 @@ class Client extends EventEmitter {
             restMode: false,
             seedVoiceConnections: false,
             ws: {}
+            agent: null
         };
         if(typeof options === "object") {
             for(const property of Object.keys(options)) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -111,7 +111,7 @@ class Client extends EventEmitter {
             requestTimeout: 15000,
             restMode: false,
             seedVoiceConnections: false,
-            ws: {}
+            ws: {},
             agent: null
         };
         if(typeof options === "object") {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -18,6 +18,7 @@ class RequestHandler {
         this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
         this.ratelimits = {};
         this.requestTimeout = client.options.requestTimeout;
+        this.agent = client.options.agent;
         this.latencyRef = {
             latency: 500,
             offset: client.options.ratelimiterOffset,
@@ -146,7 +147,8 @@ class RequestHandler {
                     method: method,
                     host: "discordapp.com",
                     path: this.baseURL + finalURL,
-                    headers: headers
+                    headers: headers,
+                    agent: this.agent
                 });
 
                 let reqError;


### PR DESCRIPTION
Fix #473

A very simple PR that add support for [HTTP Agents](https://nodejs.org/api/http.html#http_class_http_agent), allowing requests to be proxied by many kind of proxies (with [`http-proxy-agent`](https://www.npmjs.com/package/http-proxy-agent) or [`socks-proxy-agent`](https://www.npmjs.com/package/socks-proxy-agent) for instance).