### PR TITLE
Fix toJSONifying functions

### DIFF
--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -24,15 +24,16 @@ class Base {
         }
         for(const prop of props) {
             const value = this[prop];
+            const type = typeof value;
             if(value === undefined) {
                 continue;
-            } else if(typeof value !== "object" || value === null) {
+            } else if(type !== "object" && type !== "function" || value === null) {
                 json[prop] = value;
             } else if(value.toJSON !== undefined) {
                 json[prop] = value.toJSON();
             } else if(value.values !== undefined) {
-                json[prop] = Array.from(value.values());
-            } else if(typeof value !== "function") {
+                json[prop] = [...value.values()];
+            } else if (type === "object") {
                 json[prop] = value;
             }
         }


### PR DESCRIPTION
Fixes a tiny issue when jsonifying functions that have a `toJSON` property. This is to better mimic the behavior of `JSON.stringify`