### PR TITLE
Expose Channel.client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1239,6 +1239,7 @@ declare namespace Eris {
     id: string;
     mention: string;
     type: 0 | 1 | 2 | 3 | 4 | 5 | 6;
+    client: Client;
     createdAt: number;
     constructor(data: BaseData);
     static from(data: object, client: Client): AnyChannel;

--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -8,12 +8,14 @@ const {ChannelTypes} = require("../Constants");
 * @prop {String} id The ID of the channel
 * @prop {String} mention A string that mentions the channel
 * @prop {Number} type The type of the channel
+* @prop {Client} client The client that initialized the channel
 * @prop {Number} createdAt Timestamp of the channel's creation
 */
 class Channel extends Base {
-    constructor(data) {
+    constructor(data, client) {
         super(data.id);
         this.type = data.type;
+        this.client = client;
     }
 
     get mention() {
@@ -53,7 +55,7 @@ class Channel extends Base {
             return new GuildChannel(data, client);
         }
         client.emit("warn", new Error(`Unknown channel type: ${data.type}\n${JSON.stringify(data)}`));
-        return new Channel(data);
+        return new Channel(data, client);
     }
 
     toJSON(props = []) {

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -49,7 +49,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise<GroupChannel>}
     */
     edit(options) {
-        return this._client.editChannel.call(this._client, this.id, options);
+        return this.client.editChannel.call(this.client, this.id, options);
     }
 
     /**
@@ -58,7 +58,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise}
     */
     addRecipient(userID) {
-        return this._client.addGroupRecipient.call(this._client, this.id, userID);
+        return this.client.addGroupRecipient.call(this.client, this.id, userID);
     }
 
     /**
@@ -67,11 +67,11 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise}
     */
     removeRecipient(userID) {
-        return this._client.removeGroupRecipient.call(this._client, this.id, userID);
+        return this.client.removeGroupRecipient.call(this.client, this.id, userID);
     }
 
     get iconURL() {
-        return this.icon ? this._client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon)) : null;
+        return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon)) : null;
     }
 
     /**
@@ -80,7 +80,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @arg {Number} [size] The size of the icon (any power of two between 16 and 2048)
     */
     dynamicIconURL(format, size) {
-        return this.icon ? this._client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
+        return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
     }
 
     toJSON(props = []) {

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -21,8 +21,7 @@ const PermissionOverwrite = require("./PermissionOverwrite");
 */
 class GuildChannel extends Channel {
     constructor(data, client) {
-        super(data);
-        this._client = client;
+        super(data, client);
         this.guild = client.guilds.get(data.guild_id) || {
             id: data.guild_id
         };
@@ -97,7 +96,7 @@ class GuildChannel extends Channel {
     * @returns {Promise<CategoryChannel | TextChannel | VoiceChannel | NewsChannel>}
     */
     edit(options, reason) {
-        return this._client.editChannel.call(this._client, this.id, options, reason);
+        return this.client.editChannel.call(this.client, this.id, options, reason);
     }
 
     /**
@@ -106,7 +105,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     editPosition(position) {
-        return this._client.editChannelPosition.call(this._client, this.id, position);
+        return this.client.editChannelPosition.call(this.client, this.id, position);
     }
 
     /**
@@ -115,7 +114,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     delete(reason) {
-        return this._client.deleteChannel.call(this._client, this.id, reason);
+        return this.client.deleteChannel.call(this.client, this.id, reason);
     }
 
     /**
@@ -128,7 +127,7 @@ class GuildChannel extends Channel {
     * @returns {Promise<PermissionOverwrite>}
     */
     editPermission(overwriteID, allow, deny, type, reason) {
-        return this._client.editChannelPermission.call(this._client, this.id, overwriteID, allow, deny, type, reason);
+        return this.client.editChannelPermission.call(this.client, this.id, overwriteID, allow, deny, type, reason);
     }
 
     /**
@@ -138,7 +137,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     deletePermission(overwriteID, reason) {
-        return this._client.deleteChannelPermission.call(this._client, this.id, overwriteID, reason);
+        return this.client.deleteChannelPermission.call(this.client, this.id, overwriteID, reason);
     }
 
     toJSON(props = []) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -19,8 +19,7 @@ const User = require("./User");
 */
 class PrivateChannel extends Channel {
     constructor(data, client) {
-        super(data);
-        this._client = client;
+        super(data, client);
         this.lastMessageID = data.last_message_id;
         this.rateLimitPerUser = data.rate_limit_per_user;
         this.call = this.lastCall = null;
@@ -35,7 +34,7 @@ class PrivateChannel extends Channel {
     * @arg {String[]} recipients The IDs of the recipients to ring
     */
     ring(recipients) {
-        this._client.requestHandler.request("POST", Endpoints.CHANNEL_CALL_RING(this.id), true, {
+        this.client.requestHandler.request("POST", Endpoints.CHANNEL_CALL_RING(this.id), true, {
             recipients
         });
     }
@@ -44,7 +43,7 @@ class PrivateChannel extends Channel {
     * Check if the channel has an existing call
     */
     syncCall() {
-        this._client.shards.values().next().value.sendWS(GatewayOPCodes.SYNC_CALL, {
+        this.client.shards.values().next().value.sendWS(GatewayOPCodes.SYNC_CALL, {
             channel_id: this.id
         });
     }
@@ -54,7 +53,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     leave() {
-        return this._client.deleteChannel.call(this._client, this.id);
+        return this.client.deleteChannel.call(this.client, this.id);
     }
 
     /**
@@ -62,7 +61,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     sendTyping() {
-        return (this._client || this.guild.shard.client).sendChannelTyping.call((this._client || this.guild.shard.client), this.id);
+        return this.client.sendChannelTyping.call(this.client, this.id);
     }
 
     /**
@@ -71,7 +70,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return (this._client || this.guild.shard.client).getMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.getMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -83,7 +82,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message[]>}
     */
     getMessages(limit, before, after, around) {
-        return (this._client || this.guild.shard.client).getMessages.call((this._client || this.guild.shard.client), this.id, limit, before, after, around);
+        return this.client.getMessages.call(this.client, this.id, limit, before, after, around);
     }
 
     /**
@@ -91,7 +90,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message[]>}
     */
     getPins() {
-        return (this._client || this.guild.shard.client).getPins.call((this._client || this.guild.shard.client), this.id);
+        return this.client.getPins.call(this.client, this.id);
     }
 
     /**
@@ -108,7 +107,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return (this._client || this.guild.shard.client).createMessage.call((this._client || this.guild.shard.client), this.id, content, file);
+        return this.client.createMessage.call(this.client, this.id, content, file);
     }
 
     /**
@@ -122,7 +121,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return (this._client || this.guild.shard.client).editMessage.call((this._client || this.guild.shard.client), this.id, messageID, content);
+        return this.client.editMessage.call(this.client, this.id, messageID, content);
     }
 
     /**
@@ -131,7 +130,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     pinMessage(messageID) {
-        return (this._client || this.guild.shard.client).pinMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.pinMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -140,7 +139,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     unpinMessage(messageID) {
-        return (this._client || this.guild.shard.client).unpinMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.unpinMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -153,7 +152,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<User[]>}
     */
     getMessageReaction(messageID, reaction, limit, before, after) {
-        return (this._client || this.guild.shard.client).getMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, limit, before, after);
+        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, limit, before, after);
     }
 
     /**
@@ -164,7 +163,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction, userID) {
-        return (this._client || this.guild.shard.client).addMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, userID);
+        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -175,7 +174,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     removeMessageReaction(messageID, reaction, userID) {
-        return (this._client || this.guild.shard.client).removeMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, userID);
+        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -184,7 +183,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     removeMessageReactions(messageID) {
-        return (this._client || this.guild.shard.client).removeMessageReactions.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
     }
 
     /**
@@ -194,7 +193,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return (this._client || this.guild.shard.client).deleteMessage.call((this._client || this.guild.shard.client), this.id, messageID, reason);
+        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
     }
 
     /**
@@ -203,7 +202,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     unsendMessage(messageID) {
-        return (this._client || this.guild.shard.client).deleteMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.deleteMessage.call(this.client, this.id, messageID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -47,7 +47,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Invite[]>}
     */
     getInvites() {
-        return this.guild.shard.client.getChannelInvites.call(this.guild.shard.client, this.id);
+        return this.client.getChannelInvites.call(this.client, this.id);
     }
 
     /**
@@ -61,7 +61,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Invite>}
     */
     createInvite(options, reason) {
-        return this.guild.shard.client.createChannelInvite.call(this.guild.shard.client, this.id, options, reason);
+        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
     }
 
     /**
@@ -69,7 +69,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object[]>} Resolves with an array of webhook objects
     */
     getWebhooks() {
-        return this.guild.shard.client.getChannelWebhooks.call(this.guild.shard.client, this.id);
+        return this.client.getChannelWebhooks.call(this.client, this.id);
     }
 
     /**
@@ -81,7 +81,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object>} Resolves with a webhook object
     */
     createWebhook(options, reason) {
-        return this.guild.shard.client.createChannelWebhook.call(this.guild.shard.client, this.id, options, reason);
+        return this.client.createChannelWebhook.call(this.client, this.id, options, reason);
     }
 
     /**
@@ -90,7 +90,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessages(messageIDs) {
-        return this.guild.shard.client.deleteMessages.call(this.guild.shard.client, this.id, messageIDs);
+        return this.client.deleteMessages.call(this.client, this.id, messageIDs);
     }
 
     /**
@@ -102,7 +102,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
     purge(limit, filter, before, after) {
-        return this.guild.shard.client.purgeChannel.call(this.guild.shard.client, this.id, limit, filter, before, after);
+        return this.client.purgeChannel.call(this.client, this.id, limit, filter, before, after);
     }
 
     /**
@@ -110,7 +110,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     sendTyping() {
-        return (this._client || this.guild.shard.client).sendChannelTyping.call((this._client || this.guild.shard.client), this.id);
+        return this.client.sendChannelTyping.call(this.client, this.id);
     }
 
     /**
@@ -119,7 +119,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return (this._client || this.guild.shard.client).getMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.getMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -131,7 +131,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message[]>}
     */
     getMessages(limit, before, after, around) {
-        return (this._client || this.guild.shard.client).getMessages.call((this._client || this.guild.shard.client), this.id, limit, before, after, around);
+        return this.client.getMessages.call(this.client, this.id, limit, before, after, around);
     }
 
     /**
@@ -139,7 +139,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message[]>}
     */
     getPins() {
-        return (this._client || this.guild.shard.client).getPins.call((this._client || this.guild.shard.client), this.id);
+        return this.client.getPins.call(this.client, this.id);
     }
 
     /**
@@ -156,7 +156,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return (this._client || this.guild.shard.client).createMessage.call((this._client || this.guild.shard.client), this.id, content, file);
+        return this.client.createMessage.call(this.client, this.id, content, file);
     }
 
     /**
@@ -170,7 +170,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return (this._client || this.guild.shard.client).editMessage.call((this._client || this.guild.shard.client), this.id, messageID, content);
+        return this.client.editMessage.call(this.client, this.id, messageID, content);
     }
 
     /**
@@ -179,7 +179,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     pinMessage(messageID) {
-        return (this._client || this.guild.shard.client).pinMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.pinMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -188,7 +188,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     unpinMessage(messageID) {
-        return (this._client || this.guild.shard.client).unpinMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.unpinMessage.call(this.client, this.id, messageID);
     }
 
     /**
@@ -201,7 +201,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<User[]>}
     */
     getMessageReaction(messageID, reaction, limit, before, after) {
-        return (this._client || this.guild.shard.client).getMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, limit, before, after);
+        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, limit, before, after);
     }
 
     /**
@@ -212,7 +212,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction, userID) {
-        return (this._client || this.guild.shard.client).addMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, userID);
+        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -223,7 +223,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReaction(messageID, reaction, userID) {
-        return (this._client || this.guild.shard.client).removeMessageReaction.call((this._client || this.guild.shard.client), this.id, messageID, reaction, userID);
+        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -232,7 +232,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReactions(messageID) {
-        return (this._client || this.guild.shard.client).removeMessageReactions.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
     }
 
     /**
@@ -242,7 +242,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return (this._client || this.guild.shard.client).deleteMessage.call((this._client || this.guild.shard.client), this.id, messageID, reason);
+        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
     }
 
     /**
@@ -251,7 +251,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     unsendMessage(messageID) {
-        return (this._client || this.guild.shard.client).deleteMessage.call((this._client || this.guild.shard.client), this.id, messageID);
+        return this.client.deleteMessage.call(this.client, this.id, messageID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -21,8 +21,8 @@ const Member = require("./Member");
 * @prop {Collection<Member>?} voiceMembers Collection of Members in this channel
 */
 class VoiceChannel extends GuildChannel {
-    constructor(data, guild) {
-        super(data, guild);
+    constructor(data, client) {
+        super(data, client);
         this.voiceMembers = new Collection(Member);
         this.update(data);
     }
@@ -43,7 +43,7 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<Invite[]>}
     */
     getInvites() {
-        return this.guild.shard.client.getChannelInvites.call(this.guild.shard.client, this.id);
+        return this.client.getChannelInvites.call(this.client, this.id);
     }
 
     /**
@@ -57,7 +57,7 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<Invite>}
     */
     createInvite(options, reason) {
-        return this.guild.shard.client.createChannelInvite.call(this.guild.shard.client, this.id, options, reason);
+        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
     }
 
     /**
@@ -68,14 +68,14 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
     */
     join(options) {
-        return this.guild.shard.client.joinVoiceChannel.call(this.guild.shard.client, this.id, options);
+        return this.client.joinVoiceChannel.call(this.client, this.id, options);
     }
 
     /**
     * Leaves the channel.
     */
     leave() {
-        return this.guild.shard.client.leaveVoiceChannel.call(this.guild.shard.client, this.id);
+        return this.client.leaveVoiceChannel.call(this.client, this.id);
     }
 
     toJSON(props = []) {


### PR DESCRIPTION
Currently, there's no way to access the `Client` from a `Message` that was sent in DMs. Use cases for this aren't that uncommon and for those, the only option is to use internals. This can be effortlessly solved by exposing `Channel.client`.