### PR TITLE
allow null for member.edit({channeID: null})

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -538,7 +538,7 @@ declare namespace Eris {
     nick?: string;
     mute?: boolean;
     deaf?: boolean;
-    channelID?: string;
+    channelID?: string | null;
   }
   interface RoleOptions {
     name?: string;


### PR DESCRIPTION
This PR intends to allow users to be able to remove members from voice channels. Because `null` is not allowed to be a valid option in the typings, it is not possible to remove a member from a voice channel.