### PR TITLE
Document flags for editMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -495,7 +495,7 @@ declare namespace Eris {
     [key: string]: {};
   }
 
-  type MessageContent = string | { content?: string; tts?: boolean; disableEveryone?: boolean; embed?: EmbedOptions };
+  type MessageContent = string | { content?: string; tts?: boolean; disableEveryone?: boolean; embed?: EmbedOptions; flags?: number };
   interface MessageFile {
     file: Buffer | string;
     name: string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1085,6 +1085,7 @@ class Client extends EventEmitter {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message
     * @returns {Promise<Message>}
     */
     editMessage(channelID, messageID, content) {
@@ -1102,7 +1103,7 @@ class Client extends EventEmitter {
                 content.content = content.content.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
             }
         }
-        return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content).then((message) => new Message(message, this));
+        return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true).then((message) => new Message(message, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1096,8 +1096,8 @@ class Client extends EventEmitter {
                 };
             } else if(content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
-            } else if(content.content === undefined && !content.embed) {
-                return Promise.reject(new Error("No content or embed"));
+            } else if(content.content === undefined && !content.embed && content.flags === undefined) {
+                return Promise.reject(new Error("No content, embed or flags"));
             }
             if(content.content && (content.disableEveryone !== undefined ? content.disableEveryone : this.options.disableEveryone)) {
                 content.content = content.content.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1049,7 +1049,7 @@ class Client extends EventEmitter {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(channelID, messageID, content) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1103,7 +1103,7 @@ class Client extends EventEmitter {
                 content.content = content.content.replace(/@everyone/g, "@\u200beveryone").replace(/@here/g, "@\u200bhere");
             }
         }
-        return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true).then((message) => new Message(message, this));
+        return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content).then((message) => new Message(message, this));
     }
 
     /**

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -226,7 +226,7 @@ class Message extends Base {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     edit(content) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -226,6 +226,7 @@ class Message extends Base {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message
     * @returns {Promise<Message>}
     */
     edit(content) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -118,7 +118,7 @@ class PrivateChannel extends Channel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -118,6 +118,7 @@ class PrivateChannel extends Channel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -165,6 +165,7 @@ class TextChannel extends GuildChannel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -162,7 +162,7 @@ class TextChannel extends GuildChannel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {


### PR DESCRIPTION
As documented in discordapp/discord-api-docs#1003 we can now pass flags in editMessage to set/unset SUPRESS_EMBED flags.
I simply documented this change since we can directly use content in the `editMessage` method to apply the flags to the message (`content.flags`).
The `editMessage` wasalso edited to allow passing only `content.flags`
*This PR also updates typings*

Note on `editMessage`:
- you can now edit a message by only passing flags
- editing a message without flags will let the current flags (as expected)
- editing a message with only `content.content` will just edit the content of the embed without affecting the embed (as expected)
- editing a message with only `content.embed` will just edit the embed without affecting the content (as expected)
- editing the embed of a message with the SUPRESS_EMBED flag will actually edit the embed and suppress it. Unsetting SUPPRESS_EMBED will then just show the embed again.