### PR TITLE
typings fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -644,7 +644,7 @@ declare namespace Eris {
       reason?: string,
     ): Promise<Webhook>;
     public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true; }): Promise<Message>;
-    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait?: false; ): Promise<void>;
+    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait?: false; }): Promise<void>;
     public executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean }): Promise<void>;
     public deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;
     public getGuildWebhooks(guildID: string): Promise<Webhook[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -643,7 +643,7 @@ declare namespace Eris {
       token?: string,
       reason?: string,
     ): Promise<Webhook>;
-    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true; }): Promise<Eris.Message>;
+    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true; }): Promise<Message>;
     public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait?: false; ): Promise<void>;
     public executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean }): Promise<void>;
     public deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -644,7 +644,7 @@ declare namespace Eris {
       reason?: string,
     ): Promise<Webhook>;
     public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true; }): Promise<Message>;
-    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait?: false; }): Promise<void>;
+    public executeWebhook(webhookID: string, token: string, options: WebhookPayload): Promise<void>;
     public executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean }): Promise<void>;
     public deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;
     public getGuildWebhooks(guildID: string): Promise<Webhook[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1147,7 +1147,7 @@ declare namespace Eris {
     public delete(): Promise<void>;
     public leave(): Promise<void>;
     public getBans(): Promise<{ reason?: string, user: User }[]>;
-    public getBan(): Promise<{ reason?: string, user: User }>;
+    public getBan(userID: string): Promise<{ reason?: string, user: User }>;
     public editNickname(nick: string): Promise<void>;
     public getWebhooks(): Promise<Webhook[]>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -643,7 +643,8 @@ declare namespace Eris {
       token?: string,
       reason?: string,
     ): Promise<Webhook>;
-    public executeWebhook(webhookID: string, token: string, options: WebhookPayload): Promise<void>;
+    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true; }): Promise<Eris.Message>;
+    public executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait?: false; ): Promise<void>;
     public executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean }): Promise<void>;
     public deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;
     public getGuildWebhooks(guildID: string): Promise<Webhook[]>;


### PR DESCRIPTION
## Return a Message object when wait is true on executeWebhook
When setting `wait` to true, it should say that it returns a Message object, like it does. This can be accomplished via an intersection (&) to still include an interface, or directly with a property.
```typescript
function a(params: value, specificProp: specificValue): specificReturn;
function a(params: value, specificProp: otherValue): otherReturn;


function b(params: value, specificProp: Interface & { overrideProp: specificValue; }): specificReturn;
function b(params: value, specificProp: Interface & { overrideProp: otherValue; } ): otherReturn;
```
just makes it return a different type whenever that property is that specific value, ex:
```typescript
interface Payload {
	id?: string;
	wait?: boolean;
}

function j(s: string, j: string, o: Payload & { wait: true }): Promise<null>;
function j(s: string, j: string, o: Payload & { wait?: false }): Promise<void>;
function j(s: string, j: string, o: Payload): Promise<null | void> {
	return;
}

j(null, null, { wait: true }); // null
j(null, null, { wait: false }); // void
j(null, null, {}); // void
```
[true (first)](https://butts-are.cool/Code_-_Insiders_NMbyVdjHia.png)
[false (second)](https://butts-are.cool/Code_-_Insiders_PeemMiJEVS.png)
[none (third)](https://butts-are.cool/Code_-_Insiders_lXg92MjFgQ.png)
The return on the function implementation gets thrown out because of the overrides, though the return would be ideally a union of all the possible returns, at least in my opinion, i.e. `void | Message`

## add "userID" property on Guild.getBan()
`Guid.getBan()` is missing the `userID` property, effectively making it useless.