### PR TITLE
Fix incorrect typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1093,7 +1093,7 @@ declare namespace Eris {
     public createChannel(name: string, type: 0, parentID?: string): Promise<TextChannel>;
     public createChannel(name: string, type: 2, parentID?: string): Promise<VoiceChannel>;
     public createChannel(name: string, type: 4, parentID?: string): Promise<CategoryChannel>;
-    public createChannel(name: string, type: number, parentID?: string): Promise<unknown>;
+    public createChannel(name: string, type?: number, parentID?: string): Promise<unknown>;
     public createEmoji(
       options: { name: string, image: string, roles?: string[] },
       reason?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -569,10 +569,29 @@ declare namespace Eris {
     public createChannel(
       guildID: string,
       name: string,
-      type?: number,
+    ): Promise<TextChannel>;
+    public createChannel(
+      guildID: string,
+      name: string,
+      type: 0,
+    ): Promise<TextChannel>;
+    public createChannel(
+      guildID: string,
+      name: string,
+      type: 2,
+    ): Promise<VoiceChannel>;
+    public createChannel(
+      guildID: string,
+      name: string,
+      type: 4
+    ): Promise<CategoryChannel>;
+    public createChannel(
+      guildID: string,
+      name: string,
+      type: number,
       reason?: string,
       parentID?: string,
-    ): Promise<AnyGuildChannel>;
+    ): Promise<unknown>;
     public editChannel(channelID: string, options: {
       name?: string,
       icon?: string,
@@ -1070,7 +1089,11 @@ declare namespace Eris {
     public constructor(data: BaseData, client: Client);
     public fetchAllMembers(): void;
     public dynamicIconURL(format: string, size: number): string;
-    public createChannel(name: string, type: string, parentID?: string): Promise<AnyGuildChannel>;
+    public createChannel(name: string): Promise<TextChannel>;
+    public createChannel(name: string, type: 0, parentID?: string): Promise<TextChannel>;
+    public createChannel(name: string, type: 2, parentID?: string): Promise<VoiceChannel>;
+    public createChannel(name: string, type: 4, parentID?: string): Promise<CategoryChannel>;
+    public createChannel(name: string, type: number, parentID?: string): Promise<unknown>;
     public createEmoji(
       options: { name: string, image: string, roles?: string[] },
       reason?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -574,16 +574,22 @@ declare namespace Eris {
       guildID: string,
       name: string,
       type: 0,
+      reason?: string,
+      parentID?: string,
     ): Promise<TextChannel>;
     public createChannel(
       guildID: string,
       name: string,
       type: 2,
+      reason?: string,
+      parentID?: string,
     ): Promise<VoiceChannel>;
     public createChannel(
       guildID: string,
       name: string,
-      type: 4
+      type: 4,
+      reason?: string,
+      parentID?: string,
     ): Promise<CategoryChannel>;
     public createChannel(
       guildID: string,
@@ -1090,10 +1096,10 @@ declare namespace Eris {
     public fetchAllMembers(): void;
     public dynamicIconURL(format: string, size: number): string;
     public createChannel(name: string): Promise<TextChannel>;
-    public createChannel(name: string, type: 0, parentID?: string): Promise<TextChannel>;
-    public createChannel(name: string, type: 2, parentID?: string): Promise<VoiceChannel>;
-    public createChannel(name: string, type: 4, parentID?: string): Promise<CategoryChannel>;
-    public createChannel(name: string, type?: number, parentID?: string): Promise<unknown>;
+    public createChannel(name: string, type: 0, reason?: string, parentID?: string): Promise<TextChannel>;
+    public createChannel(name: string, type: 2, reason?: string, parentID?: string): Promise<VoiceChannel>;
+    public createChannel(name: string, type: 4, reason?: string, parentID?: string): Promise<CategoryChannel>;
+    public createChannel(name: string, type?: number, reason?: string, parentID?: string): Promise<unknown>;
     public createEmoji(
       options: { name: string, image: string, roles?: string[] },
       reason?: string,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1346,7 +1346,7 @@ declare namespace Eris {
     public content: string;
     public cleanContent?: string;
     public roleMentions: string[];
-    public channelMentions?: string[];
+    public channelMentions: string[];
     public editedTimestamp?: number;
     public tts: boolean;
     public mentionEveryone: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -588,7 +588,7 @@ declare namespace Eris {
     public createChannel(
       guildID: string,
       name: string,
-      type: number,
+      type?: number,
       reason?: string,
       parentID?: string,
     ): Promise<unknown>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1202,7 +1202,7 @@ declare namespace Eris {
   }
 
   export class CategoryChannel extends GuildChannel {
-    public channels?: Collection<AnyGuildChannel>;
+    public channels: Collection<TextChannel | VoiceChannel>;
   }
 
   export class TextChannel extends GuildChannel implements Textable, Invitable {

--- a/lib/structures/CategoryChannel.js
+++ b/lib/structures/CategoryChannel.js
@@ -15,7 +15,7 @@ const GuildChannel = require("./GuildChannel");
 * @prop {Number} position The position of the channel
 * @prop {Boolean} nsfw Whether the channel is an NSFW channel or not
 * @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
-* @prop {Collection<GuildChannel>?} channels A collection of guild channels that are part of this category
+* @prop {Collection<GuildChannel>} channels A collection of guild channels that are part of this category
 */
 class CategoryChannel extends GuildChannel {
     constructor(data, guild) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -236,7 +236,7 @@ class Guild extends Base {
     /**
     * Create a channel in the guild
     * @arg {String} name The name of the channel
-    * @arg {String} [type=0] The type of the channel, either 0 (text), 2 (voice), or 4 (category)
+    * @arg {Number} [type=0] The type of the channel, either 0 (text), 2 (voice), or 4 (category)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @arg {Object} [options] The properties the channel should have
     * @arg {String} [options.topic] The topic of the channel (text channels only)

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -17,7 +17,7 @@ const User = require("./User");
 * @prop {String} content Message content
 * @prop {String?} cleanContent Message content with mentions replaced by names, and @everyone/@here escaped
 * @prop {String[]} roleMentions Array of mentioned roles' ids
-* @prop {String[]?} channelMentions Array of mentions channels' ids
+* @prop {String[]} channelMentions Array of mentions channels' ids
 * @prop {Number?} editedTimestamp Timestamp of latest message edit
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Boolean} mentionEveryone Whether the message mentions everyone/here or not
@@ -25,7 +25,7 @@ const User = require("./User");
 * @prop {String} messageReference.messageID The id of the original message this message was crossposted from
 * @prop {String} messageReference.channelID The id of the channel this message was crossposted from
 * @prop {String} messageReference.guildID The id of the guild this message was crossposted from
-* @prop {Number} flags Message flags (see constants) 
+* @prop {Number} flags Message flags (see constants)
 * @prop {Object[]} attachments Array of attachments
 * @prop {Object[]} embeds Array of embeds
 * @prop {Object?} activity The activity specified in the message


### PR DESCRIPTION
This PR fixes the createChannel typings.

1. The current typings make it impossible for anyone to create a channel as it expects a `string` and Typescript throws errors because in reality it requires a number. Not being able to pass a number is preventing me from making channels. **HIGH PRIORITY PLEASE** Can we consider hotpatching this into master as its only typings changes but its a massive issue. 🙏 
![image](https://user-images.githubusercontent.com/23035000/67643520-d02c9b80-f8ee-11e9-914d-e9d91a760760.png)

2. Although it is labelled as an optional at the moment, the `type` is required making it incorrect as well. This should also be fixed now to make it properly optional.
![image](https://user-images.githubusercontent.com/23035000/67643584-71b3ed00-f8ef-11e9-9451-6bf182f3a1f4.png)

3. `reason` is a parameter and was not present in the typings. It is now.

4. Added some overloads to the typings for createChannel for it to be much cleaner for TS devs. Now depending on the `type` that is provided, it will return the proper Channel Type as well. 
- Providing no type or providing the 0 type will return TextChannel
![image](https://user-images.githubusercontent.com/23035000/67643473-54caea00-f8ee-11e9-9e6a-800d9507aceb.png)
- Providing 2 will return VoiceChannel
![image](https://user-images.githubusercontent.com/23035000/67643485-71672200-f8ee-11e9-81f3-6056d5f395a0.png)
- Providing 4 will return the CategoryChannel
![image](https://user-images.githubusercontent.com/23035000/67643497-8479f200-f8ee-11e9-9862-64e615227c03.png)
- Providing any other number will return `unknown`. Let me know if you would prefer to keep this as `<AnyGuildChannel>`

---

This PR also fixes the following:
- channelMentions typings and JSDocs. ChannelMentions can never be undefined.
- category.channels can never be undefined it will always be a collection. Also changed categor.channels from returning a `Collection<AnyGuildChannel>` => `Collection<TextChannel | VoiceChannel>` 