### PR TITLE
Adds support for channel following and messageCreate type 12.

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -162,3 +162,9 @@ module.exports.AuditLogActions = {
 
     MESSAGE_DELETE: 72
 };
+
+module.exports.MessageFlags = {
+    CROSSPOSTED: 1 << 1,
+    IS_CROSSPOST: 1 << 1,
+    SUPPRESS_EMBEDS: 1 << 2,
+}

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -167,4 +167,4 @@ module.exports.MessageFlags = {
     CROSSPOSTED: 1 << 1,
     IS_CROSSPOST: 1 << 1,
     SUPPRESS_EMBEDS: 1 << 2,
-}
+};

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -164,7 +164,7 @@ module.exports.AuditLogActions = {
 };
 
 module.exports.MessageFlags = {
-    CROSSPOSTED: 1 << 1,
+    CROSSPOSTED: 1 << 0,
     IS_CROSSPOST: 1 << 1,
     SUPPRESS_EMBEDS: 1 << 2,
 };

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -21,11 +21,11 @@ const User = require("./User");
 * @prop {Number?} editedTimestamp Timestamp of latest message edit
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
-* @prop {Object} messageReference An object containing the reference to the original message if it is a crossposted message
+* @prop {Object?} messageReference An object containing the reference to the original message if it is a crossposted message
 * @prop {String} messageReference.messageID The id of the original message this message was crossposted from
 * @prop {String} messageReference.channelID The id of the channel this message was crossposted from
 * @prop {String} messageReference.guildID The id of the guild this message was crossposted from
-* @prop {Object} flags Message flags (see constants) 
+* @prop {Number} flags Message flags (see constants) 
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
 * @prop {Object?} activity The activity specified in the message
@@ -122,8 +122,7 @@ class Message extends Base {
         } else if(this.type === 9 || this.type === 10 || this.type === 11) {
             data.content = `${this.author.mention} just boosted the server! ${this.channel.guild ? this.channel.guild.name : data.guild_id} has achieved **Level ${this.type - 8}!**`;
         } else if(this.type === 12) {
-            const guild = data.content.split('#');
-            data.content = `${this.author.mention} has added ${guild.length && guild[0]}<#${this.messageReference && this.messageReference.channelID}> to this channel`;
+            data.content = `${this.author.mention} has added ${data.content} to this channel`;
         } else {
             client.emit("warn", "Unhandled MESSAGE_CREATE type: " + JSON.stringify(data, null, 2));
         }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -54,7 +54,7 @@ class Message extends Base {
             this.messageReference = null;
         }
 
-        this.flags = data.flags !== undefined ? data.flags : null;
+        this.flags = data.flags || 0;
 
         if(data.author) {
             if(data.author.discriminator !== "0000") {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -21,6 +21,11 @@ const User = require("./User");
 * @prop {Number?} editedTimestamp Timestamp of latest message edit
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
+* @prop {Object} messageReference An object containing the reference to the original message if it is a crossposted message
+* @prop {String} messageReference.messageID The id of the original message this message was crossposted from
+* @prop {String} messageReference.channelID The id of the channel this message was crossposted from
+* @prop {String} messageReference.guildID The id of the guild this message was crossposted from
+* @prop {Object} flags Message flags (see constants) 
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
 * @prop {Object?} activity The activity specified in the message

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -54,6 +54,8 @@ class Message extends Base {
             this.messageReference = null
         }
 
+        this.flags = data.flags !== undefined ? data.flags : null;
+
         if(data.author) {
             if(data.author.discriminator !== "0000") {
                 this.author = client.users.add(data.author, client);

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -117,7 +117,8 @@ class Message extends Base {
         } else if(this.type === 9 || this.type === 10 || this.type === 11) {
             data.content = `${this.author.mention} just boosted the server! ${this.channel.guild ? this.channel.guild.name : data.guild_id} has achieved **Level ${this.type - 8}!**`;
         } else if(this.type === 12) {
-            data.content = `${this.author.mention} has added <#${this.messageReference && this.messageReference.channelID}> to this channel`;
+            const guild = data.content.split('#');
+            data.content = `${this.author.mention} has added ${guild.length && guild[0]}<#${this.messageReference && this.messageReference.channelID}> to this channel`;
         } else {
             client.emit("warn", "Unhandled MESSAGE_CREATE type: " + JSON.stringify(data, null, 2));
         }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -46,9 +46,9 @@ class Message extends Base {
 
         if (data.message_reference) {
             this.messageReference = {
-                messageId: data.message_reference.message_id,
-                channelId: data.message_reference.channel_id,
-                guildId: data.message_reference.guild_id,
+                messageID: data.message_reference.message_id,
+                channelID: data.message_reference.channel_id,
+                guildID: data.message_reference.guild_id,
             };
         } else {
             this.messageReference = null;
@@ -117,7 +117,7 @@ class Message extends Base {
         } else if(this.type === 9 || this.type === 10 || this.type === 11) {
             data.content = `${this.author.mention} just boosted the server! ${this.channel.guild ? this.channel.guild.name : data.guild_id} has achieved **Level ${this.type - 8}!**`;
         } else if(this.type === 12) {
-            data.content = `${this.author.mention} has added <#${this.messageReference && this.messageReference.channelId}> to this channel`;
+            data.content = `${this.author.mention} has added <#${this.messageReference && this.messageReference.channelID}> to this channel`;
         } else {
             client.emit("warn", "Unhandled MESSAGE_CREATE type: " + JSON.stringify(data, null, 2));
         }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -49,9 +49,9 @@ class Message extends Base {
                 messageId: data.message_reference.message_id,
                 channelId: data.message_reference.channel_id,
                 guildId: data.message_reference.guild_id,
-            }
+            };
         } else {
-            this.messageReference = null
+            this.messageReference = null;
         }
 
         this.flags = data.flags !== undefined ? data.flags : null;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -43,6 +43,17 @@ class Message extends Base {
         this.content = "";
         this.hit = !!data.hit;
         this.reactions = {};
+
+        if (data.message_reference) {
+            this.messageReference = {
+                messageId: data.message_reference.message_id,
+                channelId: data.message_reference.channel_id,
+                guildId: data.message_reference.guild_id,
+            }
+        } else {
+            this.messageReference = null
+        }
+
         if(data.author) {
             if(data.author.discriminator !== "0000") {
                 this.author = client.users.add(data.author, client);
@@ -103,7 +114,9 @@ class Message extends Base {
             data.content = `${this.author.mention} just boosted the server!`;
         } else if(this.type === 9 || this.type === 10 || this.type === 11) {
             data.content = `${this.author.mention} just boosted the server! ${this.channel.guild ? this.channel.guild.name : data.guild_id} has achieved **Level ${this.type - 8}!**`;
-        }  else {
+        } else if(this.type === 12) {
+            data.content = `${this.author.mention} has added <#${this.messageReference && this.messageReference.channelId}> to this channel`;
+        } else {
             client.emit("warn", "Unhandled MESSAGE_CREATE type: " + JSON.stringify(data, null, 2));
         }
 


### PR DESCRIPTION
This PR adds support for the new channel follow feature according to: discordapp/discord-api-docs#1051

This was tested so it support messageCreate type 12 and adds the new `messageReference` and `flags` properties to the message object.

A MessageFlags constant is also added in the Constants file.