### PR TITLE
Client#createRole should add to cache

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -764,7 +764,7 @@ class Client extends EventEmitter {
         return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => {
             const guild = this.guilds.get(guildID);
             if(guild == null) {
-                return new Role(role, guild);
+                return new Role(role);
             } else {
                 return guild.roles.add(role, guild);
             }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -761,7 +761,7 @@ class Client extends EventEmitter {
     */
     createRole(guildID, options, reason) {
         options.reason = reason;
-        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => new Role(role, this.guilds.get(guildID)));
+        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => this.guilds.get(guildID).roles.add(role, this.guilds.get(guildID)));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -765,7 +765,7 @@ class Client extends EventEmitter {
             const guild = this.guilds.get(guildID);
             if(guild == null) {
                 return new Role(role, guild);
-            }else{
+            } else {
                 return guild.roles.add(role, guild);
             }
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -761,7 +761,14 @@ class Client extends EventEmitter {
     */
     createRole(guildID, options, reason) {
         options.reason = reason;
-        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => this.guilds.get(guildID).roles.add(role, this.guilds.get(guildID)));
+        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => {
+            const guild = this.guilds.get(guildID);
+            if(guild == null) {
+                return new Role(role, guild);
+            }else{
+                return guild.roles.add(role, guild);
+            }
+        });
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -763,10 +763,10 @@ class Client extends EventEmitter {
         options.reason = reason;
         return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => {
             const guild = this.guilds.get(guildID);
-            if(guild == null) {
-                return new Role(role);
-            } else {
+            if(guild) {
                 return guild.roles.add(role, guild);
+            } else {
+                return new Role(role);
             }
         });
     }


### PR DESCRIPTION
Without this there is a race condition where a role may not be added to cache before it's expected to be used. This was found when a user attempted to edit a role's position after `await`ing it's creation and the role didn't exist in cache.