### PR TITLE
Guild#iconURL/dynamicIconURL use GIF when icon is animated.

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -175,7 +175,7 @@ class Guild extends Base {
     */
     dynamicIconURL(format, size) {
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
-            format = this.shard.client.options.defaultImageFormat;
+            format = this.icon.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat;
         }
         if(
             size < Constants.ImageSizeBoundaries.MINIMUM ||

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -165,7 +165,7 @@ class Guild extends Base {
     }
 
     get iconURL() {
-        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.icon.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     /**


### PR DESCRIPTION
Since Nitro Boosting was introduced, server icons can be animated. Use a GIF when the icon is animated in Guild#iconURL and Guild#dynamicIconURL instead of default image format like User#avatarURL and User#dynamicAvatarURL.