### PR TITLE
Adds @types/node to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ws": "^7.2.1"
   },
   "devDependencies": {
+    "@types/node": "^13.9.0",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
This PR just adds \@types/node to dev dependency for `index.d.ts`.