### PR TITLE
Max image size is 4096. Image format can be jpeg

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -166,9 +166,9 @@ declare namespace Eris {
   interface Constants {
     ImageSizeBoundaries: {
       MINIMUM: 16;
-      MAXIMUM: 2048;
+      MAXIMUM: 4096;
     };
-    ImageFormats: ["jpg", "png", "webp", "gif"];
+    ImageFormats: ["jpg", "jpeg", "png", "webp", "gif"];
     GatewayOPCodes: {
       EVENT: 0;
       HEARTBEAT: 1;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -2,6 +2,7 @@
 
 module.exports.ImageFormats = [
     "jpg",
+    "jpeg",
     "png",
     "webp",
     "gif"
@@ -9,7 +10,7 @@ module.exports.ImageFormats = [
 
 module.exports.ImageSizeBoundaries = {
     MINIMUM: 16,
-    MAXIMUM: 2048
+    MAXIMUM: 4096
 };
 
 module.exports.GatewayOPCodes = {


### PR DESCRIPTION
Ref: discord/discord-api-docs#1501
Max image size is now 4096.
Additionally, Discord support jpeg, so added that as well.