### PR TITLE
Update to guild#createChannel

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -238,11 +238,17 @@ class Guild extends Base {
     * @arg {String} name The name of the channel
     * @arg {String} [type=0] The type of the channel, either 0 (text), 2 (voice), or 4 (category)
     * @arg {String} [reason] The reason to be displayed in audit logs
-    * @arg {String} [parentID] ID of the parent category for a channel
+    * @arg {Object} [options] The properties the channel should have
+    * @arg {String} [options.topic] The topic of the channel (text channels only)
+    * @arg {Boolean} [options.nsfw] The nsfw status of the channel
+    * @arg {Number} [options.bitrate] The bitrate of the channel (voice channels only)
+    * @arg {Number} [options.userLimit] The channel user limit (voice channels only)
+    * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
+    * @arg {String?} [options.parentID] The ID of the parent channel category for this channel
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}
     */
-    createChannel(name, type, reason, parentID) {
-        return this.shard.client.createChannel.call(this.shard.client, this.id, name, type, reason, parentID);
+    createChannel(name, type, reason, options) {
+        return this.shard.client.createChannel.call(this.shard.client, this.id, name, type, reason, options);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -236,7 +236,7 @@ class Guild extends Base {
     /**
     * Create a channel in the guild
     * @arg {String} name The name of the channel
-    * @arg {String} [type=0] The type of the channel, either 0 or 2
+    * @arg {String} [type=0] The type of the channel, either 0 (text), 2 (voice), or 4 (category)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @arg {String} [parentID] ID of the parent category for a channel
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}


### PR DESCRIPTION
I updated guild#createChannel documentation, as you can also create channel categories with this method.

While I was there, I updated the method options to be in line with those on client#createChannel. 
This maintains backwards compatibility of passing a string to be a parentID, as this check exists inside the client method from before.