### PR TITLE
Addition and improvements to Collection

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1156,11 +1156,11 @@ declare namespace Eris {
   export class Collection<T extends { id: string | number }> extends Map<string | number, T> {
     baseObject: new (...args: any[]) => T;
     limit?: number;
-    constructor(baseObject: new (...args: any[]) => T, limit?: number, iterable?: object | any[]);
+    constructor(baseObject: new (...args: T[]) => T, limit?: number, iterable?: object | T[]);
     static from(array: any[], key: string, limit: number): Collection<any>;
-    toArray(): any[];
+    toArray(): T[];
     toObject(): object;
-    apply(key: string, func: string, ...args: any[]): Collection<any>;
+    apply(key: string, func: string, ...args: any[]): Collection<T>;
     add(obj: T, extra?: any, replace?: boolean): T;
     find(func: (i: T) => boolean): T | undefined;
     random(): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1156,7 +1156,11 @@ declare namespace Eris {
   export class Collection<T extends { id: string | number }> extends Map<string | number, T> {
     baseObject: new (...args: any[]) => T;
     limit?: number;
-    constructor(baseObject: new (...args: any[]) => T, limit?: number);
+    constructor(baseObject: new (...args: any[]) => T, limit?: number, iterable?: object | any[]);
+    static from(array: any[], key: string): Collection<any>;
+    toArray(): any[];
+    toObject(): object;
+    apply(key: string, func: string, ...args: any[]): Collection<any>;
     add(obj: T, extra?: any, replace?: boolean): T;
     find(func: (i: T) => boolean): T | undefined;
     random(): T;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1157,7 +1157,7 @@ declare namespace Eris {
     baseObject: new (...args: any[]) => T;
     limit?: number;
     constructor(baseObject: new (...args: any[]) => T, limit?: number, iterable?: object | any[]);
-    static from(array: any[], key: string): Collection<any>;
+    static from(array: any[], key: string, limit: number): Collection<any>;
     toArray(): any[];
     toObject(): object;
     apply(key: string, func: string, ...args: any[]): Collection<any>;

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -10,12 +10,68 @@ class Collection extends Map {
     /**
     * Construct a Collection
     * @arg {Class} baseObject The base class for all items
-    * @arg {Number} [limit] Max number of items to hold
+    * @arg {Number} [limit=null] Max number of items to hold
+    * @arg {Object} [iterable=null] An iterable to initialise the Collection
     */
-    constructor(baseObject, limit) {
-        super();
+    constructor(baseObject, limit= null, iterable = null) {
+        if(iterable && iterable instanceof Array) {
+            super(iterable);
+        } else if(iterable && iterable instanceof Object) {
+            super(Object.entries(iterable) );
+        } else {
+            super();
+        }
+
         this.baseObject = baseObject;
         this.limit = limit;
+    }
+
+    /**
+     * Creates a collection from an array. Uses the first element instances as baseObject
+     *
+     * @static
+     * @param {Array<Class>} array The array of object
+     * @param {String} key The property to use as key
+     * @returns {Collection<Class>} A newly created Collection
+     */
+    static from(array, key) {
+        return new Collection( array[0].constructor, null, array.map((e) => [e[key], e] ) );
+    }
+
+    /**
+     * Return the Collection as an Array
+     * [value, value]
+     *
+     * @returns {Array<Class>} The Collection as an Array
+     */
+    toArray() {
+        return [...this.values()];
+    }
+
+    /**
+     * Returns the Collection as an Object
+     * { key: value, key: value }
+     *
+     * @returns {Object} The Collection as an Object
+     */
+    toObject() {
+        const obj = {};
+        for(const [key, value] of this.entries() ) {
+            obj[key] = value;
+        }
+        return obj;
+    }
+
+    /**
+     * Apply a function to the Collection and returns a new Collection
+     *
+     * @param {String} key The property to use as key for the new Collection
+     * @param {String} func The function name to apply to the Collection
+     * @param {Object} args All the argument that need to be applied to the Collection
+     * @returns {Collection} A new Collection modified by the apply call
+     */
+    apply(key, func, ...args) {
+        return new Collection( this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ) );
     }
 
     /**

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -27,34 +27,34 @@ class Collection extends Map {
     }
 
     /**
-     * Creates a collection from an array. Uses the first element instances as baseObject
-     *
-     * @static
-     * @param {Array<Class>} array The array of object
-     * @param {String} key The property to use as key
-     * @param {Number} [limit] The property to use as key
-     * @returns {Collection<Class>} A newly created Collection
-     */
+    * Creates a collection from an array. Uses the first element instances as baseObject
+    *
+    * @static
+    * @arg {Array<Class>} array The array of object
+    * @arg {String} key The property to use as key
+    * @arg {Number} [limit] The property to use as key
+    * @returns {Collection<Class>} A newly created Collection
+    */
     static from(array, key, limit) {
         return new Collection(array[0].constructor, limit, array.map((e) => [e[key], e] ));
     }
 
     /**
-     * Return the Collection as an Array
-     * [value, value]
-     *
-     * @returns {Array<Class>} The Collection as an Array
-     */
+    * Return the Collection as an Array
+    * [value, value]
+    *
+    * @returns {Array<Class>} The Collection as an Array
+    */
     toArray() {
         return [...this.values()];
     }
 
     /**
-     * Returns the Collection as an Object
-     * { key: value, key: value }
-     *
-     * @returns {Object} The Collection as an Object
-     */
+    * Returns the Collection as an Object
+    * { key: value, key: value }
+    *
+    * @returns {Object} The Collection as an Object
+    */
     toObject() {
         const obj = {};
         for(const key of this.keys()) {
@@ -64,13 +64,13 @@ class Collection extends Map {
     }
 
     /**
-     * Apply a function to the Collection and returns a new Collection
-     *
-     * @param {String} key The property to use as key for the new Collection
-     * @param {String} func The function name to apply to the Collection
-     * @param {Object} args All the argument that need to be applied to the Collection
-     * @returns {Collection} A new Collection modified by the apply call
-     */
+    * Apply a function to the Collection and returns a new Collection
+    *
+    * @arg {String} key The property to use as key for the new Collection
+    * @arg {String} func The function name to apply to the Collection
+    * @arg {Object} args All the argument that need to be applied to the Collection
+    * @returns {Collection<Class>} A new Collection modified by the apply call
+    */
     apply(key, func, ...args) {
         return new Collection(this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ));
     }

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -13,7 +13,7 @@ class Collection extends Map {
     * @arg {Number} [limit=null] Max number of items to hold
     * @arg {Object} [iterable=null] An iterable to initialise the Collection
     */
-    constructor(baseObject, limit= null, iterable = null) {
+    constructor(baseObject, limit = null, iterable = null) {
         if(iterable && iterable instanceof Array) {
             super(iterable);
         } else if(iterable && iterable instanceof Object) {

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -32,10 +32,11 @@ class Collection extends Map {
      * @static
      * @param {Array<Class>} array The array of object
      * @param {String} key The property to use as key
+     * @param {Number} [limit] The property to use as key
      * @returns {Collection<Class>} A newly created Collection
      */
-    static from(array, key) {
-        return new Collection(array[0].constructor, null, array.map((e) => [e[key], e] ));
+    static from(array, key, limit) {
+        return new Collection(array[0].constructor, limit, array.map((e) => [e[key], e] ));
     }
 
     /**

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -35,7 +35,7 @@ class Collection extends Map {
      * @returns {Collection<Class>} A newly created Collection
      */
     static from(array, key) {
-        return new Collection( array[0].constructor, null, array.map((e) => [e[key], e] ));
+        return new Collection(array[0].constructor, null, array.map((e) => [e[key], e] ));
     }
 
     /**
@@ -71,7 +71,7 @@ class Collection extends Map {
      * @returns {Collection} A new Collection modified by the apply call
      */
     apply(key, func, ...args) {
-        return new Collection( this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ));
+        return new Collection(this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ));
     }
 
     /**

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -56,8 +56,8 @@ class Collection extends Map {
      */
     toObject() {
         const obj = {};
-        for(const [key, value] of this.entries()) {
-            obj[key] = value;
+        for(const key of this.keys()) {
+            obj[key] = this.get(key);
         }
         return obj;
     }

--- a/lib/util/Collection.js
+++ b/lib/util/Collection.js
@@ -17,7 +17,7 @@ class Collection extends Map {
         if(iterable && iterable instanceof Array) {
             super(iterable);
         } else if(iterable && iterable instanceof Object) {
-            super(Object.entries(iterable) );
+            super(Object.entries(iterable));
         } else {
             super();
         }
@@ -35,7 +35,7 @@ class Collection extends Map {
      * @returns {Collection<Class>} A newly created Collection
      */
     static from(array, key) {
-        return new Collection( array[0].constructor, null, array.map((e) => [e[key], e] ) );
+        return new Collection( array[0].constructor, null, array.map((e) => [e[key], e] ));
     }
 
     /**
@@ -56,7 +56,7 @@ class Collection extends Map {
      */
     toObject() {
         const obj = {};
-        for(const [key, value] of this.entries() ) {
+        for(const [key, value] of this.entries()) {
             obj[key] = value;
         }
         return obj;
@@ -71,7 +71,7 @@ class Collection extends Map {
      * @returns {Collection} A new Collection modified by the apply call
      */
     apply(key, func, ...args) {
-        return new Collection( this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ) );
+        return new Collection( this.baseObject, this.limit, this[func](...args).map((e) => [e[key], e] ));
     }
 
     /**


### PR DESCRIPTION
This PR adds several methods in Collection in order to ease Collection usage.

Allow to create Collection with an iterable.
`.from()` to return a Collection from an Array.
`.toArray()` to return an Array from the Collection.
`.toObject()` to return an Object from the Collection.
`.apply()` to run any Collection method but return a Collection.

Not sure exactly about the typings, would like review!