### PR TITLE
Improve documentation for reactionRemoveAll

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -585,7 +585,7 @@ class Shard extends EventEmitter {
                     break;
                 }
                 /**
-                * Fired when someone removes a reaction from a message
+                * Fired when all reactions are removed from a message
                 * @event Client#messageReactionRemoveAll
                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
                 */


### PR DESCRIPTION
This PR improves the wording for `reactionRemoveAll` documentation as it was the same as `reactionRemove`.