### PR TITLE
Improved ESM support

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -1,0 +1,40 @@
+import Client from "./lib/Client.js";
+// import pkg from "./package.json";
+
+export default function(token, options) {
+  return new Client(token, options);
+}
+
+export {default as Base} from "./lib/structures/Base.js";
+export {default as Bucket} from "./lib/util/Bucket.js";
+export {default as Call} from "./lib/structures/Call.js";
+export {default as CategoryChannel} from "./lib/structures/CategoryChannel.js";
+export {default as Channel} from "./lib/structures/Channel.js";
+export {Client};
+export {default as Collection} from "./lib/util/Collection.js";
+export {default as Command} from "./lib/command/Command.js";
+export {default as CommandClient} from "./lib/command/CommandClient.js";
+export {default as Constants} from "./lib/Constants.js";
+export {default as ExtendedUser} from "./lib/structures/ExtendedUser.js";
+export {default as GroupChannel} from "./lib/structures/GroupChannel.js";
+export {default as Guild} from "./lib/structures/Guild.js";
+export {default as GuildChannel} from "./lib/structures/GuildChannel.js";
+export {default as GuildIntegration} from "./lib/structures/GuildIntegration.js";
+export {default as Invite} from "./lib/structures/Invite.js";
+export {default as Member} from "./lib/structures/Member.js";
+export {default as Message} from "./lib/structures/Message.js";
+export {default as NewsChannel} from "./lib/structures/NewsChannel.js";
+export {default as Permission} from "./lib/structures/Permission.js";
+export {default as PermissionOverwrite} from "./lib/structures/PermissionOverwrite.js";
+export {default as PrivateChannel} from "./lib/structures/PrivateChannel.js";
+export {default as Relationship} from "./lib/structures/Relationship.js";
+export {default as Role} from "./lib/structures/Role.js";
+export {default as Shard} from "./lib/gateway/Shard.js";
+export {default as SharedStream} from "./lib/voice/SharedStream.js";
+export {default as TextChannel} from "./lib/structures/TextChannel.js";
+export {default as User} from "./lib/structures/User.js";
+// export const VERSION = pkg.version;
+export {default as VoiceChannel} from "./lib/structures/VoiceChannel.js";
+export {default as VoiceConnection} from "./lib/voice/VoiceConnection.js";
+export {default as VoiceConnectionManager} from "./lib/voice/VoiceConnectionManager.js";
+export {default as VoiceState} from "./lib/structures/VoiceState.js";

--- a/index.d.ts
+++ b/index.d.ts
@@ -675,6 +675,7 @@ declare namespace Eris {
     constructor(client: Client);
     connect(shard: Shard): void;
     spawn(id: number): void;
+    toString(): string;
     toJSON(props?: string[]): string;
   }
 
@@ -1065,6 +1066,7 @@ declare namespace Eris {
     searchChannelMessages(channelID: string, query: SearchOptions): Promise<SearchResults>;
     searchGuildMessages(guildID: string, query: SearchOptions): Promise<SearchResults>;
     on: ClientEvents<this>;
+    toString(): string;
     toJSON(props?: string[]): JSONCache;
   }
 
@@ -1098,6 +1100,7 @@ declare namespace Eris {
     on(event: "speakingStart", listener: (userID: string) => void): this;
     on(event: "speakingStop", listener: (userID: string) => void): this;
     on(event: "end", listener: () => void): this;
+    toString(): string;
     toJSON(props?: string[]): JSONCache;
   }
 
@@ -1132,6 +1135,7 @@ declare namespace Eris {
     join(guildID: string, channelID: string, options: VoiceResourceOptions): Promise<VoiceConnection>;
     leave(guildID: string): void;
     switch(guildID: string, channelID: string): void;
+    toString(): string;
     toJSON(props?: string[]): JSONCache;
   }
 
@@ -1698,6 +1702,7 @@ declare namespace Eris {
     editAFK(afk: boolean): void;
     editStatus(status?: string, game?: GamePresence): void;
     on: ShardEvents<this>;
+    toString(): string;
     toJSON(props?: string[]): JSONCache;
     sendWS(op: number, _data: object): void;
   }
@@ -1750,6 +1755,7 @@ declare namespace Eris {
     registerSubcommandAlias(alias: string, label: string): void;
     registerSubcommand(label: string, generator: CommandGenerator, options?: CommandOptions): Command;
     unregisterSubcommand(label: string): void;
+    toString(): string;
   }
 
   export class CommandClient extends Client {
@@ -1760,6 +1766,7 @@ declare namespace Eris {
     registerCommandAlias(alias: string, label: string): void;
     registerCommand(label: string, generator: CommandGenerator, options?: CommandOptions): Command;
     unregisterCommand(label: string): void;
+    toString(): string;
   }
 }
 

