### PR TITLE
Correctly document all USER ACCOUNT methods

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -879,7 +879,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Accept an invite (not for bot accounts)
+    * [USER ACCOUNT] Accept an invite
     * @arg {String} inviteID The ID of the invite
     * @returns {Promise<Invite>}
     */
@@ -934,7 +934,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Create a group channel with other users
+    * [USER ACCOUNT] Create a group channel with other users
     * @arg {String[]} userIDs The IDs of the other users
     * @returns {Promise<PrivateChannel>}
     */
@@ -1573,7 +1573,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Create a relationship with a user
+    * [USER ACCOUNT] Create a relationship with a user
     * @arg {String} userID The ID of the target user
     * @arg {Boolean} [block=false] If true, block the user. Otherwise, add the user as a friend
     * @returns {Promise}
@@ -1585,7 +1585,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Remove a relationship with a user
+    * [USER ACCOUNT] Remove a relationship with a user
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
     */
@@ -1594,7 +1594,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Add a user to a group
+    * [USER ACCOUNT] Add a user to a group
     * @arg {String} groupID The ID of the target group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
@@ -1604,7 +1604,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Remove a user from a group
+    * [USER ACCOUNT] Remove a user from a group
     * @arg {String} groupID The ID of the target group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
@@ -1614,7 +1614,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get profile data for a user (user accounts only)
+    * [USER ACCOUNT] Get profile data for a user
     * @arg {String} userID The ID of the target user
     * @returns {Promise<Object>} The user's profile data.
     */
@@ -1623,7 +1623,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edit the current user's note for another user (user accounts only)
+    * [USER ACCOUNT] Edit the current user's note for another user
     * @arg {String} userID The ID of the target user
     * @arg {String} note The note
     * @returns {Promise}
