### PR TITLE
Expose publicUpdatesChannelID and rulesChannelID property on Guild

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1306,6 +1306,7 @@ declare namespace Eris {
     emojis: Emoji[];
     iconURL?: string;
     explicitContentFilter: number;
+    publicUpdatesChannelID: string;
     constructor(data: BaseData, client: Client);
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -581,11 +581,16 @@ declare namespace Eris {
     verificationLevel?: number;
     defaultNotifications?: number;
     explicitContentFilter?: number;
+    systemChannelID?: string;
+    rulesChannelID?: string;
+    publicUpdatesChannelID?: string;
+    preferredLocale?: string;
     afkChannelID?: string;
     afkTimeout?: number;
     ownerID?: string;
     splash?: string;
     banner?: string;
+    description?: string;
   }
   interface OldGuild {
     name: string;
@@ -1307,6 +1312,7 @@ declare namespace Eris {
     iconURL?: string;
     explicitContentFilter: number;
     publicUpdatesChannelID: string;
+    rulesChannelID: string;
     constructor(data: BaseData, client: Client);
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1400,6 +1400,9 @@ class Client extends EventEmitter {
     * @arg {Number} [options.defaultNotifications] The default notification settings for the guild. 0 is "All Messages", 1 is "Only @mentions".
     * @arg {Number} [options.explicitContentFilter] The level of the explicit content filter for messages/images in the guild. 0 disables message scanning, 1 enables scanning the messages of members without roles, 2 enables scanning for all messages.
     * @arg {String} [options.systemChannelID] The ID of the system channel
+    * @arg {String} [options.rulesChannelID] The id of the channel where "PUBLIC" guilds display rules and/or guidelines
+    * @arg {String} [options.publicUpdatesChannelID] The id of the channel where admins and moderators of "PUBLIC" guilds receive notices from Discord
+    * @arg {String} [options.preferredLocale] Preferred "PUBLIC" guild language used in server discovery and notices from Discord
     * @arg {String} [options.afkChannelID] The ID of the AFK voice channel
     * @arg {Number} [options.afkTimeout] The AFK timeout in seconds
     * @arg {String} [options.ownerID] The ID of the user to transfer server ownership to (bot user must be owner)
@@ -1418,6 +1421,9 @@ class Client extends EventEmitter {
             default_message_notifications: options.defaultNotifications,
             explicit_content_filter: options.explicitContentFilter,
             system_channel_id: options.systemChannelID,
+            rules_channel_id: options.rulesChannelID,
+            public_updates_channel_id: options.publicUpdatesChannelID,
+            preferred_locale: options.preferredLocale,
             afk_channel_id: options.afkChannelID,
             afk_timeout: options.afkTimeout,
             owner_id: options.ownerID,

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -23,7 +23,7 @@ const VoiceState = require("./VoiceState");
 * @prop {Number} mfaLevel The admin 2FA level for the guild. 0 is not required, 1 is required
 * @prop {Number} joinedAt Timestamp of when the bot account joined the guild
 * @prop {String} ownerID The ID of the user that is the guild owner
-* @prop {String?} systemChannelID The ID of the default channel for system messages (built-in join messages)
+* @prop {String?} systemChannelID The ID of the default channel for system messages (built-in join messages and boost messages)
 * @prop {String?} splash The hash of the guild splash image, or null if no splash (VIP only)
 * @prop {String?} banner The hash of the guild banner image, or null if no banner (VIP only)
 * @prop {Boolean} unavailable Whether the guild is unavailable or not
@@ -42,10 +42,11 @@ const VoiceState = require("./VoiceState");
 * @prop {Number} premiumTier Nitro boost level of the guild
 * @prop {Number?} premiumSubscriptionCount The total number of users currently boosting this guild
 * @prop {String?} vanityURL The vanity URL of the guild (VIP only)
-* @prop {String} preferredLocale Preferred guild language
+* @prop {String} preferredLocale Preferred "PUBLIC" guild language used in server discovery and notices from Discord
 * @prop {String?} description The description for the guild (VIP only)
 * @prop {Number} maxMembers The maximum amount of members for the guild
-* @prop {String?} publicUpdatesChannelID ID of the guild's public updates channel if the guild has public features
+* @prop {String?} publicUpdatesChannelID ID of the guild's updates channel if the guild has "PUBLIC" features
+* @prop {String?} rulesChannelID The channel where "PUBLIC" guilds display rules and/or guidelines
 */
 class Guild extends Base {
     constructor(data, client) {
@@ -194,6 +195,9 @@ class Guild extends Base {
         }
         if(data.public_updates_channel_id !== undefined) {
             this.publicUpdatesChannelID = data.public_updates_channel_id;
+        }
+        if(data.rules_channel_id !== undefined) {
+            this.rulesChannelID = data.rules_channel_id;
         }
     }
 
@@ -580,11 +584,15 @@ class Guild extends Base {
     * @arg {Number} [options.defaultNotifications] The default notification settings for the guild. 0 is "All Messages", 1 is "Only @mentions".
     * @arg {Number} [options.explicitContentFilter] The level of the explicit content filter for messages/images in the guild. 0 disables message scanning, 1 enables scanning the messages of members without roles, 2 enables scanning for all messages.
     * @arg {String} [options.systemChannelID] The ID of the system channel
+    * @arg {String} [options.rulesChannelID] The id of the channel where "PUBLIC" guilds display rules and/or guidelines
+    * @arg {String} [options.publicUpdatesChannelID] The id of the channel where admins and moderators of "PUBLIC" guilds receive notices from Discord
+    * @arg {String} [options.preferredLocale] Preferred "PUBLIC" guild language used in server discovery and notices from Discord
     * @arg {String} [options.afkChannelID] The ID of the AFK voice channel
     * @arg {Number} [options.afkTimeout] The AFK timeout in seconds
     * @arg {String} [options.ownerID] The ID of the member to transfer guild ownership to (bot user must be owner)
     * @arg {String} [options.splash] The guild splash image as a base64 data URI (VIP only). Note: base64 strings alone are not base64 data URI strings
     * @arg {String} [options.banner] The guild banner image as a base64 data URI (VIP only). Note: base64 strings alone are not base64 data URI strings
+    * @arg {String} [options.description] The description for the guild (VIP only)
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Guild>}
     */

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -45,6 +45,7 @@ const VoiceState = require("./VoiceState");
 * @prop {String} preferredLocale Preferred guild language
 * @prop {String?} description The description for the guild (VIP only)
 * @prop {Number} maxMembers The maximum amount of members for the guild
+* @prop {String?} publicUpdatesChannelID ID of the guild's public updates channel if the guild has public features
 */
 class Guild extends Base {
     constructor(data, client) {
@@ -190,6 +191,9 @@ class Guild extends Base {
         }
         if(data.max_members !== undefined) {
             this.maxMembers = data.max_members;
+        }
+        if(data.public_updates_channel_id !== undefined) {
+            this.publicUpdatesChannelID = data.public_updates_channel_id;
         }
     }
 


### PR DESCRIPTION
This PR adds the `publicUpdatesChannelID ` to Guild.
Ref: discordapp/discord-api-docs#1353

We can discuss whereas we should resolve the actual channel or keep the id only. I am inclined to only keep the id only (as this PR does) to follow discord-api since it's easy to then resolve the actual Channel Object.