### PR TITLE
Fix removeMessageReactionEmoji not encoding reaction.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1163,6 +1163,9 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     removeMessageReactionEmoji(channelID, messageID, reaction) {
+        if(reaction === decodeURI(reaction)) {
+            reaction = encodeURIComponent(reaction);
+        }
         return this.requestHandler.request("DELETE", Endpoints.CHANNEL_MESSAGE_REACTION(channelID, messageID, reaction), true);
     }
 


### PR DESCRIPTION
Contrary to `getMessageReaction`, `addMessageReaction` and `removeMessageReaction`, `removeMessageReactionEmoji` was not encoding the reaction in case it was not already encoded.
This PR addresses that by adding the same check as in the above methods.