### PR TITLE
splashURL/bannerURL use user given settings

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -85,7 +85,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. This should only be enabled if you are not connecting to the gateway. Bot tokens must be prefixed manually in REST mode
     * @arg {Boolean} [options.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
     * @arg {String} [options.defaultImageFormat="jpg"] The default format to provide user avatars, guild icons, and group icons in. Can be "jpg", "png", "gif", or "webp"
-    * @arg {Number} [options.defaultImageSize=128] The default size to return user avatars, guild icons, and group icons as. Can be any power of two between 16 and 2048.
+    * @arg {Number} [options.defaultImageSize=128] The default size to return user avatars, guild icons, banners, splashes, and group icons. Can be any power of two between 16 and 2048. If the height and width are different, the width will be the value specified, and the height relative to that
     * @arg {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
     * @arg {Object} [options.agent] A HTTP Agent used to proxy requests
     */

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -165,7 +165,7 @@ class Guild extends Base {
     }
 
     get iconURL() {
-        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.icon.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.icon.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     /**
@@ -175,7 +175,7 @@ class Guild extends Base {
     */
     dynamicIconURL(format, size) {
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
-            format = this.icon.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat;
+            format = this.shard.client.options.defaultImageFormat;
         }
         if(
             size < Constants.ImageSizeBoundaries.MINIMUM ||
@@ -188,11 +188,49 @@ class Guild extends Base {
     }
 
     get splashURL() {
-        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${this.splash.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     get bannerURL() {
-        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${this.banner.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+    }
+
+    /**
+     * Get the guild's splash with the givem format and size
+     * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the icon (any power of two between 16 and 2048)
+     */
+    dynamicSplashURL(format,size){
+        if(!format || !Constants.ImageFormats.includes(format.toLowerCase())){
+            format = this.shard.client.options.defaultImageFormat;
+        }
+        if(
+            size < Constants.ImageSizeBoundaries.MINIMUM ||
+            size > Constants.ImageSizeBoundaries.MAXIMUM ||
+            (size & (size - 1))
+        ) {
+             size = this.shard.client.options.defaultImageSize;
+        }
+        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${format}?size=${size}` : null;
+    }
+
+    /**
+     * Get the guild's banner with the givem format and size
+     * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+     * @param {Number} [size] The size of the icon (any power of two between 16 and 2048)
+     */
+    dynamicBannerURL(format,size){
+        if(!format || !Constants.ImageFormats.includes(format.toLowerCase())){
+            format = this.shard.client.options.defaultImageFormat;
+        }
+        if(
+            size < Constants.ImageSizeBoundaries.MINIMUM ||
+            size > Constants.ImageSizeBoundaries.MAXIMUM ||
+            (size & (size - 1))
+        ) {
+             size = this.shard.client.options.defaultImageSize;
+        }
+        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${format}?size=${size}` : null;
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -188,11 +188,11 @@ class Guild extends Base {
     }
 
     get splashURL() {
-        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.jpg` : null;
+        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     get bannerURL() {
-        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.jpg` : null;
+        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -165,7 +165,7 @@ class Guild extends Base {
     }
 
     get iconURL() {
-        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.icon.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.icon ? `${CDN_URL}/icons/${this.id}/${this.icon}.${this.icon.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     /**
@@ -188,11 +188,11 @@ class Guild extends Base {
     }
 
     get splashURL() {
-        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${this.splash.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.splash ? `${CDN_URL}/splashes/${this.id}/${this.splash}.${this.splash.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     get bannerURL() {
-        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${this.banner.startsWith('a_') ? 'gif':this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
+        return this.banner ? `${CDN_URL}/banners/${this.id}/${this.banner}.${this.banner.startsWith("a_") ? "gif" : this.shard.client.options.defaultImageFormat}?size=${this.shard.client.options.defaultImageSize}` : null;
     }
 
     /**


### PR DESCRIPTION
Guild.splashURL and Guild.bannerURL both had URLs ending with .jpg and not the settings given in Client.options. Now uses settings given in Client.options (including the image size)