### PR TITLE
fix voice channel leave docs/typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1125,7 +1125,7 @@ declare namespace Eris {
     limit?: number;
     constructor(baseObject: new (...args: any[]) => T, limit?: number);
     add(obj: T, extra?: any, replace?: boolean): T;
-    find(func: (i: T) => boolean): T;
+    find(func: (i: T) => boolean): T | undefined;
     random(): T;
     filter(func: (i: T) => boolean): T[];
     map<R>(func: (i: T) => R): R[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -724,7 +724,7 @@ declare namespace Eris {
       listener: (user: User, oldUser: { username: string; discriminator: string; avatar?: string }) => void
     ): T;
     (event: "voiceChannelJoin", listener: (member: Member, newChannel: VoiceChannel) => void): T;
-    (event: "voiceChannelLeave", listener: (member: Member, oldChannel: VoiceChannel) => void): T;
+    (event: "voiceChannelLeave", listener: (member: Member | null, oldChannel: VoiceChannel) => void): T;
     (
       event: "voiceChannelSwitch",
       listener: (member: Member, newChannel: VoiceChannel, oldChannel: VoiceChannel) => void

--- a/index.d.ts
+++ b/index.d.ts
@@ -724,7 +724,7 @@ declare namespace Eris {
       listener: (user: User, oldUser: { username: string; discriminator: string; avatar?: string }) => void
     ): T;
     (event: "voiceChannelJoin", listener: (member: Member, newChannel: VoiceChannel) => void): T;
-    (event: "voiceChannelLeave", listener: (member: Member | null, oldChannel: VoiceChannel) => void): T;
+    (event: "voiceChannelLeave", listener: (member: Member, oldChannel: VoiceChannel) => void): T;
     (
       event: "voiceChannelSwitch",
       listener: (member: Member, newChannel: VoiceChannel, oldChannel: VoiceChannel) => void

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -385,13 +385,14 @@ class Shard extends EventEmitter {
                             this.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
                     } else if(oldChannel) {
+                        oldChannel.voiceMembers.remove(member)
                         /**
                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
                         * @event Client#voiceChannelLeave
                         * @prop {?Member} member The member
                         * @prop {VoiceChannel} oldChannel The voice channel
                         */
-                        this.emit("voiceChannelLeave", oldChannel.voiceMembers.remove(member), oldChannel);
+                        this.emit("voiceChannelLeave", member, oldChannel);
                     }
                 }
                 if(oldState.mute !== member.mute || oldState.deaf !== member.deaf || oldState.selfMute !== member.selfMute || oldState.selfDeaf !== member.selfDeaf || oldState.selfStream !== member.selfStream) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -385,7 +385,7 @@ class Shard extends EventEmitter {
                             this.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
                     } else if(oldChannel) {
-                        oldChannel.voiceMembers.remove(member)
+                        oldChannel.voiceMembers.remove(member);
                         /**
                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
                         * @event Client#voiceChannelLeave

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -380,7 +380,7 @@ class Shard extends EventEmitter {
                             * Fired when a guild member joins a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
                             * @event Client#voiceChannelJoin
                             * @prop {Member} member The member
-                            * @prop {CategoryChannel | TextChannel | VoiceChannel} newChannel The voice channel
+                            * @prop {VoiceChannel} newChannel The voice channel
                             */
                             this.emit("voiceChannelJoin", newChannel.voiceMembers.add(member, guild), newChannel);
                         }
@@ -388,8 +388,8 @@ class Shard extends EventEmitter {
                         /**
                         * Fired when a guild member leaves a voice channel. This event is not fired when a member switches voice channels, see `voiceChannelSwitch`
                         * @event Client#voiceChannelLeave
-                        * @prop {Member} member The member
-                        * @prop {CategoryChannel | TextChannel | VoiceChannel} oldChannel The voice channel
+                        * @prop {?Member} member The member
+                        * @prop {VoiceChannel} oldChannel The voice channel
                         */
                         this.emit("voiceChannelLeave", oldChannel.voiceMembers.remove(member), oldChannel);
                     }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -370,8 +370,8 @@ class Shard extends EventEmitter {
                             * Fired when a guild member switches voice channels
                             * @event Client#voiceChannelSwitch
                             * @prop {Member} member The member
-                            * @prop {CategoryChannel | TextChannel | VoiceChannel} newChannel The new voice channel
-                            * @prop {CategoryChannel | TextChannel | VoiceChannel} oldChannel The old voice channel
+                            * @prop {VoiceChannel} newChannel The new voice channel
+                            * @prop {VoiceChannel} oldChannel The old voice channel
                             */
                             oldChannel.voiceMembers.remove(member);
                             this.emit("voiceChannelSwitch", newChannel.voiceMembers.add(member, guild), newChannel, oldChannel);


### PR DESCRIPTION
This PR always sends a valid `member`in `voiceChannelLeave` event. 
It also removes Category and Text Channels from the channel type in jsdocs
It also makes Collection.find() allowed to be undefined when there is nothing found.

![image](https://user-images.githubusercontent.com/23035000/70168530-110a9380-1697-11ea-9c2c-ca9a33b26080.png)

![image](https://user-images.githubusercontent.com/23035000/70168638-3f886e80-1697-11ea-9078-965eb389d871.png)


