### PR TITLE
Fix PCM decoding that break by shared opus instance

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -205,6 +205,7 @@ declare namespace Eris {
       HEARTBEAT: 3;
       SESSION_DESCRIPTION: 4;
       SPEAKING: 5;
+      DISCONNECT: 13;
     };
     SystemJoinMessages: [
       "%user% just joined the server - glhf!",
@@ -1100,6 +1101,7 @@ declare namespace Eris {
     on(event: "speakingStart", listener: (userID: string) => void): this;
     on(event: "speakingStop", listener: (userID: string) => void): this;
     on(event: "end", listener: () => void): this;
+    on(event: "disconnect", listener: (userID: string) => void): this;
     toString(): string;
     toJSON(props?: string[]): JSONCache;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1101,7 +1101,7 @@ declare namespace Eris {
     on(event: "speakingStart", listener: (userID: string) => void): this;
     on(event: "speakingStop", listener: (userID: string) => void): this;
     on(event: "end", listener: () => void): this;
-    on(event: "disconnect", listener: (userID: string) => void): this;
+    on(event: "userDisconnect", listener: (userID: string) => void): this;
     toString(): string;
     toJSON(props?: string[]): JSONCache;
   }

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -76,7 +76,8 @@ module.exports.VoiceOPCodes = {
     READY:               2,
     HEARTBEAT:           3,
     SESSION_DESCRIPTION: 4,
-    SPEAKING:            5
+    SPEAKING:            5,
+    DISCONNECT:          13
 };
 
 module.exports.SystemJoinMessages = [

--- a/lib/util/Opus.js
+++ b/lib/util/Opus.js
@@ -1,0 +1,29 @@
+let NodeOpus;
+try {
+    NodeOpus = require("node-opus");
+} catch(err) { // eslint-disable no-empty
+}
+let OpusScript;
+try {
+    OpusScript = require("opusscript");
+} catch(err) { // eslint-disable no-empty
+}
+
+
+module.exports.createOpus = function createOpus (samplingRate, channels, bitrate) {
+    let opus;
+
+    if(NodeOpus) {
+        opus = new NodeOpus.OpusEncoder(samplingRate, channels);
+    } else if(OpusScript) {
+        opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
+        if(opus.setBitrate) {
+            opus.setBitrate(bitrate);
+        } else if(opus.encoderCTL) {
+            opus.encoderCTL(4002, bitrate);
+        }
+    } else {
+        throw new Error("No opus encoder found, playing non-opus audio will not work.");
+    }
+    return opus;
+};

--- a/lib/util/Opus.js
+++ b/lib/util/Opus.js
@@ -10,20 +10,22 @@ try {
 }
 
 
-module.exports.createOpus = function createOpus (samplingRate, channels, bitrate) {
-    let opus;
-
+module.exports.createOpus = function createOpus(samplingRate, channels, bitrate) {
     if(NodeOpus) {
-        opus = new NodeOpus.OpusEncoder(samplingRate, channels);
-    } else if(OpusScript) {
-        opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
+        return new NodeOpus.OpusEncoder(samplingRate, channels);
+    }
+
+    if(OpusScript) {
+        const opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
+
         if(opus.setBitrate) {
             opus.setBitrate(bitrate);
         } else if(opus.encoderCTL) {
             opus.encoderCTL(4002, bitrate);
         }
-    } else {
-        throw new Error("No opus encoder found, playing non-opus audio will not work.");
+
+        return opus;
     }
-    return opus;
+
+    throw new Error("No opus encoder found, playing non-opus audio will not work.");
 };

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -21,7 +21,7 @@ try {
 }
 
 class Piper extends EventEmitter {
-    constructor(converterCommand, opus) {
+    constructor(converterCommand, opusFactory) {
         super();
 
         this.reset();
@@ -32,7 +32,10 @@ class Piper extends EventEmitter {
         this._dataPacketMin = 15;
         this.encoding = false;
         this.libopus = true;
-        this.opus = opus;
+
+        this.opusFactory = opusFactory;
+        this.opus = null;
+
         this.volumeLevel = 1;
 
         this._retransformer = [];
@@ -111,7 +114,7 @@ class Piper extends EventEmitter {
                 this.streams.push(this.volume = source = source.pipe(new VolumeTransformer()).once("error", (e) => this.stop(e)));
                 this.volume.setVolume(this.volumeLevel);
                 this.streams.push(this.volume.pipe(new PCMOpusTransformer({
-                    opus: this.opus,
+                    opusFactory: this.opusFactory,
                     frameSize: options.frameSize,
                     pcmSize: options.pcmSize
                 })).once("error", (e) => this.stop(e)));
@@ -154,7 +157,7 @@ class Piper extends EventEmitter {
                         })).once("error", (e) => this.stop(e)));
                     }
                     this.streams.push(source.pipe(new PCMOpusTransformer({
-                        opus: this.opus,
+                        opusFactory: this.opusFactory,
                         frameSize: options.frameSize,
                         pcmSize: options.pcmSize
                     })).once("error", (e) => this.stop(e)));
@@ -220,6 +223,11 @@ class Piper extends EventEmitter {
     }
 
     resetPackets() {
+        // We no longer need this to convert inline volume, so... let it go.
+        if(this.opus) {
+            this.opus.destroy && this.opus.destroy();
+            this.opus = null;
+        }
         this._dataPackets = [];
     }
 
@@ -247,6 +255,11 @@ class Piper extends EventEmitter {
         if(this._retransformer.length === 0) {
             return this._dataPackets.shift();
         } else {
+            // if we don't have opus instance yet, new one on demand.
+            if(!this.opus) {
+                this.opus = this.opusFactory();
+            }
+
             const packet = this.opus.decode(this._dataPackets.shift());
             for(let i = 0, num; i < packet.length - 1; i += 2) {
                 num = ~~(this._retransformer.shift() * packet.readInt16LE(i));

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -255,7 +255,7 @@ class Piper extends EventEmitter {
         if(this._retransformer.length === 0) {
             return this._dataPackets.shift();
         } else {
-            // if we don't have opus instance yet, new one on demand.
+            // If we don't have an opus instance yet, create one.
             if(!this.opus) {
                 this.opus = this.opusFactory();
             }

--- a/lib/voice/Piper.js
+++ b/lib/voice/Piper.js
@@ -225,7 +225,7 @@ class Piper extends EventEmitter {
     resetPackets() {
         // We no longer need this to convert inline volume, so... let it go.
         if(this.opus) {
-            this.opus.destroy && this.opus.destroy();
+            this.opus.delete && this.opus.delete();
             this.opus = null;
         }
         this._dataPackets = [];

--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -3,22 +3,13 @@
 const Piper = require("./Piper");
 const VoiceConnection = require("./VoiceConnection");
 const Collection = require("../util/Collection");
+const {createOpus} = require("../util/Opus");
 
 let EventEmitter;
 try {
     EventEmitter = require("eventemitter3");
 } catch(err) {
     EventEmitter = require("events").EventEmitter;
-}
-let NodeOpus;
-try {
-    NodeOpus = require("node-opus");
-} catch(err) { // eslint-disable no-empty
-}
-let OpusScript;
-try {
-    OpusScript = require("opusscript");
-} catch(err) { // eslint-disable no-empty
 }
 
 /**
@@ -36,25 +27,12 @@ class SharedStream extends EventEmitter {
 
         this.voiceConnections = new Collection(VoiceConnection);
 
-        if(NodeOpus) {
-            this.opus = new NodeOpus.OpusEncoder(this.samplingRate, this.channels);
-        } else if(OpusScript) {
-            this.emit("debug", "node-opus not found, falling back to opusscript");
-            this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
-            if(this.opus.setBitrate) {
-                this.opus.setBitrate(this.bitrate);
-            } else if(this.opus.encoderCTL) {
-                this.opus.encoderCTL(4002, this.bitrate);
-            }
-        } else {
-            this.emit("warn", new Error("No opus encoder found, playing non-opus audio will not work."));
-        }
 
         if(!VoiceConnection._converterCommand.cmd) {
             VoiceConnection._converterCommand.pickCommand();
         }
 
-        this.piper = new Piper(VoiceConnection._converterCommand.cmd, this.opus);
+        this.piper = new Piper(VoiceConnection._converterCommand.cmd, () => createOpus(this.samplingRate, this.channels, this.bitrate));
         this.piper.on("error", (e) => this.emit("error", e));
         if(!VoiceConnection._converterCommand.libopus) {
             this.piper.libopus = false;

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -334,8 +334,13 @@ class VoiceConnection extends EventEmitter {
 
                     if(!this.opusOnly && !this.shared) {
                         if(packet.d.speaking) {
-                            this.opus[packet.d.user_id] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
+                            if(!this.opus[packet.d.user_id]) {
+                                this.opus[packet.d.user_id] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
+                            }
                         } else {
+                            if(this.opus[packet.d.user_id].delete) {
+                                this.opus[packet.d.user_id].delete();
+                            }
                             delete this.opus[packet.d.user_id];
                         }
                     }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -313,6 +313,12 @@ class VoiceConnection extends EventEmitter {
                     break;
                 }
                 case VoiceOPCodes.DISCONNECT: {
+                    /**
+                    * Fired when a user disconnect from the channel
+                    * @event VoiceConnection#disconnect
+                    * @prop {String} userID The ID of the user that disconnect from the channel
+                    */
+
                     // opusscript requires explicit release wasm instance
                     if(this.opus[packet.d.user_id] && this.opus[packet.d.user_id].delete) {
                         this.opus[packet.d.user_id].delete();

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -140,7 +140,7 @@ class VoiceConnection extends EventEmitter {
     _destroy() {
         if(this.opus) {
             for(const key in this.opus) {
-                this.opus[key].delete();
+                this.opus[key].delete && this.opus[key].delete();
                 delete this.opus[key];
             }
         }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -312,20 +312,19 @@ class VoiceConnection extends EventEmitter {
                     break;
                 }
                 case VoiceOPCodes.DISCONNECT: {
-                    /**
-                    * Fired when a user disconnect from the channel
-                    * @event VoiceConnection#disconnect
-                    * @prop {String} userID The ID of the user that disconnect from the channel
-                    */
-
-                    // opusscript requires explicit release wasm instance
+                    // opusscript requires manual cleanup
                     if(this.opus[packet.d.user_id] && this.opus[packet.d.user_id].delete) {
                         this.opus[packet.d.user_id].delete();
                     }
 
                     delete this.opus[packet.d.user_id];
 
-                    this.emit("disconnect", packet.d.user_id);
+                    /**
+                    * Fired when a user disconnects from the voice server
+                    * @event VoiceConnection#userDisconnect
+                    * @prop {String} userID The ID of the user that disconnected
+                    */
+                    this.emit("userDisconnect", packet.d.user_id);
                     break;
                 }
                 default: {

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -308,7 +308,6 @@ class VoiceConnection extends EventEmitter {
                     * @event VoiceConnection#speakingStop
                     * @prop {String} userID The ID of the user that stopped speaking
                     */
-
                     this.emit(packet.d.speaking ? "speakingStart" : "speakingStop", packet.d.user_id);
                     break;
                 }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -6,6 +6,8 @@ const {VoiceOPCodes, GatewayOPCodes} = require("../Constants");
 const Dgram = require("dgram");
 const Piper = require("./Piper");
 const VoiceDataStream = require("./VoiceDataStream");
+const {createOpus} = require("../util/Opus");
+
 let WebSocket = typeof window !== "undefined" ? window.WebSocket : require("ws");
 
 let EventEmitter;
@@ -14,16 +16,7 @@ try {
 } catch(err) {
     EventEmitter = require("events").EventEmitter;
 }
-let NodeOpus;
-try {
-    NodeOpus = require("node-opus");
-} catch(err) { // eslint-disable no-empty
-}
-let OpusScript;
-try {
-    OpusScript = require("opusscript");
-} catch(err) { // eslint-disable no-empty
-}
+
 let Sodium = false;
 let NaCl = false;
 try {
@@ -66,24 +59,6 @@ converterCommand.pickCommand = function pickCommand() {
         return;
     }
 };
-
-function getOpusDecoder (samplingRate, channels, bitrate) {
-    let opus;
-
-    if(NodeOpus) {
-        opus = new NodeOpus.OpusEncoder(samplingRate, channels);
-    } else if(OpusScript) {
-        opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
-        if(opus.setBitrate) {
-            opus.setBitrate(bitrate);
-        } else if(opus.encoderCTL) {
-            opus.encoderCTL(4002, bitrate);
-        }
-    } else {
-        throw new Error("No opus encoder found, playing non-opus audio will not work.");
-    }
-    return opus;
-}
 
 /**
 * Represents a voice connection
@@ -147,7 +122,7 @@ class VoiceConnection extends EventEmitter {
                 converterCommand.pickCommand();
             }
 
-            this.piper = new Piper(converterCommand.cmd, this.opus);
+            this.piper = new Piper(converterCommand.cmd, () => createOpus(this.samplingRate, this.channels, this.bitrate));
             /**
             * Fired when the voice connection encounters an error. This event should be handled by users
             * @event VoiceConnection#error
@@ -163,9 +138,11 @@ class VoiceConnection extends EventEmitter {
     }
 
     _destroy() {
-        if(this.opus && this.opus.delete) {
-            this.opus.delete();
-            delete this.opus;
+        if(this.opus) {
+            for(const key in this.opus) {
+                this.opus[key].delete();
+                delete this.opus[key];
+            }
         }
         delete this.piper;
         if(this.receiveStreamOpus) {
@@ -675,7 +652,7 @@ class VoiceConnection extends EventEmitter {
             if(this.receiveStreamPCM) {
                 const userId = this.ssrcUserMap[nonce.readUIntBE(8, 4)];
                 if(!this.opus[userId]) {
-                    this.opus[userId] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
+                    this.opus[userId] = createOpus(this.samplingRate, this.channels, this.bitrate);
                 }
 
                 data = this.opus[userId].decode(data, this.frameSize);

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -76,7 +76,7 @@ function getOpusDecoder (samplingRate, channels, bitrate) {
         opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
         if(opus.setBitrate) {
             opus.setBitrate(bitrate);
-        } else if(this.opus.encoderCTL) {
+        } else if(opus.encoderCTL) {
             opus.encoderCTL(4002, bitrate);
         }
     } else {

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -332,20 +332,18 @@ class VoiceConnection extends EventEmitter {
                     * @prop {String} userID The ID of the user that stopped speaking
                     */
 
-                    if(!this.opusOnly && !this.shared) {
-                        if(packet.d.speaking) {
-                            if(!this.opus[packet.d.user_id]) {
-                                this.opus[packet.d.user_id] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
-                            }
-                        } else {
-                            if(this.opus[packet.d.user_id].delete) {
-                                this.opus[packet.d.user_id].delete();
-                            }
-                            delete this.opus[packet.d.user_id];
-                        }
+                    this.emit(packet.d.speaking ? "speakingStart" : "speakingStop", packet.d.user_id);
+                    break;
+                }
+                case VoiceOPCodes.DISCONNECT: {
+                    // opusscript requires explicit release wasm instance
+                    if(this.opus[packet.d.user_id] && this.opus[packet.d.user_id].delete) {
+                        this.opus[packet.d.user_id].delete();
                     }
 
-                    this.emit(packet.d.speaking ? "speakingStart" : "speakingStop", packet.d.user_id);
+                    delete this.opus[packet.d.user_id];
+
+                    this.emit("disconnect", packet.d.user_id);
                     break;
                 }
                 default: {
@@ -675,11 +673,16 @@ class VoiceConnection extends EventEmitter {
                 this.receiveStreamOpus.emit("data", data, this.ssrcUserMap[nonce.readUIntBE(8, 4)], nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
             if(this.receiveStreamPCM) {
-                data = this.opus[this.ssrcUserMap[nonce.readUIntBE(8, 4)]].decode(data, this.frameSize);
+                const userId = this.ssrcUserMap[nonce.readUIntBE(8, 4)];
+                if(!this.opus[userId]) {
+                    this.opus[userId] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
+                }
+
+                data = this.opus[userId].decode(data, this.frameSize);
                 if(!data) {
                     return this.emit("warn", "Failed to decode received packet");
                 }
-                this.receiveStreamPCM.emit("data", data, this.ssrcUserMap[nonce.readUIntBE(8, 4)], nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
+                this.receiveStreamPCM.emit("data", data, userId, nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
         });
     }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -67,6 +67,24 @@ converterCommand.pickCommand = function pickCommand() {
     }
 };
 
+function getOpusDecoder (samplingRate, channels, bitrate) {
+    let opus;
+
+    if(NodeOpus) {
+        opus = new NodeOpus.OpusEncoder(samplingRate, channels);
+    } else if(OpusScript) {
+        opus = new OpusScript(samplingRate, channels, OpusScript.Application.AUDIO);
+        if(opus.setBitrate) {
+            opus.setBitrate(bitrate);
+        } else if(this.opus.encoderCTL) {
+            opus.encoderCTL(4002, bitrate);
+        }
+    } else {
+        throw new Error("No opus encoder found, playing non-opus audio will not work.");
+    }
+    return opus;
+}
+
 /**
 * Represents a voice connection
 * @extends EventEmitter
@@ -108,19 +126,7 @@ class VoiceConnection extends EventEmitter {
         this.opusOnly = !!options.opusOnly;
 
         if(!this.opusOnly && !this.shared) {
-            if(NodeOpus) {
-                this.opus = new NodeOpus.OpusEncoder(this.samplingRate, this.channels);
-            } else if(OpusScript) {
-                this.emit("debug", "node-opus not found, falling back to opusscript");
-                this.opus = new OpusScript(this.samplingRate, this.channels, OpusScript.Application.AUDIO);
-                if(this.opus.setBitrate) {
-                    this.opus.setBitrate(this.bitrate);
-                } else if(this.opus.encoderCTL) {
-                    this.opus.encoderCTL(4002, this.bitrate);
-                }
-            } else {
-                throw new Error("No opus encoder found, playing non-opus audio will not work.");
-            }
+            this.opus = {};
         }
 
         this.channelID = null;
@@ -325,6 +331,15 @@ class VoiceConnection extends EventEmitter {
                     * @event VoiceConnection#speakingStop
                     * @prop {String} userID The ID of the user that stopped speaking
                     */
+
+                    if(!this.opusOnly && !this.shared) {
+                        if(packet.d.speaking) {
+                            this.opus[packet.d.user_id] = getOpusDecoder(this.samplingRate, this.channels, this.bitrate);
+                        } else {
+                            delete this.opus[packet.d.user_id];
+                        }
+                    }
+
                     this.emit(packet.d.speaking ? "speakingStart" : "speakingStop", packet.d.user_id);
                     break;
                 }
@@ -655,7 +670,7 @@ class VoiceConnection extends EventEmitter {
                 this.receiveStreamOpus.emit("data", data, this.ssrcUserMap[nonce.readUIntBE(8, 4)], nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
             if(this.receiveStreamPCM) {
-                data = this.opus.decode(data, this.frameSize);
+                data = this.opus[this.ssrcUserMap[nonce.readUIntBE(8, 4)]].decode(data, this.frameSize);
                 if(!data) {
                     return this.emit("warn", "Failed to decode received packet");
                 }

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -654,16 +654,16 @@ class VoiceConnection extends EventEmitter {
                 this.receiveStreamOpus.emit("data", data, this.ssrcUserMap[nonce.readUIntBE(8, 4)], nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
             if(this.receiveStreamPCM) {
-                const userId = this.ssrcUserMap[nonce.readUIntBE(8, 4)];
-                if(!this.opus[userId]) {
-                    this.opus[userId] = createOpus(this.samplingRate, this.channels, this.bitrate);
+                const userID = this.ssrcUserMap[nonce.readUIntBE(8, 4)];
+                if(!this.opus[userID]) {
+                    this.opus[userID] = createOpus(this.samplingRate, this.channels, this.bitrate);
                 }
 
-                data = this.opus[userId].decode(data, this.frameSize);
+                data = this.opus[userID].decode(data, this.frameSize);
                 if(!data) {
                     return this.emit("warn", "Failed to decode received packet");
                 }
-                this.receiveStreamPCM.emit("data", data, userId, nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
+                this.receiveStreamPCM.emit("data", data, userID, nonce.readUIntBE(4, 4), nonce.readUIntBE(2, 2));
             }
         });
     }

--- a/lib/voice/streams/PCMOpusTransformer.js
+++ b/lib/voice/streams/PCMOpusTransformer.js
@@ -4,12 +4,9 @@ const BaseTransformer = require("./BaseTransformer");
 
 class PCMOpusTransformer extends BaseTransformer {
     constructor(options = {}) {
-        if(!options.opus) {
-            throw new Error("Supported opus encoder not found");
-        }
         super(options);
 
-        this.opus = options.opus;
+        this.opus = options.opusFactory();
         this.frameSize = options.frameSize || 2880;
         this.pcmSize = options.pcmSize || 11520;
 
@@ -50,6 +47,14 @@ class PCMOpusTransformer extends BaseTransformer {
             this._remainder = null;
         }
         cb();
+    }
+
+    _destroy(...args) {
+        if(this.opus.destroy) {
+            this.opus.destroy();
+        }
+
+        return super._destroy(...args);
     }
 }
 

--- a/lib/voice/streams/PCMOpusTransformer.js
+++ b/lib/voice/streams/PCMOpusTransformer.js
@@ -50,8 +50,8 @@ class PCMOpusTransformer extends BaseTransformer {
     }
 
     _destroy(...args) {
-        if(this.opus.destroy) {
-            this.opus.destroy();
+        if(this.opus.delete) {
+            this.opus.delete();
         }
 
         return super._destroy(...args);


### PR DESCRIPTION
- User voice decoding in `VoiceConnection.js` is now using own codec per user.
- All opus codec are now initiated per stream (both decode/encode) because share the instance cause decode/encode error.
- Add `disconnect` event to `VoiceConnection.js` in order to trigger codec clean up on user leaved.
- Move opus codec creation into own function to prevent duplication.

This PR is aimed to Fix #443 

~~Not ready yet, only `VoiceConnection` was tested~~

VoiceConnection was tested with my own bot https://github.com/mmis1000/discord-record-bot-eris to ensure sound no longer garbled(sounds exactly same like you sound on discord itself). Other things may still requires a test to ensure it does not go wrong.