### PR TITLE
Fixed member objects having no id when using REST

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -40,7 +40,7 @@ const VoiceState = require("./VoiceState");
 */
 class Member extends Base {
     constructor(data, guild, client) {
-        super(data.id);
+        super(data.id || data.user.id);
         if((this.guild = guild)) {
             this.user = guild.shard.client.users.get(data.id);
             if(!this.user && data.user) {


### PR DESCRIPTION
Requesting a guild member via REST mode results in the returning member object having no base ID, since the member data coming from Discord has no base ID. This PR simply instantiates the base class with the user ID of said member data instead.