--- a/index.js
+++ b/index.js
@@ -40,8 +40,4 @@ Eris.VoiceConnection = require("./lib/voice/VoiceConnection");
 Eris.VoiceConnectionManager = require("./lib/voice/VoiceConnectionManager");
 Eris.VoiceState = require("./lib/structures/VoiceState");
 
-Object.keys(Eris).filter((prop) => Eris.hasOwnProperty(prop) && typeof Eris[prop] === "function" && !(Eris[prop] instanceof Eris.Base)).forEach((prop) => {
-    Eris[prop].prototype.toString = Eris.Base.prototype.toString;
-});
-
 module.exports = Eris;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2057,6 +2057,10 @@ class Client extends EventEmitter {
         }));
     }
 
+    toString() {
+        return `[Client ${this.user.id}]`;
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "options",

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -492,6 +492,10 @@ class Command {
         }
     }
 
+    toString() {
+        return `[Command ${this.label}]`;
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "parentCommand",

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -428,6 +428,10 @@ class CommandClient extends Client {
         }
     }
 
+    toString() {
+        return `[CommandClient ${this.user.id}]`;
+    }
+
     toJSON(props = []) {
         return super.toJSON([
             "commandOptions",

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1855,6 +1855,10 @@ class Shard extends EventEmitter {
         });
     }
 
+    toString() {
+        return Base.prototype.toString.call(this);
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "connecting",

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -114,6 +114,10 @@ class ShardManager extends Collection {
         }
     }
 
+    toString() {
+        return `[ShardManager ${this.size}]`;
+    }
+
     toJSON(props = []) {
         return super.toJSON([
             "connectQueue",

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -335,6 +335,10 @@ class RequestHandler {
         });
     }
 
+    toString() {
+        return "[RequestHandler]";
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "baseURL",

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -758,6 +758,10 @@ class VoiceConnection extends EventEmitter {
         }
     }
 
+    toString() {
+        return `[VoiceConnection ${this.channelID}]`;
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "channelID",

--- a/lib/voice/VoiceConnectionManager.js
+++ b/lib/voice/VoiceConnectionManager.js
@@ -133,6 +133,10 @@ class VoiceConnectionManager extends Collection {
         connection.switch(channelID);
     }
 
+    toString() {
+        return "[VoiceConnectionManager]";
+    }
+
     toJSON(props = []) {
         return Base.prototype.toJSON.call(this, [
             "pendingGuilds",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "0.11.1",
   "description": "A NodeJS Discord library",
   "main": "./index.js",
+  "exports": {
+    ".": [
+      {
+        "require": "./index.js",
+        "import": "./esm.mjs"
+      },
+      "./index.js"
+    ],
+    "./esm": "./esm.mjs"
+  },
   "typings": "./index.d.ts",
   "engines": {
     "node": ">=8.0.0"

--- a/package.json
+++ b/package.json
@@ -31,17 +31,17 @@
   },
   "homepage": "https://abal.moe/Eris/",
   "dependencies": {
-    "ws": "^7.1.2"
+    "ws": "^7.2.1"
   },
   "devDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.7.0",
-    "@typescript-eslint/parser": "^2.7.0",
-    "eslint": "^6.6.0",
-    "typescript": "^3.7.2"
+    "@typescript-eslint/eslint-plugin": "^2.13.0",
+    "@typescript-eslint/parser": "^2.13.0",
+    "eslint": "^6.8.0",
+    "typescript": "^3.7.4"
   },
   "optionalDependencies": {
-    "opusscript": "^0.0.4",
-    "tweetnacl": "^1.0.0"
+    "opusscript": "^0.0.7",
+    "tweetnacl": "^1.0.1"
   },
   "browser": {
     "child_process": false,


### PR DESCRIPTION
ECMAScript modules can import CommonJS modules, however this is simply as a default export and can't take advantage of named exports. This PR adds named exports to Eris when imported by an ECMAScript module.
 - CommonJS support for Node.js 8+ (and for obsolete versions before 8).
 - Full ECMAScript support for Node.js 12+ (using an `eris/esm` import and/or flags).
 - Forwards compatibility with future versions of Node.js using [conditional exports](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_conditional_exports).
 - `Eris.VERSION` is temporarily removed from the ECMAScript exports, as importing JSON files is [experimental and behind a flag](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_experimental_json_modules). The code needed to add it back is commented out.
 - Updated dependencies, as every single one of them were outdated.

One side effect of this PR is that it prevents using [subpath imports](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_package_exports). Whether this is a good thing or not is worth discussion, but it causes no problems with normal use nor with TypeScript. An alternative method could be using the `eris/esm.mjs` subpath import, as while it's less appealing and lacks forwards compatibility it doesn't prevent use of subpaths.