### PR TITLE
Fix voiceChannelLeave race condition

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1007,7 +1007,8 @@ class Shard extends EventEmitter {
                     }
                     if(channel.type === ChannelTypes.GUILD_VOICE) {
                         channel.voiceMembers.forEach((member) => {
-                            this.emit("voiceChannelLeave", channel.voiceMembers.remove(member), channel);
+                            channel.voiceMembers.remove(member);
+                            this.emit("voiceChannelLeave", member, channel);
                         });
                     }
                     this.emit("channelDelete", channel);


### PR DESCRIPTION
This PR will prevent the `voiceChannelLeave` event being emitted with a `null` for a member.