### PR TITLE
Fixes not passing client in Channel.from

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -871,6 +871,11 @@ class Shard extends EventEmitter {
                     }
                     channel.guild.channels.add(channel, this.client);
                     this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
+                    /**
+                    * Fired when a channel is created
+                    * @event Client#channelCreate
+                    * @prop {PrivateChannel | TextChannel | VoiceChannel | CategoryChannel | StoreChannel} channel The channel
+                    */
                     this.emit("channelCreate", channel);
                 } else if(channel instanceof PrivateChannel) {
                     if(channel instanceof GroupChannel) {
@@ -920,7 +925,7 @@ class Shard extends EventEmitter {
                     channel.update(packet.d);
                 } else {
                     this.emit("debug", `Channel ${packet.d.id} changed from type ${oldType} to ${packet.d.type}`);
-                    const newChannel = Channel.from(packet.d);
+                    const newChannel = Channel.from(packet.d, this.client);
                     if(packet.d.guild_id) {
                         const guild = this.client.guilds.get(packet.d.guild_id);
                         if(!guild) {
@@ -947,7 +952,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when a channel is updated
                 * @event Client#channelUpdate
-                * @prop {PrivateChannel | TextChannel | VoiceChannel | CategoryChannel} channel The updated channel
+                * @prop {PrivateChannel | TextChannel | VoiceChannel | CategoryChannel | StoreChannel} channel The updated channel
                 * @prop {Object} oldChannel The old channel data
                 * @prop {String} oldChannel.name The name of the channel
                 * @prop {Number} oldChannel.position The position of the channel

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -874,7 +874,7 @@ class Shard extends EventEmitter {
                     /**
                     * Fired when a channel is created
                     * @event Client#channelCreate
-                    * @prop {PrivateChannel | TextChannel | VoiceChannel | CategoryChannel | StoreChannel} channel The channel
+                    * @prop {TextChannel | VoiceChannel | CategoryChannel | StoreChannel | NewsChannel | GuildChannel | PrivateChannel} channel The channel
                     */
                     this.emit("channelCreate", channel);
                 } else if(channel instanceof PrivateChannel) {
@@ -952,7 +952,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when a channel is updated
                 * @event Client#channelUpdate
-                * @prop {PrivateChannel | TextChannel | VoiceChannel | CategoryChannel | StoreChannel} channel The updated channel
+                * @prop {TextChannel | VoiceChannel | CategoryChannel | StoreChannel | NewsChannel | GuildChannel | PrivateChannel} channel The updated channel
                 * @prop {Object} oldChannel The old channel data
                 * @prop {String} oldChannel.name The name of the channel
                 * @prop {Number} oldChannel.position The position of the channel


### PR DESCRIPTION
Fixes a missing parameter in b0c7a07 .
This brings the Channel.from update to a stable and working state.
Also re add the documentation for the `channelCreate` event that was removed.