### PR TITLE
Update the channelUpdate event

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -931,6 +931,7 @@ class Shard extends EventEmitter {
                     oldChannel = {
                         name: channel.name,
                         topic: channel.topic,
+                        type: channel.type,
                         position: channel.position,
                         bitrate: channel.bitrate,
                         nsfw: channel.nsfw,

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -985,6 +985,7 @@ class Shard extends EventEmitter {
                 * @prop {Number} oldChannel.position The position of the channel
                 * @prop {Boolean} oldChannel.nsfw Whether the channel is NSFW or not
                 * @prop {String?} oldChannel.topic The topic of the channel (text channels only)
+                * @prop {Number} oldChannel.type The type of the old channel
                 * @prop {Number?} oldChannel.bitrate The bitrate of the channel (voice channels only)
                 * @prop {Collection} oldChannel.permissionOverwrites Collection of PermissionOverwrites in this channel
                 */


### PR DESCRIPTION
Now that channels can be converted from TextChannels to NewsChannels, the channelUpdate event should reflect that and allow access to the type of the old channel.