### PR TITLE
Slight change to RequestHandler debug message

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -236,7 +236,7 @@ class RequestHandler {
                         }
 
                         if(resp.statusCode !== 429) {
-                            this._client.emit("debug", `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                            this._client.emit("debug", `${body && body.content || "None"} ${now} ${method} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
                         if(resp.statusCode >= 300) {


### PR DESCRIPTION
Changed debug message to look cleaner, and provide more info, instead of
`undefined 1576528937750 /channels/614408413492936705/messages/:id/reactions/:id/@me 204: 196ms (330ms avg) | 0/1 left | Reset 1576528937750 (0ms left)`, we have `None 1576528937750 POST /channels/614408413492936705/messages/:id/reactions/:id/@me 204: 196ms (330ms avg) | 0/1 left | Reset 1576528937750 (0ms left)`, removing that nasty undefined when there wasn't a body, and adding in the request method.