### PR TITLE
Add support for self_stream field on voice state

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,7 @@ declare namespace Eris {
     deaf: boolean;
     selfMute: boolean;
     selfDeaf: boolean;
+    selfStream: boolean;
   }
 
   interface OAuthApplicationInfo {
@@ -1620,6 +1621,7 @@ declare namespace Eris {
     suppress: boolean;
     selfMute: boolean;
     selfDeaf: boolean;
+    selfStream: boolean;
     constructor(data: BaseData);
     toJSON(arg?: any, cache?: (string | any)[]): JSONCache;
   }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -338,7 +338,8 @@ class Shard extends EventEmitter {
                     mute: member.voiceState.mute,
                     deaf: member.voiceState.deaf,
                     selfMute: member.voiceState.selfMute,
-                    selfDeaf: member.voiceState.selfDeaf
+                    selfDeaf: member.voiceState.selfDeaf,
+                    selfStream: member.voiceState.selfStream
                 };
                 const oldChannelID = member.voiceState.channelID;
                 member.update(packet.d, this.client);
@@ -383,7 +384,7 @@ class Shard extends EventEmitter {
                         this.emit("voiceChannelLeave", oldChannel.voiceMembers.remove(member), oldChannel);
                     }
                 }
-                if(oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf) {
+                if(oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf || oldState.selfStream !== member.selfStream) {
                     /**
                     * Fired when a guild member's voice state changes
                     * @event Client#voiceStateUpdate
@@ -393,6 +394,7 @@ class Shard extends EventEmitter {
                     * @prop {Boolean} oldState.deaf The previous server deaf status
                     * @prop {Boolean} oldState.selfMute The previous self mute status
                     * @prop {Boolean} oldState.selfDeaf The previous self deaf status
+                    * @prop {Boolean} oldState.selfStream The previous self stream status
                     */
                     this.emit("voiceStateUpdate", member, oldState);
                 }

--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -32,7 +32,7 @@ class VoiceState extends Base {
         this.suppress = data.suppress !== undefined ? data.suppress : this.suppress || false; // Bots ignore this
         this.selfMute = data.self_mute !== undefined ? data.self_mute : this.selfMute || false;
         this.selfDeaf = data.self_deaf !== undefined ? data.self_deaf : this.selfDeaf || false;
-        this.selfStream = data.self_stream !== undefined ? data.self_stream : this.selfStream || false;
+        this.selfStream = data.self_stream || false;
     }
 
     toJSON(props = []) {

--- a/lib/structures/VoiceState.js
+++ b/lib/structures/VoiceState.js
@@ -12,6 +12,7 @@ const Base = require("./Base");
 * @prop {Boolean} suppress Whether the member is suppressed or not
 * @prop {Boolean} selfMute Whether the member is self muted or not
 * @prop {Boolean} selfDeaf Whether the member is self deafened or not
+* @prop {Boolean} selfStream Whether the member is streaming using "Go Live"
 */
 class VoiceState extends Base {
     constructor(data) {
@@ -31,6 +32,7 @@ class VoiceState extends Base {
         this.suppress = data.suppress !== undefined ? data.suppress : this.suppress || false; // Bots ignore this
         this.selfMute = data.self_mute !== undefined ? data.self_mute : this.selfMute || false;
         this.selfDeaf = data.self_deaf !== undefined ? data.self_deaf : this.selfDeaf || false;
+        this.selfStream = data.self_stream !== undefined ? data.self_stream : this.selfStream || false;
     }
 
     toJSON(props = []) {
@@ -40,6 +42,7 @@ class VoiceState extends Base {
             "mute",
             "selfMute",
             "selfDeaf",
+            "selfStream",
             "sessionID",
             "suppress",
             ...props


### PR DESCRIPTION
This PR implements support for self_stream field on voice state, otherwise known as Go Live

- [x] Fully tested
- [x] Typings Updated
- [x] JSDocs updated

![image](https://user-images.githubusercontent.com/23035000/69904858-4dc64a00-137a-11ea-8dda-404ef1d471f1.png)

Before user is online
![image](https://user-images.githubusercontent.com/23035000/69904925-40f62600-137b-11ea-9d59-607623d4e29d.png)


Once user is online
![image](https://user-images.githubusercontent.com/23035000/69905427-58381200-1381-11ea-9f89-4ae764ef9418.png)


Once user is offline or leaves the channel
![image](https://user-images.githubusercontent.com/23035000/69905431-5ff7b680-1381-11ea-8bb7-90680b513bce.png)
