### PR TITLE
Bump lowest supported Node to v10

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "typings": "./index.d.ts",
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=10.0.0"
   },
   "scripts": {
     "lint:js": "eslint -c .eslintrc.yml lib examples *.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./index.js",
   "typings": "./index.d.ts",
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=10.2.0"
   },
   "scripts": {
     "lint:js": "eslint -c .eslintrc.yml lib examples *.js",


### PR DESCRIPTION
On December 31st, 2019, Node v8 will reach EOL. Thus, we should no longer support it either. Additionally, this'll open us up to using features from newer versions without worrying about backwards compatibility.