### PR TITLE
remove optional

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1502,7 +1502,7 @@ declare namespace Eris {
     type: 2;
     bitrate?: number;
     userLimit?: number;
-    voiceMembers?: Collection<Member>;
+    voiceMembers: Collection<Member>;
     getInvites(): Promise<Invite[]>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite>;
     join(options: VoiceResourceOptions): Promise<VoiceConnection>;

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -18,7 +18,7 @@ const Member = require("./Member");
 * @prop {Collection<PermissionOverwrite>} permissionOverwrites Collection of PermissionOverwrites in this channel
 * @prop {Number?} bitrate The bitrate of the channel
 * @prop {Number?} userLimit The max number of users that can join the channel
-* @prop {Collection<Member>?} voiceMembers Collection of Members in this channel
+* @prop {Collection<Member>} voiceMembers Collection of Members in this channel
 */
 class VoiceChannel extends GuildChannel {
     constructor(data, client) {


### PR DESCRIPTION
This PR removes the optional type from voiceMembers as it is always present as an empty collection or a collection with members.