### PR TITLE
Add spoiler support in Message.cleanContent

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -185,7 +185,7 @@ class Message extends Base {
             }
         });
 
-        return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
+        return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere").replace(/\|\|/g, "");
     }
 
     get channelMentions() {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -186,9 +186,11 @@ class Message extends Base {
         });
         
         if(cleanContent.match(/\|\|([\s\S])+?\|\|/g)) {
-            cleanContent = cleanContent.replace(/\|\|/g, "");
+            let matches = cleanContent.match(/\|\|([\s\S])+?\|\|/g);
+            matches.forEach((match) => {
+                cleanContent = cleanContent.replace(match, match.replace(/\|\|/g, ""));
+            });
         }
-
         return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
     }
 

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -15,7 +15,7 @@ const User = require("./User");
 * @prop {Member?} member The message author with server-specific data
 * @prop {User[]} mentions Array of mentioned users
 * @prop {String} content Message content
-* @prop {String?} cleanContent Message content with mentions replaced by names, and @everyone/@here escaped
+* @prop {String?} cleanContent Message content with mentions replaced by names, @everyone/@here escaped and with no spoilers.
 * @prop {String[]} roleMentions Array of mentioned roles' ids
 * @prop {String[]?} channelMentions Array of mentions channels' ids
 * @prop {Number?} editedTimestamp Timestamp of latest message edit

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -184,8 +184,12 @@ class Message extends Base {
                 cleanContent = cleanContent.replace(channel.mention, "#" + channel.name);
             }
         });
+        
+        if(cleanContent.match(/\|\|([\s\S])+?\|\|/g)) {
+            cleanContent = cleanContent.replace(/\|\|/g, "");
+        }
 
-        return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere").replace(/\|\|/g, "");
+        return cleanContent.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
     }
 
     get channelMentions() {


### PR DESCRIPTION
Some of you may think that this may not be that useful, but if you cover every letter with "||" it would seem harder to read.

e.g. `||C||||R||||A||||W||||L||||I||||N||||G|||| ||||I||||N|||| ||||M||||Y|||| ||||S||||K||||I||||N||`

So, that's why I think it does seem to matter.