### PR TITLE
fix Permission not being required for createRole

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -13,6 +13,7 @@ const GuildIntegration = require("./structures/GuildIntegration");
 const Invite = require("./structures/Invite");
 const Member = require("./structures/Member");
 const Message = require("./structures/Message");
+const Permission = require("./structures/Permission");
 const PrivateChannel = require("./structures/PrivateChannel");
 const Relationship = require("./structures/Relationship");
 const RequestHandler = require("./rest/RequestHandler");
@@ -21,7 +22,6 @@ const ShardManager = require("./gateway/ShardManager");
 const UnavailableGuild = require("./structures/UnavailableGuild");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
-const Permission = require("./structures/Permission");
 
 let EventEmitter;
 try {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -21,6 +21,7 @@ const ShardManager = require("./gateway/ShardManager");
 const UnavailableGuild = require("./structures/UnavailableGuild");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
+const Permission = require("./structures/Permission")
 
 let EventEmitter;
 try {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -21,7 +21,7 @@ const ShardManager = require("./gateway/ShardManager");
 const UnavailableGuild = require("./structures/UnavailableGuild");
 const User = require("./structures/User");
 const VoiceConnectionManager = require("./voice/VoiceConnectionManager");
-const Permission = require("./structures/Permission")
+const Permission = require("./structures/Permission");
 
 let EventEmitter;
 try {


### PR DESCRIPTION
This PR should fix a small bug introduced in #663 for `Client#createRole()`, it was throwing an error because Permission wasn't required. 