### PR TITLE
channelMentions is never undefined

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1315,7 +1315,7 @@ declare module "eris" {
     public content: string;
     public cleanContent?: string;
     public roleMentions: string[];
-    public channelMentions?: string[];
+    public channelMentions: string[];
     public editedTimestamp?: number;
     public tts: boolean;
     public mentionEveryone: boolean;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -17,7 +17,7 @@ const User = require("./User");
 * @prop {String} content Message content
 * @prop {String?} cleanContent Message content with mentions replaced by names, and @everyone/@here escaped
 * @prop {String[]} roleMentions Array of mentioned roles' ids
-* @prop {String[]?} channelMentions Array of mentions channels' ids
+* @prop {String[]} channelMentions Array of mentions channels' ids
 * @prop {Number?} editedTimestamp Timestamp of latest message edit
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
@@ -25,7 +25,7 @@ const User = require("./User");
 * @prop {String} messageReference.messageID The id of the original message this message was crossposted from
 * @prop {String} messageReference.channelID The id of the channel this message was crossposted from
 * @prop {String} messageReference.guildID The id of the guild this message was crossposted from
-* @prop {Number} flags Message flags (see constants) 
+* @prop {Number} flags Message flags (see constants)
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
 * @prop {Object?} activity The activity specified in the message


### PR DESCRIPTION
This PR fixes the typings and JSDocs stating that `message.channelMentions` can be optional/undefined.

Based on the getter this can never be undefined. It will always return an array.
![image](https://user-images.githubusercontent.com/23035000/67639150-becd9a00-f8c2-11e9-8611-a3291bd7c704.png)
