### PR TITLE
Change deprecated arguments syntax to rest parameters

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1856,10 +1856,10 @@ class Shard extends EventEmitter {
         return base;
     }
 
-    emit(event) {
-        this.client.emit.apply(this.client, arguments);
+    emit(event, ...args) {
+        this.client.emit.call(this.client, event, ...args);
         if(event !== "error" || this.listeners("error").length > 0) {
-            super.emit.apply(this, arguments);
+            super.emit.call(this, event, ...args);
         }
     }
 }


### PR DESCRIPTION
This PR updates the emit method in Shard.js to use rest parameters instead of `arguments` as `arguments` is deprecated (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/arguments).
I also switched the `.apply` to `.call` using spread syntax because `.call` is prefered in the rest of the lib but if that matters we can still use `.apply` with the `args` array directly.