### PR TITLE
Improved ESM Support

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -1,0 +1,41 @@
+import Eris from "./index.js";
+
+export default function(token, options) {
+  return new Eris.Client(token, options);
+}
+
+export const {
+  Base,
+  Bucket,
+  Call,
+  CategoryChannel,
+  Channel,
+  Client,
+  Collection,
+  Command,
+  CommandClient,
+  Constants,
+  ExtendedUser,
+  GroupChannel,
+  Guild,
+  GuildChannel,
+  GuildIntegration,
+  Invite,
+  Member,
+  Message,
+  NewsChannel,
+  Permission,
+  PermissionOverwrite,
+  PrivateChannel,
+  Relationship,
+  Role,
+  Shard,
+  SharedStream,
+  TextChannel,
+  User,
+  VERSION,
+  VoiceChannel,
+  VoiceConnection,
+  VoiceConnectionManager,
+  VoiceState
+} = Eris;

--- a/package.json
+++ b/package.json
@@ -3,6 +3,16 @@
   "version": "0.11.1",
   "description": "A NodeJS Discord library",
   "main": "./index.js",
+  "exports": {
+    ".": [
+      {
+        "require": "./index.js",
+        "import": "./esm.mjs"
+      },
+      "./index.js"
+    ],
+    "./esm": "./esm.mjs"
+  },
   "typings": "./index.d.ts",
   "engines": {
     "node": ">=8.0.0"


### PR DESCRIPTION
ECMAScript modules can import CommonJS modules, however this is simply as a default export and can't take advantage of named exports. This PR adds named exports to Eris when imported by an ECMAScript module.
 - CommonJS support for Node.js 8+ (and for obsolete versions before 8).
 - Full ECMAScript support for Node.js 12+ (using an `eris/esm` import and/or flags).
 - Forwards compatibility with future versions of Node.js using [conditional exports](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_conditional_exports).

One side effect of this PR is that it prevents using [subpath imports](https://nodejs.org/docs/latest-v13.x/api/esm.html#esm_package_exports). Whether this is a good thing or not is worth discussion, but it causes no problems with normal use nor with TypeScript. An alternative method could be using the `eris/esm.mjs` subpath import, as while it's less appealing and lacks forwards compatibility it doesn't prevent use of subpaths.