### PR TITLE
Minor typing fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1533,7 +1533,7 @@ declare namespace Eris {
     timestamp: number;
     type: number;
     author: User;
-    member?: Member;
+    member: Member | null;
     mentions: User[];
     content: string;
     cleanContent?: string;
@@ -1762,6 +1762,8 @@ declare namespace Eris {
 
   export class CommandClient extends Client {
     commands: { [s: string]: Command };
+    commandAliases: { [s: string]: string };
+    guildPrefixes: { [s: string]: string };
     constructor(token: string, options?: ClientOptions, commandOptions?: CommandClientOptions);
     onMessageCreate(msg: Message): void;
     registerGuildPrefix(guildID: string, prefix: string[] | string): void;


### PR DESCRIPTION
This PR introduces 2 missing typings of properties `guildPrefixes` and `commandAliases` in the CommandClient class.
It also replaces the `Member | undefined` typing of a `member` property in a Message class with `Member | null`, as, in case of absence of `Member`, `null` is thrown, not `undefined`.