### PR TITLE
Use Channel.from() in channel event handlers

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -874,13 +874,13 @@ class Shard extends EventEmitter {
                     }
                     let channel;
                     if(packet.d.type === 2) {
-                        channel = guild.channels.add(new VoiceChannel(packet.d, guild), guild);
+                        channel = guild.channels.add(new VoiceChannel(packet.d, this.client), guild);
                     } else if(packet.d.type === 4) {
-                        channel = guild.channels.add(new CategoryChannel(packet.d, guild), guild);
+                        channel = guild.channels.add(new CategoryChannel(packet.d, this.client), guild);
                     } else if(packet.d.type === 5) {
-                        channel = guild.channels.add(new NewsChannel(packet.d, guild), guild);
+                        channel = guild.channels.add(new NewsChannel(packet.d, this.client), guild);
                     } else if(packet.d.type === 0 || (packet.d.guild_id && packet.d.last_message_id !== undefined)) {
-                        channel = guild.channels.add(new TextChannel(packet.d, guild), guild);
+                        channel = guild.channels.add(new TextChannel(packet.d, this.client), guild);
                     } else {
                         channel = guild.channels.add(packet.d, guild);
                     }
@@ -941,16 +941,16 @@ class Shard extends EventEmitter {
                     if(guild) {
                         if(packet.d.type === 2) {
                             guild.channels.remove(channel);
-                            channel = guild.channels.add(new VoiceChannel(packet.d, guild), guild);
+                            channel = guild.channels.add(new VoiceChannel(packet.d, this.client), guild);
                         } else if(packet.d.type === 4) {
                             guild.channels.remove(channel);
-                            channel = guild.channels.add(new CategoryChannel(packet.d, guild), guild);
+                            channel = guild.channels.add(new CategoryChannel(packet.d, this.client), guild);
                         } else if(packet.d.type === 5) {
                             guild.channels.remove(channel);
-                            channel = guild.channels.add(new NewsChannel(packet.d, guild), guild);
+                            channel = guild.channels.add(new NewsChannel(packet.d, this.client), guild);
                         } else if(packet.d.type === 0 || packet.d.last_message_id !== undefined) {
                             guild.channels.remove(channel);
-                            channel = guild.channels.add(new TextChannel(packet.d, guild), guild);
+                            channel = guild.channels.add(new TextChannel(packet.d, this.client), guild);
                         }
                     }
                 }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2,16 +2,13 @@
 
 const Bucket = require("../util/Bucket");
 const Call = require("../structures/Call");
-const CategoryChannel = require("../structures/CategoryChannel");
+const Channel = require("../structures/Channel");
 const Constants = require("../Constants");
 const ExtendedUser = require("../structures/ExtendedUser");
 const Guild = require("../structures/Guild");
 const GuildChannel = require("../structures/GuildChannel");
 const OPCodes = Constants.GatewayOPCodes;
-const TextChannel = require("../structures/TextChannel");
-const NewsChannel = require("../structures/NewsChannel");
 const User = require("../structures/User");
-const VoiceChannel = require("../structures/VoiceChannel");
 let WebSocket = typeof window !== "undefined" ? window.WebSocket : require("ws");
 
 let EventEmitter;
