### PR TITLE
Allow Eris() for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,7 @@ import { EventEmitter } from "events";
 import { Readable as ReadableStream } from "stream";
 import { Agent as HTTPSAgent } from "https";
 
-declare function Eris(token?: string, options?: Eris.ClientOptions): Eris.Client;
-
-export = Eris;
+declare function Eris(token: string, options?: Eris.ClientOptions): Eris.Client;
 
 declare namespace Eris {
   // TODO good hacktoberfest PR: implement ShardManager, RequestHandler and other stuff
@@ -1646,3 +1644,5 @@ declare namespace Eris {
     public unregisterCommand(label: string): void;
   }
 }
+
+export = Eris;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,13 @@
-declare module "eris" {
+import { EventEmitter } from "events";
+import { Readable as ReadableStream } from "stream";
+import { Agent as HTTPSAgent } from "https";
+
+declare function Eris(token?: string, options?: Eris.ClientOptions): Eris.Client;
+
+export = Eris;
+
+declare namespace Eris {
   // TODO good hacktoberfest PR: implement ShardManager, RequestHandler and other stuff
-  import { EventEmitter } from "events";
-  import { Readable as ReadableStream } from "stream";
-  import { Agent as HTTPAgent } from "http";
-  import { Agent as HTTPSAgent } from "https";
 
   export const VERSION: string;
   interface JSONCache { [s: string]: any; }
@@ -463,7 +467,7 @@ declare module "eris" {
     defaultImageSize?: number;
     ws?: any;
     latencyThreshold?: number;
-    agent?: HTTPAgent | HTTPSAgent
+    agent?: HTTPSAgent
   }
   interface CommandClientOptions {
     defaultHelpCommand?: boolean;


### PR DESCRIPTION
Also removed `HTTPAgent` because that wouldn't even have worked anyway.