### PR TITLE
Missing reason parameter in TextChannel.deleteMessages and purgeChannel

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1085,7 +1085,8 @@ declare namespace Eris {
       limit?: number,
       filter?: (m: Message) => boolean,
       before?: string,
-      after?: string
+      after?: string,
+      reason?: string
     ): Promise<number>;
     getGuildEmbed(guildID: string): Promise<GuildEmbed>;
     getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
@@ -1464,8 +1465,8 @@ declare namespace Eris {
     getWebhooks(): Promise<Webhook[]>;
     createWebhook(options: { name: string; avatar: string }, reason?: string): Promise<Webhook>;
     sendTyping(): Promise<void>;
-    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string): Promise<number>;
-    deleteMessages(messageIDs: string[]): Promise<void>;
+    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
+    deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
   }
@@ -1548,9 +1549,9 @@ declare namespace Eris {
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
-    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string): Promise<number>;
+    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
-    deleteMessages(messageIDs: string[]): Promise<void>;
+    deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
   }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1227,9 +1227,10 @@ class Client extends EventEmitter {
     * @arg {function} [filter] Optional filter function that returns a boolean when passed a Message object
     * @arg {String} [before] Get messages before this message ID
     * @arg {String} [after] Get messages after this message ID
+    * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
-    async purgeChannel(channelID, limit, filter, before, after) {
+    async purgeChannel(channelID, limit, filter, before, after, reason) {
         if(typeof filter === "string") {
             filter = (msg) => msg.content.includes(filter);
         }
@@ -1243,7 +1244,7 @@ class Client extends EventEmitter {
             const messageIDs = (done && toDelete) || (toDelete.length >= 100 && toDelete.splice(0, 100));
             if(messageIDs) {
                 deleted += messageIDs.length;
-                await this.deleteMessages(channelID, messageIDs);
+                await this.deleteMessages(channelID, messageIDs, reason);
                 if(done) {
                     return deleted;
                 }

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -87,10 +87,11 @@ class TextChannel extends GuildChannel {
     /**
     * Bulk delete messages (bot accounts only)
     * @arg {String[]} messageIDs Array of message IDs to delete
+    * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise}
     */
-    deleteMessages(messageIDs) {
-        return this.client.deleteMessages.call(this.client, this.id, messageIDs);
+    deleteMessages(messageIDs, reason) {
+        return this.client.deleteMessages.call(this.client, this.id, messageIDs, reason);
     }
 
     /**

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -100,10 +100,11 @@ class TextChannel extends GuildChannel {
     * @arg {function} [filter] Optional filter function that returns a boolean when passed a Message object
     * @arg {String} [before] Get messages before this message ID
     * @arg {String} [after] Get messages after this message ID
+    * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
-    purge(limit, filter, before, after) {
-        return this.client.purgeChannel.call(this.client, this.id, limit, filter, before, after);
+    purge(limit, filter, before, after, reason) {
+        return this.client.purgeChannel.call(this.client, this.id, limit, filter, before, after, reason);
     }
 
     /**


### PR DESCRIPTION
The deleteMessages method in TextChannel does not accept a reason parameter while the deleteMessages method in the Client does accept a reason.
Also added reason to purgeChannel.

TextChannel.deleteMessages: https://github.com/abalabahaha/eris/blob/dev/lib/structures/TextChannel.js#L92
Client.deleteMessages:
https://github.com/abalabahaha/eris/blob/master/lib/Client.js#L1182