@@ -868,19 +865,7 @@ class Shard extends EventEmitter {
                         this.emit("channelCreate", this.client.privateChannels.add(packet.d, this.client));
                     }
                 } else if(packet.d.guild_id) {
-                    let channel;
-                    if(packet.d.type === 2) {
-                        channel = new VoiceChannel(packet.d, this.client);
-                    } else if(packet.d.type === 4) {
-                        channel = new CategoryChannel(packet.d, this.client);
-                    } else if(packet.d.type === 5) {
-                        channel = new NewsChannel(packet.d, this.client);
-                    } else if(packet.d.type === 0 || (packet.d.guild_id && packet.d.last_message_id !== undefined)) {
-                        channel = new TextChannel(packet.d, this.client);
-                    } else {
-                        channel = packet.d;
-                        channel.guild = this.client.guilds.get(packet.d.guild_id);
-                    }
+                    const channel = Channel.from(packet.d, this.client);
                     if(!channel.guild || !(channel.guild instanceof Guild)) { // Safe guard: don't add channel if the guild isn't cached
                         this.emit("debug", `Missing guild ${packet.d.guild_id} in CHANNEL_CREATE`);
                         break;
@@ -938,21 +923,12 @@ class Shard extends EventEmitter {
                 if(oldType !== packet.d.type) {
                     this.emit("warn", `Channel ${packet.d.id} changed from type ${oldType} to ${packet.d.type}`);
                     if(packet.d.guild_id) {
-                        let newChannel;
-                        if(packet.d.type === 2) {
-                            newChannel = new VoiceChannel(packet.d, this.client);
-                        } else if(packet.d.type === 4) {
-                            newChannel = new CategoryChannel(packet.d, this.client);
-                        } else if(packet.d.type === 5) {
-                            newChannel = new NewsChannel(packet.d, this.client);
-                        } else if(packet.d.type === 0 || packet.d.last_message_id !== undefined) {
-                            newChannel = new TextChannel(packet.d, this.client);
-                        }
-                        if(!(newChannel.guild instanceof Guild)) {
+                        const newChannel = Channel.from(packet.d, this.client);
+                        if(newChannel.guild instanceof Guild) {
                             newChannel.guild.channels.remove(channel);
                             newChannel.guild.channels.add(newChannel, newChannel.guild);
+                            channel = newChannel;
                         }
-                        channel = newChannel;
                     }
                 }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -866,6 +866,9 @@ class Shard extends EventEmitter {
                     }
                 } else if(packet.d.guild_id) {
                     const channel = Channel.from(packet.d, this.client);
+                    if(!channel.guild) { // manually adds the guild if Channel.from didn't create a GuildChannel
+                        channel.guild = this.client.guilds.get(packet.d.guild_id);
+                    }
                     if(!channel.guild || !(channel.guild instanceof Guild)) { // Safe guard: don't add channel if the guild isn't cached
                         this.emit("debug", `Missing guild ${packet.d.guild_id} in CHANNEL_CREATE`);
                         break;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -5,6 +5,7 @@ const Call = require("../structures/Call");
 const CategoryChannel = require("../structures/CategoryChannel");
 const Constants = require("../Constants");
 const ExtendedUser = require("../structures/ExtendedUser");
+const Guild = require("../structures/Guild");
 const GuildChannel = require("../structures/GuildChannel");
 const OPCodes = Constants.GatewayOPCodes;
 const TextChannel = require("../structures/TextChannel");
@@ -867,26 +868,28 @@ class Shard extends EventEmitter {
                         this.emit("channelCreate", this.client.privateChannels.add(packet.d, this.client));
                     }
                 } else if(packet.d.guild_id) {
-                    const guild = this.client.guilds.get(packet.d.guild_id);
-                    if(!guild) {
+                    let channel;
+                    if(packet.d.type === 2) {
+                        channel = new VoiceChannel(packet.d, this.client);
+                    } else if(packet.d.type === 4) {
+                        channel = new CategoryChannel(packet.d, this.client);
+                    } else if(packet.d.type === 5) {
+                        channel = new NewsChannel(packet.d, this.client);
+                    } else if(packet.d.type === 0 || (packet.d.guild_id && packet.d.last_message_id !== undefined)) {
+                        channel = new TextChannel(packet.d, this.client);
+                    } else {
+                        channel = packet.d;
+                        channel.guild = this.client.guilds.get(packet.d.guild_id);
+                    }
+                    if(!channel.guild || !(channel.guild instanceof Guild)) { // Safe guard: don't add channel if the guild isn't cached
                         this.emit("debug", `Missing guild ${packet.d.guild_id} in CHANNEL_CREATE`);
                         break;
                     }
-                    let channel;
-                    if(packet.d.type === 2) {
-                        channel = guild.channels.add(new VoiceChannel(packet.d, this.client), guild);
-                    } else if(packet.d.type === 4) {
-                        channel = guild.channels.add(new CategoryChannel(packet.d, this.client), guild);
-                    } else if(packet.d.type === 5) {
-                        channel = guild.channels.add(new NewsChannel(packet.d, this.client), guild);
-                    } else if(packet.d.type === 0 || (packet.d.guild_id && packet.d.last_message_id !== undefined)) {
-                        channel = guild.channels.add(new TextChannel(packet.d, this.client), guild);
-                    } else {
-                        channel = guild.channels.add(packet.d, guild);
-                    }
+                    channel.guild.channels.add(channel, channel.guild);
+
                     this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
                     if(packet.d.parent_id) {
-                        if(!guild.channels.has(packet.d.parent_id)) {
+                        if(!channel.guild.channels.has(packet.d.parent_id)) {
                             this.emit("debug", `Missing category channel ${packet.d.parent_id} in CHANNEL_CREATE`);
                             break;
                         }
@@ -905,10 +908,6 @@ class Shard extends EventEmitter {
                 let channel = this.client.getChannel(packet.d.id);
                 if(!channel) {
                     break;
-                }
-                let guild;
-                if(packet.d.guild_id) {
-                    guild = this.client.guilds.get(packet.d.guild_id);
                 }
                 let oldChannel;
                 if(channel.type === 3) {
@@ -938,30 +937,32 @@ class Shard extends EventEmitter {
                 channel.update(packet.d);
                 if(oldType !== packet.d.type) {
                     this.emit("warn", `Channel ${packet.d.id} changed from type ${oldType} to ${packet.d.type}`);
-                    if(guild) {
+                    if(packet.d.guild_id) {
+                        let newChannel;
                         if(packet.d.type === 2) {
-                            guild.channels.remove(channel);
-                            channel = guild.channels.add(new VoiceChannel(packet.d, this.client), guild);
+                            newChannel = new VoiceChannel(packet.d, this.client);
                         } else if(packet.d.type === 4) {
-                            guild.channels.remove(channel);
-                            channel = guild.channels.add(new CategoryChannel(packet.d, this.client), guild);
+                            newChannel = new CategoryChannel(packet.d, this.client);
                         } else if(packet.d.type === 5) {
-                            guild.channels.remove(channel);
-                            channel = guild.channels.add(new NewsChannel(packet.d, this.client), guild);
+                            newChannel = new NewsChannel(packet.d, this.client);
                         } else if(packet.d.type === 0 || packet.d.last_message_id !== undefined) {
-                            guild.channels.remove(channel);
-                            channel = guild.channels.add(new TextChannel(packet.d, this.client), guild);
+                            newChannel = new TextChannel(packet.d, this.client);
                         }
+                        if(!(newChannel.guild instanceof Guild)) {
+                            newChannel.guild.channels.remove(channel);
+                            newChannel.guild.channels.add(newChannel, newChannel.guild);
+                        }
+                        channel = newChannel;
                     }
                 }
 
                 if(packet.d.parent_id) {
                     if(packet.d.parent_id !== channel.parentID) {
-                        if(!guild.channels.has(channel.parentID)) {
+                        if(!channel.guild.channels.has(channel.parentID)) {
                             break;
                         }
                     }
-                    if(!guild.channels.has(packet.d.parent_id)) {
+                    if(!channel.guild.channels.has(packet.d.parent_id)) {
                         this.emit("debug", `Missing category channel ${packet.d.parent_id} in UPDATE`);
                         break;
                     }


### PR DESCRIPTION
This PR changes the implementation of `CHANNEL_CREATE` and `CHANNEL_UPDATE` to works with changes in #565 .
Since the guild is resolved inside the channel constructor, I first instantiate the Channel and then check for the guild.

This change was tested and it works / actually fix the bug. However please double check that everything is fine.
I am also concerned about the instanceof check toknowif the Guild is valid (cached) or not. Maybe this can be replaced with checking specifically for one of the property always included in `Guild` (eg: `guild.name`)