### PR TITLE
Break out embed properties and reformat options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -337,7 +337,7 @@ declare namespace Eris {
     wait?: boolean;
     disableEveryone?: boolean;
   }
-  
+
   interface EmbedAuthorOptions {
     name: string;
     url?: string;
@@ -346,13 +346,13 @@ declare namespace Eris {
   interface EmbedAuthor extends EmbedAuthorOptions {
     proxy_icon_url?: string;
   }
-  
+
   interface EmbedField {
     name: string;
     value: string;
     inline?: boolean;
   }
-  
+
   interface EmbedFooterOptions {
     text: string;
     icon_url?: string;
@@ -360,7 +360,7 @@ declare namespace Eris {
   interface EmbedFooter extends EmbedFooterOptions {
     proxy_icon_url?: string;
   }
-  
+
   interface EmbedImageOptions {
     url?: string;
   }
@@ -375,7 +375,7 @@ declare namespace Eris {
     height?: number;
     width?: number;
   }
-  
+
   interface EmbedProvider {
     name?: string;
     url?: string;
@@ -402,8 +402,8 @@ declare namespace Eris {
     footer?: EmbedFooter;
     image?: EmbedImage;
     thumbnail?: EmbedImage; // REVIEW: same as line 392
-    author?: EmbedAuthor;    
-  };
+    author?: EmbedAuthor;
+  }
 
   interface Webhook {
     name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -337,27 +337,73 @@ declare namespace Eris {
     wait?: boolean;
     disableEveryone?: boolean;
   }
+  
+  interface EmbedAuthorOptions {
+    name: string;
+    url?: string;
+    icon_url?: string;
+  }
+  interface EmbedAuthor extends EmbedAuthorOptions {
+    proxy_icon_url?: string;
+  }
+  
+  interface EmbedField {
+    name: string;
+    value: string;
+    inline?: boolean;
+  }
+  
+  interface EmbedFooterOptions {
+    text: string;
+    icon_url?: string;
+  }
+  interface EmbedFooter extends EmbedFooterOptions {
+    proxy_icon_url?: string;
+  }
+  
+  interface EmbedImageOptions {
+    url?: string;
+  }
+  interface EmbedImage extends EmbedImageOptions {
+    proxy_url?: string;
+    height?: number;
+    width?: number;
+  }
 
-  interface EmbedBase {
+  interface EmbedVideo {
+    url?: string;
+    height?: number;
+    width?: number;
+  }
+  
+  interface EmbedProvider {
+    name?: string;
+    url?: string;
+  }
+
+  interface EmbedOptions {
     title?: string;
     description?: string;
     url?: string;
     timestamp?: Date | string;
     color?: number;
-    footer?: { text: string; icon_url?: string; proxy_icon_url?: string };
-    image?: { url?: string; proxy_url?: string; height?: number; width?: number };
-    thumbnail?: { url?: string; proxy_url?: string; height?: number; width?: number };
-    video?: { url: string; height?: number; width?: number };
-    provider?: { name: string; url?: string };
-    fields?: { name: string; value: string; inline?: boolean }[];
-    author?: { name: string; url?: string; icon_url?: string; proxy_icon_url?: string };
+    footer?: EmbedFooterOptions;
+    image?: EmbedImageOptions;
+    thumbnail?: EmbedImageOptions; // REVIEW: Image and thumbnail structures are identical, but discord does have separate entries for them. Could this change in the future?
+    fields?: EmbedField[];
+    author?: EmbedAuthorOptions;
   }
-  type Embed = {
+
+  // Omit<T, K> used to override
+  interface Embed extends Omit<EmbedOptions, "footer" | "image" | "thumbnail" | "author"> {
     type: string;
-  } & EmbedBase;
-  type EmbedOptions = {
-    type?: string;
-  } & EmbedBase;
+    video?: EmbedVideo;
+    provider?: EmbedProvider;
+    footer?: EmbedFooter;
+    image?: EmbedImage;
+    thumbnail?: EmbedImage; // REVIEW: same as line 392
+    author?: EmbedAuthor;    
+  };
 
   interface Webhook {
     name: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -389,7 +389,7 @@ declare namespace Eris {
     color?: number;
     footer?: EmbedFooterOptions;
     image?: EmbedImageOptions;
-    thumbnail?: EmbedImageOptions; // REVIEW: Image and thumbnail structures are identical, but discord does have separate entries for them. Could this change in the future?
+    thumbnail?: EmbedImageOptions;
     fields?: EmbedField[];
     author?: EmbedAuthorOptions;
   }
@@ -401,7 +401,7 @@ declare namespace Eris {
     provider?: EmbedProvider;
     footer?: EmbedFooter;
     image?: EmbedImage;
-    thumbnail?: EmbedImage; // REVIEW: same as line 392
+    thumbnail?: EmbedImage;
     author?: EmbedAuthor;
   }
 


### PR DESCRIPTION
Creates individual interfaces for the various embed fields so they can be used as individual types more easily by TS consumers.

Functional changes:
- EmbedBase no longer exists
- EmbedOptions no longer allows specifying `type`
- Some fields were made optional according to Discord docs