### PR TITLE
Make IP discovery port parsing use big endian

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -255,7 +255,7 @@ class VoiceConnection extends EventEmitter {
                         while(++i < packet.indexOf(0, i)) {
                             localIP += String.fromCharCode(packet[i]);
                         }
-                        const localPort = parseInt(packet.readUIntLE(packet.length - 2, 2).toString(10));
+                        const localPort = parseInt(packet.readUIntBE(packet.length - 2, 2).toString(10));
 
                         this.sendWS(VoiceOPCodes.SELECT_PROTOCOL, {
                             protocol: "udp",


### PR DESCRIPTION
Even though the docs currently say that the port will be sent across little endian encoded,
this is incorrect. Without this fix, Discord won't send data to our UDP connection.

Fixes #592