### PR TITLE
Add ms precision ratelimit

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -76,7 +76,8 @@ class RequestHandler {
             const actualCall = (cb) => {
                 const headers = {
                     "User-Agent": this.userAgent,
-                    "Accept-Encoding": "gzip,deflate"
+                    "Accept-Encoding": "gzip,deflate",
+                    "X-RateLimit-Precision": "millisecond"
                 };
                 let data;
                 let finalURL = url;


### PR DESCRIPTION
This PR adds support for ms precision ratelimit which was for some reason never added in eris.
I believe it should work out of the box looking at the format discord uses, documented [here](https://discordapp.com/developers/docs/topics/rate-limits#more-precise-rate-limit-resets).