### PR TITLE
fix uncached role delete

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -871,6 +871,10 @@ class Shard extends EventEmitter {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_ROLE_DELETE`);
                     break;
                 }
+                if(!guild.roles.has(packet.d.role_id)) {
+                    this.emit("debug", `Missing role ${packet.d.role_id} in GUILD_ROLE_DELETE`);
+                    break;
+                }
                 this.emit("guildRoleDelete", guild, guild.roles.remove({id: packet.d.role_id}));
                 break;
             }


### PR DESCRIPTION
This PR handles a potential bug that keeps appearing whenever a guild role is deleted. For some reason, the role that was deleted has not been cached properly. 

For whatever, reason Role is `null`

NOTE: This does not fix the underlying cause of why the role was not cached to begin with. I was unable to figure out why that kept happening.

![image](https://user-images.githubusercontent.com/23035000/72206829-51142180-3460-11ea-8daa-4afcfd4b0652.png)

![image](https://user-images.githubusercontent.com/23035000/72206845-76089480-3460-11ea-89c5-dcd26d7c3d1f.png)

