### PR TITLE
Add guildID prop to Message

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1530,7 +1530,7 @@ declare namespace Eris {
     id: string;
     createdAt: number;
     channel: TextableChannel;
-    guildID: string;
+    guildID?: string;
     timestamp: number;
     type: number;
     author: User;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1530,6 +1530,7 @@ declare namespace Eris {
     id: string;
     createdAt: number;
     channel: TextableChannel;
+    guildID: string;
     timestamp: number;
     type: number;
     author: User;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -9,7 +9,7 @@ const User = require("./User");
 * Represents a message
 * @prop {String} id The ID of the message
 * @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the message is in
-* @prop {String} [guildID] The id of the guild where this message was sent. (Will be undefined in DM.)
+* @prop {String} [guildID] The ID of the guild this message is in (undefined if in DMs)
 * @prop {Number} timestamp Timestamp of message creation
 * @prop {Number} type The type of the message
 * @prop {User} author The message author

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -48,6 +48,7 @@ class Message extends Base {
         this.content = "";
         this.hit = !!data.hit;
         this.reactions = {};
+        this.guildID = data.guild_id;
 
         if(data.message_reference) {
             this.messageReference = {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -9,6 +9,7 @@ const User = require("./User");
 * Represents a message
 * @prop {String} id The ID of the message
 * @prop {PrivateChannel | TextChannel | NewsChannel} channel The channel the message is in
+* @prop {String} [guildID] The id of the guild where this message was sent. (Will be undefined in DM.)
 * @prop {Number} timestamp Timestamp of message creation
 * @prop {Number} type The type of the message
 * @prop {User} author The message author


### PR DESCRIPTION
This PR adds a `guildID` prop onto the Message class. The data that discord sends has a `guild_id` prop attached to it and it is made unavailable to the eris user. Instead it is made that users do `message.channel.guild.id`.

I still don't truly understand why `message.guild` is not a thing but having the guild_id prop exposed would be HUGE. 99% of the times i do `message.channel.guild` is just to get the guildID. 

![image](https://user-images.githubusercontent.com/23035000/72533678-8dba9100-3843-11ea-9f8c-07a1eb65afe4.png)

The current dilemma with having to do `message.channel.guild` is it forces any TS user to have to add additional checks.

Everytime i make a function I have to run these two checks just to get a guild id. 
![image](https://user-images.githubusercontent.com/23035000/72533807-c78b9780-3843-11ea-915d-cef4ad3a23d9.png)

It's silly!
![image](https://user-images.githubusercontent.com/23035000/72534017-1fc29980-3844-11ea-9ce5-4b0c138764fa.png)

Eris should not make a prop that Discord passes unavailable to the end user, please 🙏.

Side Note: Some good points were brough up in discord chat about having a `message.guild` getter. If desired i can add this in.
```js
get guild() {
  return this.guildID ? this.client.guilds.get(guildID) || { id: this.guildID } : null
}
```