### PR TITLE
Add permissionOverwrites option when creating guild channels

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -379,7 +379,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.userLimit] The channel user limit (voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel
-    * @arg {Array} [options.permissionOverwrites] An array containing overwrite objects
+    * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}
     */
     createChannel(guildID, name, type, reason, options = {}) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -379,6 +379,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.userLimit] The channel user limit (voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel
+    * @arg {Array} [options.permissionOverwrites] An array containing overwrite objects
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}
     */
     createChannel(guildID, name, type, reason, options = {}) {
@@ -397,7 +398,8 @@ class Client extends EventEmitter {
             bitrate: options.bitrate,
             user_limit: options.userLimit,
             rate_limit_per_user: options.rateLimitPerUser,
-            parent_id: options.parentID
+            parent_id: options.parentID,
+            permission_overwrites: options.permissionOverwrites
         }).then((channel) => {
             if(channel.type === 2) {
                 return new VoiceChannel(channel, guild);

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -245,7 +245,7 @@ class Guild extends Base {
     * @arg {Number} [options.userLimit] The channel user limit (voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel
-    * @arg {Array} [options.permissionOverwrites] An array containing overwrite objects
+    * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}
     */
     createChannel(name, type, reason, options) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -245,6 +245,7 @@ class Guild extends Base {
     * @arg {Number} [options.userLimit] The channel user limit (voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel
+    * @arg {Array} [options.permissionOverwrites] An array containing overwrite objects
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel>}
     */
     createChannel(name, type, reason, options) {


### PR DESCRIPTION
Adds the option to specify an array of overwrite objects to be applied when creating a guild channel as specified in the [Discord API Documentation](https://discordapp.com/developers/docs/resources/guild#create-guild-channel).

I'm not experienced with writing typings for TypeScript, so I did not update any of those.