### PR TITLE
Update viewGuildAnalytics to viewGuildInsights 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -214,7 +214,7 @@ declare namespace Eris {
       readMessageHistory: 65536;
       mentionEveryone: 131072;
       externalEmojis: 262144;
-      viewGuildAnalytics: 524288;
+      viewGuildInsights: 524288;
       voiceConnect: 1048576;
       voiceSpeak: 2097152;
       voiceMuteMembers: 4194304;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -52,7 +52,7 @@ module.exports.Permissions = {
     readMessageHistory:   1 << 16,
     mentionEveryone:      1 << 17,
     externalEmojis:       1 << 18,
-    viewGuildAnalytics:   1 << 19,
+    viewGuildInsights:    1 << 19,
     voiceConnect:         1 << 20,
     voiceSpeak:           1 << 21,
     voiceMuteMembers:     1 << 22,


### PR DESCRIPTION
Apparently `viewGuildAnalytics` was added in #523 but was never actually documented in discord API docs.
Whatsoever, this PR updates it to reflect the actual name used in API docs. See discordapp/discord-api-docs#1421