### PR TITLE
feat: add commandNotFound event

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -187,6 +187,8 @@ class CommandClient extends Client {
                     }
                 }
             }
+        } else {
+            this.emit("commandNotFound", msg);
         }
     }
 


### PR DESCRIPTION
This PR adds a new event to the `CommandClient` called `commandNotFound`. It gets triggered when the CommandClient could not resolve the user's message to any of the existing commands. This offers the ability for developers to hook into this event to show a response to their users that it could not find a matching command. An example would be:

```
bot.on("commandNotFound", async (message) => {
  // can also inspect the message itself here as that gets passed along
  await message.channel.createMessage(`Sorry, that command does not exist`);
})
```

Unless I missed something, I could not find an existing way to have the bot handle non-existing commands when using the `CommandClient`.