### PR TITLE
Await command requirements check, fixes #627

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -281,7 +281,7 @@ class Command {
         }
 
         let reply;
-        if(!this.permissionCheck(msg)) {
+        if(!await this.permissionCheck(msg)) {
             if(this.hooks.postCheck) {
                 const response = await Promise.resolve(this.hooks.postCheck(msg, args, false));
                 if(response) {


### PR DESCRIPTION
Adds an `await` to an async function call so commands will fail properly when requirements are unfulfilled. Without `await`, this block was never executed since promises are truthy.