### PR TITLE
Handle more rest errors

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -173,13 +173,17 @@ class CommandClient extends Client {
                     }
                     let newMsg;
                     if(msg.command.errorMessage) {
-                        if(typeof msg.command.errorMessage === "function") {
-                            const reply = msg.command.errorMessage();
-                            if(reply !== undefined) {
-                                newMsg = await this.createMessage(msg.channel.id, reply);
+                        try {
+                            if(typeof msg.command.errorMessage === "function") {
+                                const reply = msg.command.errorMessage();
+                                if(reply !== undefined) {
+                                    newMsg = await this.createMessage(msg.channel.id, reply);
+                                }
+                            } else {
+                                newMsg = await this.createMessage(msg.channel.id, msg.command.errorMessage);
                             }
-                        } else {
-                            newMsg = await this.createMessage(msg.channel.id, msg.command.errorMessage);
+                        } catch(err) {
+                            this.emit("error", err);
                         }
                     }
                     if(msg.command.hooks.postCommand) {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -201,6 +201,9 @@ class RequestHandler {
 
                     _respStream.on("data", (str) => {
                         response += str;
+                    }).on("error", (err) => {
+                        reqError = err;
+                        req.abort();
                     }).once("end", () => {
                         const now = Date.now();
 


### PR DESCRIPTION
- Stream errors must be handled to prevent crash. E.g. abort while receiving a response may cause "zlib methods will throw an error when decompressing truncated data."
- Catch _createMessage()_ reject while senging _errorMessage_.