### PR TITLE
Fix typings typos

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1330,6 +1330,7 @@ declare namespace Eris {
         userLimit?: number;
         rateLimitPerUser?: number;
         nsfw?: boolean;
+        parentID?: string;
       },
       reason?: string
     ): Promise<AnyGuildChannel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1539,7 +1539,7 @@ declare namespace Eris {
 
   interface Overwrite {
     id: string;
-    type: "user" | "member";
+    type: "role" | "member";
     allow: number;
     deny: number;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -372,7 +372,7 @@ declare namespace Eris {
     thumbnail?: { url?: string; proxy_url?: string; height?: number; width?: number };
     video?: { url: string; height?: number; width?: number };
     provider?: { name: string; url?: string };
-    fields?: { name?: string; value?: string; inline?: boolean }[];
+    fields?: { name: string; value: string; inline?: boolean }[];
     author?: { name: string; url?: string; icon_url?: string; proxy_icon_url?: string };
   }
   type Embed = {

--- a/index.d.ts
+++ b/index.d.ts
@@ -372,7 +372,7 @@ declare namespace Eris {
     thumbnail?: { url?: string; proxy_url?: string; height?: number; width?: number };
     video?: { url: string; height?: number; width?: number };
     provider?: { name: string; url?: string };
-    fields?: Array<{ name?: string; value?: string; inline?: boolean }>;
+    fields?: Array<{ name: string; value: string; inline?: boolean }>;
     author?: { name: string; url?: string; icon_url?: string; proxy_icon_url?: string };
   }
   type Embed = {

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -86,6 +86,7 @@ class GuildChannel extends Channel {
     * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
     * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text channels only)
+    * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild channels only)
     * @arg {Number?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel | NewsChannel>}

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -86,7 +86,7 @@ class GuildChannel extends Channel {
     * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
     * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text channels only)
-    * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild channels only)
+    * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild text channels only)
     * @arg {Number?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel | NewsChannel>}

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -86,7 +86,7 @@ class GuildChannel extends Channel {
     * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
     * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text channels only)
-    * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild text channels only)
+    * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {Number?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel | NewsChannel>}


### PR DESCRIPTION
This PR fixes 2 more typos in the typings.

1. Overwrite types are `member` and `role`.
2. fields `name` and `value` are mandatory and can not be optional.