### PR TITLE
Ignore duplicate spaces between command args

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -149,7 +149,7 @@ class CommandClient extends Client {
 
         msg.command = false;
         if((!this.commandOptions.ignoreSelf || msg.author.id !== this.user.id) && (!this.commandOptions.ignoreBots || !msg.author.bot) && (msg.prefix = this.checkPrefix(msg))) {
-            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).split(" ");
+            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).split(" ").filter((s) => !!s);
             const label = args.shift();
             const command = this.resolveCommand(label);
             if(command !== undefined) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -149,7 +149,7 @@ class CommandClient extends Client {
 
         msg.command = false;
         if((!this.commandOptions.ignoreSelf || msg.author.id !== this.user.id) && (!this.commandOptions.ignoreBots || !msg.author.bot) && (msg.prefix = this.checkPrefix(msg))) {
-            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).split(" ").filter((s) => !!s);
+            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).trim().split(/\s+/g);
             const label = args.shift();
             const command = this.resolveCommand(label);
             if(command !== undefined) {


### PR DESCRIPTION
In my experience users often add multiple spaces between commands, especially after an `@mention` due to the way discord "helpfully" autocomplets a space all on its own. e.g. 
```
@botname  hello
```
Unfortunately, the current command client naively parses the commands into `["", "hello"]` and gives up when the empty string isn't a registered command.

This simply filters out any empty strings from the args to allow such messages to be processed as a user would expect.