### PR TITLE
Speed up resume attempts

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -259,12 +259,12 @@ class Shard extends EventEmitter {
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
-                    // this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
+                    this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user.id);
                 if(member && JSON.stringify(member.game) === JSON.stringify(packet.d.game) && member.status === packet.d.status) {
-                    // this.emit("debug", "Duplicate presence update: " + JSON.stringify(packet));
+                    this.emit("debug", "Duplicate presence update: " + JSON.stringify(packet));
                     break;
                 }
                 let oldPresence = null;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -126,11 +126,16 @@ class Shard extends EventEmitter {
             * @prop {String} message The debug message
             * @prop {Number} id The ID of the shard
             */
-            this.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
-            setTimeout(() => {
+            if(this.sessionID) {
+                this.emit("debug", `Immediately reconnecting for potential resume | Attempt ${this.connectAttempts}`, this.id);
                 this.client.shards.connect(this);
-            }, this.sessionID ? 0 : this.reconnectInterval);
-            this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
+            } else {
+                this.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
+                setTimeout(() => {
+                    this.client.shards.connect(this);
+                }, this.reconnectInterval);
+                this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
+            }
         } else if(!options.reconnect) {
             this.hardReset();
         }
@@ -254,12 +259,12 @@ class Shard extends EventEmitter {
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
-                    this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
+                    // this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
                 }
                 let member = guild.members.get(packet.d.id = packet.d.user.id);
                 if(member && JSON.stringify(member.game) === JSON.stringify(packet.d.game) && member.status === packet.d.status) {
-                    this.emit("debug", "Duplicate presence update: " + JSON.stringify(packet));
+                    // this.emit("debug", "Duplicate presence update: " + JSON.stringify(packet));
                     break;
                 }
                 let oldPresence = null;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -129,7 +129,7 @@ class Shard extends EventEmitter {
             this.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
             setTimeout(() => {
                 this.client.shards.connect(this);
-            }, this.reconnectInterval);
+            }, this.sessionID ? 0 : this.reconnectInterval);
             this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
         } else if(!options.reconnect) {
             this.hardReset();
@@ -1633,8 +1633,10 @@ class Shard extends EventEmitter {
                     err = new Error("Gateway received invalid message");
                 } else if(event.code === 4003) {
                     err = new Error("Not authenticated");
+                    this.sessionID = null;
                 } else if(event.code === 4004) {
                     err = new Error("Authentication failed");
+                    this.sessionID = null;
                     reconnect = false;
                     this.emit("error", new Error(`Invalid token: ${this.client.token}`));
                 } else if(event.code === 4005) {
@@ -1649,9 +1651,11 @@ class Shard extends EventEmitter {
                     err = new Error("Gateway connection was ratelimited");
                 } else if(event.code === 4010) {
                     err = new Error("Invalid shard key");
+                    this.sessionID = null;
                     reconnect = false;
                 } else if(event.code === 4011) {
                     err = new Error("Shard has too many guilds (>2500)");
+                    this.sessionID = null;
                     reconnect = false;
                 } else if(event.code === 1006) {
                     err = new Error("Connection reset by peer");

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -19,7 +19,7 @@ class ShardManager extends Collection {
     }
 
     connect(shard) {
-        if(this.lastConnect <= Date.now() - 5000 && !this.find((shard) => shard.connecting)) {
+        if(shard.sessionID || (this.lastConnect <= Date.now() - 5000 && !this.find((shard) => shard.connecting))) {
             shard.connect();
             this.lastConnect = Date.now() + 7500;
         } else {


### PR DESCRIPTION
`RESUME` attempts are time-sensitive, and do not count towards the `IDENTIFY` rate limit. If a shard is potentially resumable (`sessionID` exists), it can bypass the reconnect queue.