### PR TITLE
using "auto" instead of string on maxShards throws ts error

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -433,7 +433,7 @@ declare module "eris" {
     guildCreateTimeout?: number;
     largeThreshold?: number;
     lastShardID?: number;
-    maxShards?: number | "auto";
+    maxShards?: number | string;
     messageLimit?: number;
     opusOnly?: boolean;
     restMode?: boolean;


### PR DESCRIPTION
the maxShards property being number | "auto" on ClientOptions causes a typescript error to be thrown because string is not assignable to number | "auto"

[error message](https://butts-are.cool/_2360_2019-07-20_16-21-43.641.png)
[config](https://butts-are.cool/img2361_Code_-_Insiders_2019-07-20_16-27-24.827.png)