### PR TITLE
Type fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -79,6 +79,8 @@ declare namespace Eris {
     type: 1 | 2 | 4 | 5 | 6;
     bitrate?: number;
     permissionOverwrites: Collection<PermissionOverwrite>;
+    parentID?: string;
+    rateLimitPerUser?: number;
   }
 
   type FriendSuggestionReasons = { type: number; platform_type: string; name: string }[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -663,7 +663,7 @@ declare namespace Eris {
       event: "channelRecipientAdd" | "channelRecipientRemove",
       listener: (channel: GroupChannel, user: User) => void
     ): T;
-    (event: "channelUpdate", listener: (channel: AnyChannel, oldChannel: GenericOldChannel & ({ type: 0; topic?: string; rateLimitPerUser: number; } | { type: 2; bitrate: number; } | { type: 5; topic?: string; rateLimitPerUser: 0 } | { type: 4 | 6; })) => void): T;
+    (event: "channelUpdate", listener: (channel: AnyChannel, oldChannel: GenericOldChannel & ({ type: 0; topic?: string; rateLimitPerUser: number } | { type: 2; bitrate: number } | { type: 5; topic?: string; rateLimitPerUser: 0 } | { type: 4 | 6 })) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
     (event: "guildAvailable" | "guildBanAdd" | "guildBanRemove", listener: (guild: Guild, user: User) => void): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -486,22 +486,22 @@ declare namespace Eris {
     banner?: string;
   }
   interface OldGuild {
-    name: string,
-    verificationLevel: 0 | 1 | 2 | 3 | 4,
-    splash?: string,
-    banner?: string,
-    region: string,
-    ownerID: string,
-    icon: string,
-    features: string[],
+    name: string;
+    verificationLevel: 0 | 1 | 2 | 3 | 4;
+    splash?: string;
+    banner?: string;
+    region: string;
+    ownerID: string;
+    icon: string;
+    features: string[];
     emojis: Emoji[],
-    afkChannelID?: string,
-    afkTimeout: number,
-    mfaLevel: 0 | 1,
-    large: boolean,
-    maxPresences?: number,
-    explicitContentFilter: 0 | 1 | 2,
-    systemChannelID?: string
+    afkChannelID?: string;
+    afkTimeout: number;
+    mfaLevel: 0 | 1;
+    large: boolean;
+    maxPresences?: number;
+    explicitContentFilter: 0 | 1 | 2;
+    systemChannelID?: string;
   }
   interface MemberOptions {
     roles?: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -73,13 +73,13 @@ declare namespace Eris {
 
   interface OldChannel {
     name: string;
-    position?: string;
-    nsfw?: boolean;
-    permissionOverwrites?: Collection<PermissionOverwrite>;
+    position: string;
+    nsfw: boolean;
+    permissionOverwrites: Collection<PermissionOverwrite>;
     parentID?: string;
     topic?: string;
     rateLimitPerUser?: number;
-    type?: 0 | 2 | 4 | 5 | 6;
+    type: 0 | 2 | 4 | 5 | 6;
   }
 
   type FriendSuggestionReasons = { type: number; platform_type: string; name: string }[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -491,7 +491,6 @@ declare namespace Eris {
     color?: number;
     hoist?: boolean;
     mentionable?: boolean;
-    managed?: boolean;
   }
 
   interface OldRole {

--- a/index.d.ts
+++ b/index.d.ts
@@ -494,7 +494,7 @@ declare namespace Eris {
     ownerID: string;
     icon: string;
     features: string[];
-    emojis: Emoji[],
+    emojis: Emoji[];
     afkChannelID?: string;
     afkTimeout: number;
     mfaLevel: 0 | 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -80,6 +80,7 @@ declare namespace Eris {
     topic?: string;
     rateLimitPerUser?: number;
     type: 0 | 2 | 4 | 5 | 6;
+    bitrate?: number;
   }
 
   type FriendSuggestionReasons = { type: number; platform_type: string; name: string }[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,6 @@ declare namespace Eris {
     name: string;
     position: string;
     nsfw: boolean;
-    type: 1 | 2 | 4 | 5 | 6;
     permissionOverwrites: Collection<PermissionOverwrite>;
     parentID?: string;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,12 +71,15 @@ declare namespace Eris {
     unavailable: boolean;
   }
 
-  interface GenericOldChannel {
+  interface OldChannel {
     name: string;
-    position: string;
-    nsfw: boolean;
-    permissionOverwrites: Collection<PermissionOverwrite>;
+    position?: string;
+    nsfw?: boolean;
+    permissionOverwrites?: Collection<PermissionOverwrite>;
     parentID?: string;
+    topic?: string;
+    rateLimitPerUser?: number;
+    type?: 0 | 2 | 4 | 5 | 6;
   }
 
   type FriendSuggestionReasons = { type: number; platform_type: string; name: string }[];
@@ -487,7 +490,19 @@ declare namespace Eris {
     color?: number;
     hoist?: boolean;
     mentionable?: boolean;
+    managed?: boolean;
   }
+
+  interface OldRole {
+    color: number;
+    hoist: boolean;
+    managed: boolean;
+    name: string;
+    permissions: Permission;
+    position: number;
+    mentionable: boolean;
+  }
+
   interface GamePresence {
     name: string;
     type?: number;
@@ -662,7 +677,7 @@ declare namespace Eris {
       event: "channelRecipientAdd" | "channelRecipientRemove",
       listener: (channel: GroupChannel, user: User) => void
     ): T;
-    (event: "channelUpdate", listener: (channel: AnyChannel, oldChannel: GenericOldChannel & ({ type: 0; topic?: string; rateLimitPerUser: number } | { type: 2; bitrate: number } | { type: 5; topic?: string; rateLimitPerUser: 0 } | { type: 4 | 6 })) => void): T;
+    (event: "channelUpdate", listener: (channel: AnyGuildChannel, oldChannel: OldChannel) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
     (event: "guildAvailable" | "guildBanAdd" | "guildBanRemove", listener: (guild: Guild, user: User) => void): T;
@@ -676,7 +691,7 @@ declare namespace Eris {
       listener: (guild: Guild, member: Member, oldMember: { roles: string[]; nick?: string }) => void
     ): T;
     (event: "guildRoleCreate" | "guildRoleDelete", listener: (guild: Guild, role: Role) => void): T;
-    (event: "guildRoleUpdate", listener: (guild: Guild, role: Role, oldRole: RoleOptions) => void): T;
+    (event: "guildRoleUpdate", listener: (guild: Guild, role: Role, oldRole: OldRole) => void): T;
     (event: "guildUpdate", listener: (guild: Guild, oldGuild: GuildOptions) => void): T;
     (event: "hello", listener: (trace: string[], id: number) => void): T;
     (event: "messageCreate", listener: (message: Message) => void): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -494,7 +494,7 @@ declare namespace Eris {
     ownerID: string;
     icon: string;
     features: string[];
-    emojis: (Omit<Emoji, "user" | "icon"> & { available: boolean; })[];
+    emojis: (Omit<Emoji, "user" | "icon"> & { available: boolean })[];
     afkChannelID?: string;
     afkTimeout: number;
     mfaLevel: 0 | 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -485,6 +485,24 @@ declare namespace Eris {
     splash?: string;
     banner?: string;
   }
+  interface OldGuild {
+    name: string,
+    verificationLevel: 0 | 1 | 2 | 3 | 4,
+    splash?: string,
+    banner?: string,
+    region: string,
+    ownerID: string,
+    icon: string,
+    features: string[],
+    emojis: Emoji[],
+    afkChannelID?: string,
+    afkTimeout: number,
+    mfaLevel: 0 | 1,
+    large: boolean,
+    maxPresences?: number,
+    explicitContentFilter: 0 | 1 | 2,
+    systemChannelID?: string
+  }
   interface MemberOptions {
     roles?: string[];
     nick?: string;
@@ -699,7 +717,7 @@ declare namespace Eris {
     ): T;
     (event: "guildRoleCreate" | "guildRoleDelete", listener: (guild: Guild, role: Role) => void): T;
     (event: "guildRoleUpdate", listener: (guild: Guild, role: Role, oldRole: OldRole) => void): T;
-    (event: "guildUpdate", listener: (guild: Guild, oldGuild: GuildOptions) => void): T;
+    (event: "guildUpdate", listener: (guild: Guild, oldGuild: OldGuild) => void): T;
     (event: "hello", listener: (trace: string[], id: number) => void): T;
     (event: "messageCreate", listener: (message: Message) => void): T;
     (event: "messageDelete" | "messageReactionRemoveAll", listener: (message: PossiblyUncachedMessage) => void): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,7 +74,9 @@ declare namespace Eris {
   interface OldChannel {
     name: string;
     position: string;
+    nsfw: boolean;
     topic?: string;
+    type: 1 | 2 | 4 | 5 | 6;
     bitrate?: number;
     permissionOverwrites: Collection<PermissionOverwrite>;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,7 +71,7 @@ declare namespace Eris {
     unavailable: boolean;
   }
 
-  interface OldChannel {
+  interface OldGuildChannel {
     name: string;
     position: string;
     nsfw: boolean;
@@ -702,7 +702,7 @@ declare namespace Eris {
       event: "channelRecipientAdd" | "channelRecipientRemove",
       listener: (channel: GroupChannel, user: User) => void
     ): T;
-    (event: "channelUpdate", listener: (channel: AnyGuildChannel, oldChannel: OldChannel) => void): T;
+    (event: "channelUpdate", listener: (channel: AnyGuildChannel, oldChannel: OldGuildChannel) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
     (event: "guildAvailable" | "guildBanAdd" | "guildBanRemove", listener: (guild: Guild, user: User) => void): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -71,16 +71,13 @@ declare namespace Eris {
     unavailable: boolean;
   }
 
-  interface OldChannel {
+  interface GenericOldChannel {
     name: string;
     position: string;
     nsfw: boolean;
-    topic?: string;
     type: 1 | 2 | 4 | 5 | 6;
-    bitrate?: number;
     permissionOverwrites: Collection<PermissionOverwrite>;
     parentID?: string;
-    rateLimitPerUser?: number;
   }
 
   type FriendSuggestionReasons = { type: number; platform_type: string; name: string }[];
@@ -666,7 +663,7 @@ declare namespace Eris {
       event: "channelRecipientAdd" | "channelRecipientRemove",
       listener: (channel: GroupChannel, user: User) => void
     ): T;
-    (event: "channelUpdate", listener: (channel: AnyChannel, oldChannel: OldChannel) => void): T;
+    (event: "channelUpdate", listener: (channel: AnyChannel, oldChannel: GenericOldChannel & ({ type: 0; topic?: string; rateLimitPerUser: number; } | { type: 2; bitrate: number; } | { type: 5; topic?: string; rateLimitPerUser: 0 } | { type: 4 | 6; })) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
     (event: "guildAvailable" | "guildBanAdd" | "guildBanRemove", listener: (guild: Guild, user: User) => void): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -494,7 +494,7 @@ declare namespace Eris {
     ownerID: string;
     icon: string;
     features: string[];
-    emojis: Emoji[];
+    emojis: (Omit<Emoji, "user" | "icon"> & { available: boolean; })[];
     afkChannelID?: string;
     afkTimeout: number;
     mfaLevel: 0 | 1;


### PR DESCRIPTION
The `OldChannel` object, which is used in the [`channelUpdate`](https://github.com/abalabahaha/eris/blob/dev/index.d.ts#L665) event is missing the `nsfw`, and `type` properties, which are present in the [jsdoc](https://abal.moe/Eris/docs/Client#event-channelUpdate).