### PR TITLE
Add missing jsdoc for Guild getters

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -38,6 +38,8 @@ const VoiceState = require("./VoiceState");
 * @prop {String[]} features An array of guild feature strings
 * @prop {Object[]} emojis An array of guild emoji objects
 * @prop {String?} iconURL The URL of the guild's icon
+* @prop {String?} bannerURL The URL of the guild's banner image
+* @prop {String?} splashURL The URL of the guild's splash image
 * @prop {Number} explicitContentFilter The explicit content filter level for the guild. 0 is off, 1 is on for people without roles, 2 is on for all
 * @prop {Number} premiumTier Nitro boost level of the guild
 * @prop {Number?} premiumSubscriptionCount The total number of users currently boosting this guild


### PR DESCRIPTION
Add missing jsdoc for Guild getters `bannerURL` and `splashURL`.
Closes #898 