### PR TITLE
Fix: permissionCheck() verification

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -281,7 +281,7 @@ class Command {
         }
 
         let reply;
-        if(!this.permissionCheck(msg)) {
+        if(!(await this.permissionCheck(msg))) {
             if(this.hooks.postCheck) {
                 const response = await Promise.resolve(this.hooks.postCheck(msg, args, false));
                 if(response) {


### PR DESCRIPTION
permissionCheck() is async, returning a "Promise {Pending}" Object when checked. this returns a falsy positive state.