### PR TITLE
Emit shard disconnect after reset

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -109,15 +109,16 @@ class Shard extends EventEmitter {
             this.emit("error", err, this.id);
         }
 
+        this.ws = null;
+        this.reset();
+
         /**
         * Fired when the shard disconnects
         * @event Shard#disconnect
         * @prop {Error?} err The error, if any
         */
         super.emit("disconnect", error || null);
-        this.ws = null;
 
-        this.reset();
         if(options.reconnect === "auto" && this.client.options.autoreconnect) {
             /**
             * Fired when stuff happens and gives more info


### PR DESCRIPTION
Figured out that the current shard that is disconnecting still will be read as `ready` when the shard manager checks all shards before emitting `disconnect`.

Not too sure what else this would impact, but it should fix the purpose of that event.