### PR TITLE
Convert all Message<this> to Message for now

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,13 +40,13 @@ declare namespace Eris {
 
   interface Textable {
     lastMessageID: string;
-    messages: Collection<Message<this>>;
+    messages: Collection<Message>;
     sendTyping(): Promise<void>;
-    getMessage(messageID: string): Promise<Message<this>>;
-    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message<this>[]>;
-    getPins(): Promise<Message<this>[]>;
-    createMessage(content: MessageContent, file?: MessageFile): Promise<Message<this>>;
-    editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
+    getMessage(messageID: string): Promise<Message>;
+    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message[]>;
+    getPins(): Promise<Message[]>;
+    createMessage(content: MessageContent, file?: MessageFile): Promise<Message>;
+    editMessage(messageID: string, content: MessageContent): Promise<Message>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
     getMessageReaction(
@@ -1410,18 +1410,18 @@ declare namespace Eris {
     topic?: string;
     lastMessageID: string;
     rateLimitPerUser: number;
-    messages: Collection<Message<this>>;
+    messages: Collection<Message>;
     lastPinTimestamp?: number;
     getInvites(): Promise<Invite[]>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite>;
     getWebhooks(): Promise<Webhook[]>;
     createWebhook(options: { name: string; avatar: string }, reason?: string): Promise<Webhook>;
     sendTyping(): Promise<void>;
-    getMessage(messageID: string): Promise<Message<this>>;
-    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message<this>[]>;
-    getPins(): Promise<Message<this>[]>;
-    createMessage(content: MessageContent, file?: MessageFile): Promise<Message<this>>;
-    editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
+    getMessage(messageID: string): Promise<Message>;
+    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message[]>;
+    getPins(): Promise<Message[]>;
+    createMessage(content: MessageContent, file?: MessageFile): Promise<Message>;
+    editMessage(messageID: string, content: MessageContent): Promise<Message>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
     getMessageReaction(
@@ -1434,7 +1434,7 @@ declare namespace Eris {
     addMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
-    purge(limit: number, filter?: (message: Message<this>) => boolean, before?: string, after?: string): Promise<number>;
+    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string): Promise<number>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[]): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
@@ -1635,16 +1635,16 @@ declare namespace Eris {
     type: 1 | 3;
     lastMessageID: string;
     recipient: User;
-    messages: Collection<Message<this>>;
+    messages: Collection<Message>;
     ring(recipient: string[]): void;
     syncCall(): void;
     leave(): Promise<void>;
     sendTyping(): Promise<void>;
-    getMessage(messageID: string): Promise<Message<this>>;
-    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message<this>[]>;
-    getPins(): Promise<Message<this>[]>;
-    createMessage(content: MessageContent, file?: MessageFile): Promise<Message<this>>;
-    editMessage(messageID: string, content: MessageContent): Promise<Message<this>>;
+    getMessage(messageID: string): Promise<Message>;
+    getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message[]>;
+    getPins(): Promise<Message[]>;
+    createMessage(content: MessageContent, file?: MessageFile): Promise<Message>;
+    editMessage(messageID: string, content: MessageContent): Promise<Message>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
     getMessageReaction(


### PR DESCRIPTION
Partial revert of #621, ref https://github.com/microsoft/TypeScript/issues/36307

#621 introduced some strange behavior that nobody really expected before it was tested more thoroughly. The way Typescript handles this particular situation is inaccurate and results in the `Promse` returned by these methods being weirdly broken (`.then` not being callable because of conflicting union types).