### PR TITLE
Prevent Member.activities to be overriden by undefined values

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -62,7 +62,7 @@ class Member extends Base {
         this.game = data.game !== undefined ? data.game : this.game || null;
         this.joinedAt = data.joined_at !== undefined ? Date.parse(data.joined_at) : this.joinedAt;
         this.clientStatus = data.client_status !== undefined ? Object.assign({web: "offline", desktop: "offline", mobile: "offline"}, data.client_status) : this.clientStatus;
-        this.activities = data.activities;
+        this.activities = data.activities !== undefined ? data.activities : this.activities;
         this.premiumSince = data.premium_since !== undefined ? data.premium_since : this.premiumSince;
 
         if("mute" in data) {


### PR DESCRIPTION
This PR adds a test to make sure we are not overriding the `Member.activities` property with undefined value on update.
Here we will only override it if `data.activities` is defined.