### PR TITLE
Add the guild property onto Guild channels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,7 +20,9 @@ declare module "eris" {
 
   type TextableChannel = TextChannel | PrivateChannel | GroupChannel;
   type AnyChannel = TextChannel | VoiceChannel | CategoryChannel | PrivateChannel | GroupChannel;
-  type AnyGuildChannel = TextChannel | VoiceChannel | CategoryChannel;
+  type AnyGuildChannel = (TextChannel | VoiceChannel | CategoryChannel) & {
+    guild: Guild
+  };
 
   interface CreateInviteOptions {
     maxAge?: number;


### PR DESCRIPTION
This adds a "guild" property onto of the channels from a Guild, which keeps these typings in line with the documentation at https://abal.moe/Eris/. I've discussed this at length with members of the Discord API channel at https://discordapp.com/channels/81384788765712384/381890266052689920/616695091935051792.