### PR TITLE
Remove unusuable methods from Private channel (removeMessageReactionEmoji and removeMessageReactions)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -59,8 +59,6 @@ declare namespace Eris {
     ): Promise<User[]>;
     addMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
-    removeMessageReactions(messageID: string): Promise<void>;
-    removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
   }
@@ -1429,6 +1427,8 @@ declare namespace Eris {
     sendTyping(): Promise<void>;
     purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string): Promise<number>;
     deleteMessages(messageIDs: string[]): Promise<void>;
+    removeMessageReactions(messageID: string): Promise<void>;
+    removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
   }
 
   export class CategoryChannel extends GuildChannel {
@@ -1701,8 +1701,6 @@ declare namespace Eris {
     ): Promise<User[]>;
     addMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
-    removeMessageReactions(messageID: string): Promise<void>;
-    removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
   }

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -187,16 +187,6 @@ class PrivateChannel extends Channel {
     }
 
     /**
-    * Remove all reactions from a message for a single emoji
-    * @arg {String} messageID The ID of the message
-    * @arg {String} reaction The reaction (Unicode string if Unicode emoji, `emojiName:emojiID` if custom emoji)
-    * @returns {Promise}
-    */
-    removeMessageReactionEmoji(messageID, reaction) {
-        return this.client.removeMessageReactionEmoji.call(this.client, this.id, messageID, reaction);
-    }
-
-    /**
     * Delete a message
     * @arg {String} messageID The ID of the message
     * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -178,15 +178,6 @@ class PrivateChannel extends Channel {
     }
 
     /**
-    * Remove all reactions from a message
-    * @arg {String} messageID The ID of the message
-    * @returns {Promise}
-    */
-    removeMessageReactions(messageID) {
-        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
-    }
-
-    /**
     * Delete a message
     * @arg {String} messageID The ID of the message
     * @arg {String} [reason] The reason to be displayed in audit logs


### PR DESCRIPTION
This PR removes `removeMessageReactionEmoji` and `removeMessageReactions` from PrivateChannel as they seem to not be callable in PrivateChannel at all.
Trying to use these methods results in a direct error from the API: 
` DiscordRESTError [50003]: Cannot execute action on a DM channel`

As for the typings, deleting these methods directly seems to not be possible because `PrivateChannel` wouldn't be implementing `TextableChannel` entirely.
I'd like review on the best approach to do this.
