### PR TITLE
Custom reconnect

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -445,6 +445,7 @@ declare namespace Eris {
   }
   type PossiblyUncachedMessage = Message | { id: string, channel: TextableChannel };
   interface RawPacket { op: number; t?: string; d?: any; s?: number; }
+  type ReconnectDelayFunction = (lastDelay: number, attempts: number) => number;
   interface ClientOptions {
     autoreconnect?: boolean;
     compress?: boolean;
@@ -465,7 +466,9 @@ declare namespace Eris {
     defaultImageSize?: number;
     ws?: any;
     latencyThreshold?: number;
-    agent?: HTTPSAgent
+    agent?: HTTPSAgent;
+    reconnectAttempts: number;
+    reconnectDelay: ReconnectDelayFunction;
   }
   interface CommandClientOptions {
     defaultHelpCommand?: boolean;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -98,6 +98,8 @@ class Client extends EventEmitter {
     * @arg {Number} [options.defaultImageSize=128] The default size to return user avatars, guild icons, banners, splashes, and group icons. Can be any power of two between 16 and 2048. If the height and width are different, the width will be the value specified, and the height relative to that
     * @arg {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
     * @arg {Object} [options.agent] A HTTP Agent used to proxy requests
+    * @arg {Number} [options.maxReconnectAttempts=Infinity] The maximum amount of times that the client is allowed to try to reconnect to Discord.
+    * @arg {Function} [options.reconnectDelay] A function which returns how long the bot should wait until reconnecting to Discord.
     */
     constructor(token, options) {
         super();
@@ -124,7 +126,9 @@ class Client extends EventEmitter {
             restMode: false,
             seedVoiceConnections: false,
             ws: {},
-            agent: null
+            agent: null,
+            maxReconnectAttempts: Infinity,
+            reconnectDelay: (lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000
         }, options);
         if(this.options.lastShardID === undefined && this.options.maxShards !== "auto") {
             this.options.lastShardID = this.options.maxShards - 1;
@@ -177,6 +181,8 @@ class Client extends EventEmitter {
         this.voiceConnections = new VoiceConnectionManager();
 
         this.connect = this.connect.bind(this);
+        this.lastReconnectDelay = 0;
+        this.reconnectAttempts = 0;
     }
 
     get uptime() {
@@ -222,8 +228,10 @@ class Client extends EventEmitter {
             if(!this.options.autoreconnect) {
                 throw err;
             }
-            this.emit("error", err);
-            await sleep(2000);
+            const reconnectDelay = this.options.reconnectDelay(this.lastReconnectDelay, this.reconnectAttempts);
+            await sleep(reconnectDelay);
+            this.lastReconnectDelay = reconnectDelay;
+            this.reconnectAttempts = this.reconnectAttempts + 1;
             return this.connect();
         }
     }


### PR DESCRIPTION
- Added ClientOptions.maxReconnectAttempts
- Added ClientOptions.reconnectDelay

N.B. The reconnect number starts at 0
N.B. If connect() fails in any way, the error will be caught and the connection will retry until maxReconnectAttempts is met.

The default increases by `(n+1)^0.7 * 20000ms` where `n` is the amount of previous reconnects.
i.e.
Attempt    | Timeout
0               | 20000ms
1               | 32490ms
2               | 43153ms
3               | 52780ms
4               | 61703ms


