### PR TITLE
align activity type with docs

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -120,11 +120,6 @@ declare namespace Eris {
     url?: string;
   }
   interface Activity extends ActivityPartial<ActivityType> {
-    // start undocumented props
-    id: string;
-    sync_id?: string;
-    session_id?: string;
-    // end undocumented props
     created_at: number;
     timestamps?: { start: number; end?: number };
     application_id?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -130,7 +130,7 @@ declare namespace Eris {
     application_id?: string;
     details?: string;
     state?: string;
-    emoji?: { name: string; id?: string; animated?: boolean }
+    emoji?: { name: string; id?: string; animated?: boolean };
     party?: { id?: string; size?: [number, number] };
     assets?: {
       small_text?: string;
@@ -139,7 +139,7 @@ declare namespace Eris {
       large_image?: string;
       [key: string]: unknown;
     };
-    secrets?: { join?: string; spectate?: string; match?: string }
+    secrets?: { join?: string; spectate?: string; match?: string };
     instance?: boolean;
     flags?: number;
     // the stuff attached to this object apparently varies even more than documented, so...

--- a/index.d.ts
+++ b/index.d.ts
@@ -105,10 +105,10 @@ declare namespace Eris {
   }
 
   interface Presence {
-    activities?: AnyActivity[];
+    activities?: Activity[];
     clientStatus?: ClientStatus;
     status: Status;
-    game?: AnyActivity;
+    game?: Activity;
   }
 
   type BotActivityType = 0 | 1 | 2 | 3
@@ -120,17 +120,18 @@ declare namespace Eris {
     url?: string;
   }
   interface Activity extends ActivityPartial<ActivityType> {
+    // start undocumented props
     id: string;
+    sync_id?: string;
+    session_id?: string;
+    // end undocumented props
     created_at: number;
-  }
-
-  interface RichActivity extends Activity {
     timestamps?: { start: number; end?: number };
     application_id?: string;
-    sync_id?: string;
     details?: string;
     state?: string;
-    party?: { id?: string };
+    emoji?: { name: string; id?: string; animated?: boolean }
+    party?: { id?: string; size?: [number, number] };
     assets?: {
       small_text?: string;
       small_image?: string;
@@ -138,13 +139,12 @@ declare namespace Eris {
       large_image?: string;
       [key: string]: unknown;
     };
+    secrets?: { join?: string; spectate?: string; match?: string }
     instance?: boolean;
     flags?: number;
     // the stuff attached to this object apparently varies even more than documented, so...
     [key: string]: unknown;
   }
-
-  type AnyActivity = Activity | RichActivity
 
   interface OldVoiceState {
     mute: boolean;
@@ -1583,10 +1583,10 @@ declare namespace Eris {
     defaultAvatarURL: string;
     avatarURL: string;
     staticAvatarURL: string;
-    game?: AnyActivity;
+    game?: Activity;
     status: Status;
     clientStatus?: ClientStatus;
-    activities?: AnyActivity[];
+    activities?: Activity[];
     constructor(data: BaseData, guild: Guild);
     edit(options: MemberOptions, reason?: string): Promise<void>;
     addRole(roleID: string, reason?: string): Promise<void>;
@@ -1700,10 +1700,10 @@ declare namespace Eris {
     id: string;
     user: User;
     type: number;
-    game?: AnyActivity;
+    game?: Activity;
     status: Status;
     clientStatus?: ClientStatus;
-    activities?: AnyActivity[];
+    activities?: Activity[];
     constructor(data: BaseData, client: Client);
   }
 


### PR DESCRIPTION
- Removed RichActivity since discord does not have this
- Added/fixed props found in Discord docs
  - emoji (new)
  - secrets (new)
  - party (added to)
- ~~Added props found in practice and marked which props are undocumented~~
  - ~~session_id~~
- Removed undocumented props