### PR TITLE
Prefix _token to emphasize it is private

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -859,7 +859,7 @@ declare namespace Eris {
   }
 
   export class Client extends EventEmitter {
-    _token?: string;
+    token?: string;
     gatewayURL?: string;
     bot?: boolean;
     options: ClientOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -859,7 +859,7 @@ declare namespace Eris {
   }
 
   export class Client extends EventEmitter {
-    token?: string;
+    _token?: string;
     gatewayURL?: string;
     bot?: boolean;
     options: ClientOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -859,7 +859,6 @@ declare namespace Eris {
   }
 
   export class Client extends EventEmitter {
-    token?: string;
     gatewayURL?: string;
     bot?: boolean;
     options: ClientOptions;

--- a/index.d.ts
+++ b/index.d.ts
@@ -913,6 +913,7 @@ declare namespace Eris {
   }
 
   export class Client extends EventEmitter {
+    token?: string;
     gatewayURL?: string;
     bot?: boolean;
     options: ClientOptions;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -187,6 +187,12 @@ class Client extends EventEmitter {
         return this.startTime ? Date.now() - this.startTime : 0;
     }
 
+    _validateToken() {
+        if(!this._token.startsWith("Bot ")) {
+            this._token = "Bot " + this._token;
+        }
+    }
+
     /**
     * Tells all shards to connect.
     * @returns {Promise} Resolves when all shards are initialized
@@ -247,9 +253,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} Resolves with an object containing gateway connection info
     */
     getBotGateway() {
-        if(!this._token.startsWith("Bot ")) {
-            this._token = "Bot " + this._token;
-        }
+        this._validateToken();
         return this.requestHandler.request("GET", Endpoints.GATEWAY_BOT, true);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -47,7 +47,7 @@ const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 /**
 * Represents the main Eris client
 * @extends EventEmitter
-* @prop {String} token The bot user token
+* @prop {String} _token The bot user token
 * @prop {Boolean?} bot Whether the bot user belongs to an OAuth2 application
 * @prop {Object} options Eris options
 * @prop {Object} channelGuildMap Object mapping channel IDs to guild IDs
@@ -147,7 +147,7 @@ class Client extends EventEmitter {
             this.options.ws.agent = this.options.agent;
         }
 
-        this.token = token;
+        this._token = token;
 
         this.requestHandler = new RequestHandler(this);
 
@@ -177,6 +177,10 @@ class Client extends EventEmitter {
         this.connect = this.connect.bind(this);
         this.lastReconnectDelay = 0;
         this.reconnectAttempts = 0;
+    }
+
+    get token() {
+        return this._token;
     }
 
     get uptime() {
@@ -243,8 +247,8 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} Resolves with an object containing gateway connection info
     */
     getBotGateway() {
-        if(!this.token.startsWith("Bot ")) {
-            this.token = "Bot " + this.token;
+        if(!this._token.startsWith("Bot ")) {
+            this._token = "Bot " + this._token;
         }
         return this.requestHandler.request("GET", Endpoints.GATEWAY_BOT, true);
     }
@@ -1767,7 +1771,7 @@ class Client extends EventEmitter {
             code
         }).then((data) => {
             if(data.token) {
-                this.token = data.token;
+                this._token = data.token;
             }
         });
     }
@@ -1782,7 +1786,7 @@ class Client extends EventEmitter {
             code
         }).then((data) => {
             if(data.token) {
-                this.token = data.token;
+                this._token = data.token;
             }
         });
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -47,7 +47,6 @@ const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 /**
 * Represents the main Eris client
 * @extends EventEmitter
-* @prop {String} _token The bot user token
 * @prop {Boolean?} bot Whether the bot user belongs to an OAuth2 application
 * @prop {Object} options Eris options
 * @prop {Object} channelGuildMap Object mapping channel IDs to guild IDs

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -48,6 +48,7 @@ const sleep = (ms) => new Promise((res) => setTimeout(res, ms));
 /**
 * Represents the main Eris client
 * @extends EventEmitter
+* @prop {String} token The bot user token
 * @prop {Boolean?} bot Whether the bot user belongs to an OAuth2 application
 * @prop {Object} options Eris options
 * @prop {Object} channelGuildMap Object mapping channel IDs to guild IDs

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -214,7 +214,7 @@ class Client extends EventEmitter {
         return this.startTime ? Date.now() - this.startTime : 0;
     }
 
-    _validateToken() {
+    _formatToken() {
         if(!this._token.startsWith("Bot ")) {
             this._token = "Bot " + this._token;
         }
@@ -280,7 +280,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} Resolves with an object containing gateway connection info
     */
     getBotGateway() {
-        this._validateToken();
+        this._formatToken();
         return this.requestHandler.request("GET", Endpoints.GATEWAY_BOT, true);
     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1340,7 +1340,7 @@ class Shard extends EventEmitter {
                 this.client.user = this.client.users.update(new ExtendedUser(packet.d.user, this.client), this.client);
                 if(this.client.user.bot) {
                     this.client.bot = true;
-                    this.client._validateToken();
+                    this.client._formatToken();
                 } else {
                     this.client.bot = false;
                     this.client.userGuildSettings = {};

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1311,9 +1311,7 @@ class Shard extends EventEmitter {
                 this.client.user = this.client.users.update(new ExtendedUser(packet.d.user, this.client), this.client);
                 if(this.client.user.bot) {
                     this.client.bot = true;
-                    if(!this.client.token.startsWith("Bot ")) {
-                        this.client.token = "Bot " + this.client.token;
-                    }
+                    this.client._validateToken();
                 } else {
                     this.client.bot = false;
                     this.client.userGuildSettings = {};


### PR DESCRIPTION
This PR emphasize that token should be private by prefixing it as `Client._token`.

**Goal**
The main purpose is to emphasize that token is private and read only. It is assigned at Client instantiation and should never be accessible for the user later.
This is mostly sematic, but in my opinion token should be private by nature.

**Side effects**
- Since token is private, it should be Client responsability to prefix the token with `"Bot "`. This is enforced by adding a `_validateToken` method in Client that will do that if necessary.
Before, both Shards and Client would prefix the token with `"Bot"`. Now it's Client responsability only.
- Since the token is directly used to identify to the gateway or for REST request, I added a getter. This makes token readOnly via `Client.token`.

**Additional benefits**
This will also hide the token from logging via `util.inspect` since Client automatically hide prefixed properties (https://github.com/abalabahaha/eris/blob/master/lib/structures/Base.js#L42)
While this is not the main goal of this PR this is a cool addition.