### PR TITLE
Add a keepalive agent to RequestHandlers

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -28,6 +28,10 @@ class RequestHandler {
         };
         this.globalBlock = false;
         this.readyQueue = [];
+        this.agent = new HTTPS.Agent({
+            keepAlive: true,
+            keepAliveMsecs: 10000,
+        });
         if(forceQueueing) {
             this.globalBlock = true;
             this._client.once("shardPreReady", () => this.globalUnblock());
@@ -149,7 +153,8 @@ class RequestHandler {
                     method: method,
                     host: "discordapp.com",
                     path: this.baseURL + finalURL,
-                    headers: headers
+                    headers: headers,
+                    agent: this.agent,
                 });
 
                 let reqError;


### PR DESCRIPTION
This stops NodeJS from opening a new connection for every REST request.