### PR TITLE
Allow embed timestamp to be Date in typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ declare namespace Eris {
     title?: string;
     description?: string;
     url?: string;
-    timestamp?: Date;
+    timestamp?: string | Date;
     color?: number;
     footer?: { text: string; icon_url?: string; proxy_icon_url?: string };
     image?: { url?: string; proxy_url?: string; height?: number; width?: number };

--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ declare namespace Eris {
     title?: string;
     description?: string;
     url?: string;
-    timestamp?: string | Date;
+    timestamp?: Date | string;
     color?: number;
     footer?: { text: string; icon_url?: string; proxy_icon_url?: string };
     image?: { url?: string; proxy_url?: string; height?: number; width?: number };

--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ declare namespace Eris {
     title?: string;
     description?: string;
     url?: string;
-    timestamp?: string | Date;
+    timestamp?: Date;
     color?: number;
     footer?: { text: string; icon_url?: string; proxy_icon_url?: string };
     image?: { url?: string; proxy_url?: string; height?: number; width?: number };

--- a/index.d.ts
+++ b/index.d.ts
@@ -316,7 +316,7 @@ declare namespace Eris {
     title?: string;
     description?: string;
     url?: string;
-    timestamp?: string;
+    timestamp?: string | Date;
     color?: number;
     footer?: { text: string; icon_url?: string; proxy_icon_url?: string };
     image?: { url?: string; proxy_url?: string; height?: number; width?: number };


### PR DESCRIPTION
Type should be `string | Date` in order to allow for doing `timestamp: new Date()`