@@ -1635,7 +1635,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Delete the current user's note for another user (user accounts only)
+    * [USER ACCOUNT] Delete the current user's note for another user
     * @returns {Promise}
     */
     deleteUserNote(userID) {
@@ -1643,7 +1643,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get the connections for the current user (user accounts only)
+    * [USER ACCOUNT] Get the connections for the current user
     * @returns {Promise<Object>} The user's connections
     */
     getSelfConnections() {
@@ -1651,7 +1651,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edit a connection for the current user (user accounts only)
+    * [USER ACCOUNT] Edit a connection for the current user
     * @arg {String} platform The connection platform (e.g. "twitch", "reddit")
     * @arg {String} id The connection ID
     * @arg {Object} data The connection data
@@ -1667,7 +1667,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Delete a connection for the current user (user accounts only)
+    * [USER ACCOUNT] Delete a connection for the current user
     * @arg {String} platform The connection platform (e.g. "twitch", "reddit")
     * @arg {String} id The connection ID
     * @returns {Promise}
@@ -1677,7 +1677,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get settings for the current user (user accounts only)
+    * [USER ACCOUNT] Get settings for the current user
     * @returns {Promise<Object>} The user's settings data.
     */
     getSelfSettings() {
@@ -1685,7 +1685,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edit settings for the current user (user accounts only)
+    * [USER ACCOUNT] Edit settings for the current user
     * @arg {Object} data The user settings data
     * @arg {Boolean} [data.convertEmoticons] Whether to convert emoticons or not (e.g. :D => 😄)
     * @arg {Boolean} [data.detectPlatformAccounts] Whether to automatically detect accounts from other platforms or not (Blizzard, Skype, etc.)
@@ -1743,7 +1743,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get the MFA backup codes for the current user (user accounts only)
+    * [USER ACCOUNT] Get the MFA backup codes for the current user
     * @arg {String} password The password for the current user
     * @arg {Boolean} [regenerate] Whether to regenerate the MFA backup codes or not
     * @returns {Promise<Object>} The user's MFA codes
@@ -1756,7 +1756,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Enable TOTP authentication for the current user (user accounts only)
+    * [USER ACCOUNT] Enable TOTP authentication for the current user
     * @arg {String} secret The TOTP secret used to generate the auth code
     * @arg {String} code The timed auth code for the current user
     * @returns {Promise<Object>} An object containing the user's new authorization token and backup codes
@@ -1773,7 +1773,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Disable TOTP authentication for the current user (user accounts only)
+    * [USER ACCOUNT] Disable TOTP authentication for the current user
     * @arg {String} code The timed auth code for the current user
     * @returns {Promise<Object>} An object containing the user's new authorization token
     */
@@ -1788,7 +1788,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get the billing info for the current user (user accounts only)
+    * [USER ACCOUNT] Get the billing info for the current user
     * @returns {Promise<Object>} The user's billing info
     */
     getSelfBilling() {
@@ -1796,7 +1796,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get the payment history for the current user (user accounts only)
+    * [USER ACCOUNT]Get the payment history for the current user
     * @returns {Promise<Object>} The user's payment history
     */
     getSelfPayments() {
@@ -1804,7 +1804,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Purchase a premium subscription (Nitro) for the current user (user accounts only)
+    * [USER ACCOUNT] Purchase a premium subscription (Nitro) for the current user
     * You must get a Stripe card token from the Stripe API for this to work
     * @arg {String} token The Stripe credit card token
     * @arg {String} plan The plan to purchase, either "premium_month" or "premium_year"
@@ -1819,7 +1819,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Cancel the premium subscription (Nitro) for the current user (user accounts only)
+    * [USER ACCOUNT] Cancel the premium subscription (Nitro) for the current user
     * @returns {Promise}
     */
     deleteSelfPremiumSubscription() {
@@ -1962,7 +1962,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Search a channel's messages
+    * [USER ACCOUNT] Search a channel's messages
     * @arg {String} channelID The ID of the channel
     * @arg {Object} query Search parameters
     * @arg {String} [query.sortBy="timestamp"] What to sort by, either "timestamp" or "relevance"
@@ -2016,7 +2016,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Search a guild's messages
+    * [USER ACCOUNT] Search a guild's messages
     * @arg {String} guildID The ID of the guild
     * @arg {Object} query Search parameters
     * @arg {String} [query.sortBy="timestamp"] What to sort by, either "timestamp" or "relevance"

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1796,7 +1796,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [USER ACCOUNT]Get the payment history for the current user
+    * [USER ACCOUNT] Get the payment history for the current user
     * @returns {Promise<Object>} The user's payment history
     */
     getSelfPayments() {

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -6,7 +6,7 @@ const PrivateChannel = require("./PrivateChannel");
 const User = require("./User");
 
 /**
-* Represents a group channel. See PrivateChannel docs for additional properties.
+* [USER ACCOUNT] Represents a group channel. See PrivateChannel docs for additional properties.
 * @extends PrivateChannel
 * @prop {String} id The ID of the channel
 * @prop {String} mention A string that mentions the channel
@@ -41,7 +41,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * Edit the channel's properties
+    * [USER ACCOUNT] Edit the channel's properties
     * @arg {Object} options The properties to edit
     * @arg {String} [options.name] The name of the channel
     * @arg {String} [options.icon] The icon of the channel as a base64 data URI (group channels only). Note: base64 strings alone are not base64 data URI strings
@@ -53,7 +53,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * Add a user to the group
+    * [USER ACCOUNT] Add a user to the group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
     */
@@ -62,7 +62,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * Remove a user from the group
+    * [USER ACCOUNT] Remove a user from the group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
     */

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -30,7 +30,7 @@ class PrivateChannel extends Channel {
     }
 
     /**
-    * Ring fellow group channel recipient(s)
+    * [USER ACCOUNT] Ring fellow group channel recipient(s)
     * @arg {String[]} recipients The IDs of the recipients to ring
     */
     ring(recipients) {

--- a/lib/structures/Relationship.js
+++ b/lib/structures/Relationship.js
@@ -3,7 +3,7 @@
 const Base = require("./Base");
 
 /**
-* Represents a Relationship
+* [USER ACCOUNT] Represents a Relationship
 * @prop {User} user The other user in the relationship
 * @prop {Number} type The type of relationship. 1 is friend, 2 is block, 3 is incoming request, 4 is outgoing request
 * @prop {String} status The other user's status. Either "online", "idle", or "offline"

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -87,7 +87,7 @@ class User extends Base {
     }
 
     /**
-    * Create a relationship with the user (user accounts only)
+    * [USER ACCOUNT] Create a relationship with the user
     * @arg {Boolean} [block=false] If true, block the user. Otherwise, add the user as a friend
     * @returns {Promise}
     */
@@ -96,7 +96,7 @@ class User extends Base {
     }
 
     /**
-    * Remove a relationship with the user (user accounts only)
+    * [USER ACCOUNT] Remove a relationship with the user
     * @returns {Promise}
     */
     removeRelationship() {
@@ -104,7 +104,7 @@ class User extends Base {
     }
 
     /**
-    * Get profile data for the user (user accounts only)
+    * [USER ACCOUNT] Get profile data for the user
     * @returns {Promise<Object>} The user's profile data.
     */
     getProfile() {
@@ -112,7 +112,7 @@ class User extends Base {
     }
 
     /**
-    * Edit the current user's note for the user (user accounts only)
+    * [USER ACCOUNT] Edit the current user's note for the user
     * @arg {String} note The note
     * @returns {Promise}
     */
@@ -121,7 +121,7 @@ class User extends Base {
     }
 
     /**
-    * Delete the current user's note for another user (user accounts only)
+    * [USER ACCOUNT] Delete the current user's note for another user
     */
     deleteNote() {
         return this._client.deleteUserNote.call(this._client, this.id);


### PR DESCRIPTION
This PR correctly document user account methods. Some method were missing the flag in the documentation.  
To make it even clearer I changed it by adding `[USER ACCOUNT]` at the beginning of the method description directly.