### PR TITLE
Allow Role input for createRole

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1004,7 +1004,7 @@ declare namespace Eris {
       reason?: string
     ): Promise<Emoji>;
     deleteGuildEmoji(guildID: string, emojiID: string, reason?: string): Promise<void>;
-    createRole(guildID: string, options?: RoleOptions, reason?: string): Promise<Role>;
+    createRole(guildID: string, options?: RoleOptions | Role, reason?: string): Promise<Role>;
     editRole(guildID: string, roleID: string, options: RoleOptions, reason?: string): Promise<Role>; // TODO not all options are available?
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
     deleteRole(guildID: string, roleID: string, reason?: string): Promise<void>;
@@ -1331,7 +1331,7 @@ declare namespace Eris {
     createEmoji(options: { name: string; image: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     deleteEmoji(emojiID: string, reason?: string): Promise<void>;
-    createRole(options: RoleOptions, reason?: string): Promise<Role>;
+    createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
     getPruneCount(days: number): Promise<number>;
     pruneMembers(days: number, reason?: string): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -746,7 +746,7 @@ class Client extends EventEmitter {
     /**
     * Create a guild role
     * @arg {String} guildID The ID of the guild to create the role in
-    * @arg {Object|Role} [options] The properties to set or a Role instance
+    * @arg {Object|Role} [options] An object or Role containing the properties to set
     * @arg {String} [options.name] The name of the role
     * @arg {Number} [options.permissions] The role permissions number
     * @arg {Number} [options.color] The hex color of the role, in number form (ex: 0x3d15b3 or 4040115)

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -746,7 +746,7 @@ class Client extends EventEmitter {
     /**
     * Create a guild role
     * @arg {String} guildID The ID of the guild to create the role in
-    * @arg {Object} [options] The properties to set
+    * @arg {Object|Role} [options] The properties to set or a Role instance
     * @arg {String} [options.name] The name of the role
     * @arg {Number} [options.permissions] The role permissions number
     * @arg {Number} [options.color] The hex color of the role, in number form (ex: 0x3d15b3 or 4040115)
@@ -756,8 +756,14 @@ class Client extends EventEmitter {
     * @returns {Promise<Role>}
     */
     createRole(guildID, options, reason) {
-        options.reason = reason;
-        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, options).then((role) => {
+        return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, {
+            name: options.name,
+            permissions: options instanceof Role ? options.permissions.allow : options.permissions,
+            color: options.color,
+            hoist: options.hoist,
+            mentionable: options.mentionable,
+            reason
+        }).then((role) => {
             const guild = this.guilds.get(guildID);
             if(guild) {
                 return guild.roles.add(role, guild);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -758,7 +758,7 @@ class Client extends EventEmitter {
     createRole(guildID, options, reason) {
         return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, {
             name: options.name,
-            permissions: options instanceof Role ? options.permissions.allow : options.permissions,
+            permissions: options.permissions instanceof Permission ? options.permissions.allow : options.permissions,
             color: options.color,
             hoist: options.hoist,
             mentionable: options.mentionable,

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -298,7 +298,7 @@ class Guild extends Base {
 
     /**
     * Create a guild role
-    * @arg {Object} [options] The properties to set
+    * @arg {Object|Role} [options] The properties to set or a Role instance
     * @arg {String} [options.name] The name of the role
     * @arg {Number} [options.permissions] The role permissions number
     * @arg {Number} [options.color] The hex color of the role, in number form (ex: 0x3d15b3 or 4040115)

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -298,7 +298,7 @@ class Guild extends Base {
 
     /**
     * Create a guild role
-    * @arg {Object|Role} [options] The properties to set or a Role instance
+    * @arg {Object|Role} [options] An object or Role containing the properties to set
     * @arg {String} [options.name] The name of the role
     * @arg {Number} [options.permissions] The role permissions number
     * @arg {Number} [options.color] The hex color of the role, in number form (ex: 0x3d15b3 or 4040115)


### PR DESCRIPTION
There's only one inconsistency preventing Role objects from being passed to `Client#createRole()`, and being able to pass a Role object is relatively useful when cloning or recreating Roles. This change also explicitly passes options to discord which could potentially prevent user errors.

For example, without this change in order to recreate a Role you would need:
```js
await oldRole.delete();
const newRole = await guild.createRole({
  name: oldRole.name,
  permissions: oldRole.permissions.allow,
  color: oldRole.color,
  hoist: oldRole.hoist,
  mentionable: oldRole.mentionable,
});
await newRole.editPosition(oldRole.position);
```
However this PR would reduce that code to:
```js
await oldRole.delete();
const newRole = await guild.createRole(oldRole);
await newRole.editPosition(oldRole.position);
```