### PR TITLE
Fix reaction events when channel not cached

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -517,10 +517,10 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_REACTION_ADD": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
-                    break;
+                let message;
+                if(channel) {
+                    message = channel.messages.get(packet.d.message_id);
                 }
-                const message = channel.messages.get(packet.d.message_id);
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
                     if(message.reactions[reaction]) {
@@ -546,16 +546,16 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionAdd", message || {
                     id: packet.d.message_id,
-                    channel: channel
+                    channel: channel || { id: packet.d.channel_id }
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
-                    break;
+                let message;
+                if(channel) {
+                    message = channel.messages.get(packet.d.message_id);
                 }
-                const message = channel.messages.get(packet.d.message_id);
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
                     if(message.reactions[reaction]) {
@@ -576,7 +576,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionRemove", message || {
                     id: packet.d.message_id,
-                    channel: channel
+                    channel: channel || { id: packet.d.channel_id }
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }


### PR DESCRIPTION
MESSAGE_REACTION_ADD and MESSAGE_REACTION_REMOVE
relied on channels to be cached, which is not the case
with dm channels. This allows users to see reactions
added to user dms if the bot does not have the channel
cached.