### PR TITLE
Basic support for upcoming channel mention format

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -197,7 +197,7 @@ class Message extends Base {
             return this._channelMentions;
         }
 
-        return (this._channelMentions = (this.content.match(/<#[0-9]+>/g) || []).map((mention) => mention.substring(2, mention.length - 1)));
+        return (this._channelMentions = (this.content.match(/<#(\d+)[^>]*>/g) || []).map((_, id) => id));
     }
 
     /**

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -185,7 +185,7 @@ class Message extends Base {
         this.channelMentions.forEach((id) => {
             const channel = this._client.getChannel(id);
             if(channel && channel.name && channel.mention) {
-                cleanContent = cleanContent.replace(channel.mention, "#" + channel.name);
+                cleanContent = cleanContent.replace(new RegExp(`<#${id}[^>]*>`, "g"), "#" + channel.name);
             }
         });
 


### PR DESCRIPTION
ref discordapp/discord-api-docs#1030

- [x] Make Message#channelMentions return channel IDs for mentions in this format (aca5075)
- [x] Update the matching in Message#cleanContent to replace this format with a channel name where possible (9f6396a)

Also fixes a bug in Message#cleanContent where only the first instance of a channel in a message would get replaced with the channel names and the rest would stay in the `<#id>` format. (9f6396a)