### PR TITLE
Add support for crossposting messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1107,7 +1107,7 @@ declare namespace Eris {
       after?: string,
       reason?: string
     ): Promise<number>;
-    crosspost(channelID: string, messageID: string): Promise<Message>;
+    crosspostMessage(channelID: string, messageID: string): Promise<Message>;
     getGuildEmbed(guildID: string): Promise<GuildEmbed>;
     getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1107,6 +1107,7 @@ declare namespace Eris {
       after?: string,
       reason?: string
     ): Promise<number>;
+    crosspost(channelID: string, messageID: string): Promise<Message>;
     getGuildEmbed(guildID: string): Promise<GuildEmbed>;
     getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
@@ -1577,6 +1578,7 @@ declare namespace Eris {
   export class NewsChannel extends TextChannel {
     type: 5;
     rateLimitPerUser: 0;
+    crosspost(messageID: string): Promise<Message>;
   }
 
   export class VoiceChannel extends GuildChannel implements Invitable {
@@ -1711,6 +1713,7 @@ declare namespace Eris {
     removeReactions(): Promise<void>;
     removeMessageReactionEmoji(reaction: string): Promise<void>;
     delete(reason?: string): Promise<void>;
+    crosspost(): Promise<Message>;
   }
 
   export class Permission {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1578,7 +1578,7 @@ declare namespace Eris {
   export class NewsChannel extends TextChannel {
     type: 5;
     rateLimitPerUser: 0;
-    crosspost(messageID: string): Promise<Message>;
+    crosspostMessage(messageID: string): Promise<Message>;
   }
 
   export class VoiceChannel extends GuildChannel implements Invitable {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1247,7 +1247,7 @@ class Client extends EventEmitter {
     }
 
     /**
-     * Publish a message to subscribed channels
+     * Crosspost (publish) a message to subscribed channels
      * @arg {String} channelID The ID of the NewsChannel
      * @arg {String} messageID The ID of the message
      * @returns {Promise<Message>}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1315,6 +1315,16 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Publish a message in a NewsChannel
+     * @arg {String} channelID The ID of the NewsChannel
+     * @arg {String} messageID The ID of the message
+     * @returns {Promise<Message>}
+     */
+    crosspost(channelID, messageID) {
+        return this.requestHandler.request("POST", Endpoints.CHANNEL_CROSSPOST(channelID, messageID), true).then((message) => new Message(message, this));
+    }
+
+    /**
     * Get a guild's embed object
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<Object>} A guild embed object

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1247,6 +1247,16 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Publish a message to subscribed channels
+     * @arg {String} channelID The ID of the NewsChannel
+     * @arg {String} messageID The ID of the message
+     * @returns {Promise<Message>}
+     */
+    crosspostMessage(channelID, messageID) {
+        return this.requestHandler.request("POST", Endpoints.CHANNEL_CROSSPOST(channelID, messageID), true).then((message) => new Message(message, this));
+    }
+
+    /**
     * Purge previous messages in a channel with an optional filter (bot accounts only)
     * @arg {String} channelID The ID of the channel
     * @arg {Number} limit The max number of messages to search through, -1 for no limit
@@ -1312,16 +1322,6 @@ class Client extends EventEmitter {
         };
         await del(before, after);
         return checkToDelete();
-    }
-
-    /**
-     * Publish a message in a NewsChannel
-     * @arg {String} channelID The ID of the NewsChannel
-     * @arg {String} messageID The ID of the message
-     * @returns {Promise<Message>}
-     */
-    crosspost(channelID, messageID) {
-        return this.requestHandler.request("POST", Endpoints.CHANNEL_CROSSPOST(channelID, messageID), true).then((message) => new Message(message, this));
     }
 
     /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -8,6 +8,7 @@ module.exports.CDN_URL = "https://cdn.discordapp.com";
 module.exports.CHANNEL =                                                (chanID) => `/channels/${chanID}`;
 module.exports.CHANNEL_BULK_DELETE =                                    (chanID) => `/channels/${chanID}/messages/bulk-delete`;
 module.exports.CHANNEL_CALL_RING =                                      (chanID) => `/channels/${chanID}/call/ring`;
+module.exports.CHANNEL_CROSSPOST =                               (chanID, msgID) => `/channels/${chanID}/messages/${msgID}/crosspost`
 module.exports.CHANNEL_INVITES =                                        (chanID) => `/channels/${chanID}/invites`;
 module.exports.CHANNEL_MESSAGE_REACTION =              (chanID, msgID, reaction) => `/channels/${chanID}/messages/${msgID}/reactions/${reaction}`;
 module.exports.CHANNEL_MESSAGE_REACTION_USER = (chanID, msgID, reaction, userID) => `/channels/${chanID}/messages/${msgID}/reactions/${reaction}/${userID}`;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -360,7 +360,7 @@ class Message extends Base {
     }
 
     /**
-     * Publish a message to subscribed channels (NewsChannel only)
+     * Crosspost (publish) a message to subscribed channels (NewsChannel only)
      * @returns {Promise<Message>}
      */
     crosspost() {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -364,7 +364,7 @@ class Message extends Base {
      * @returns {Promise<Message>}
      */
     crosspost() {
-        return this._client.crosspost.call(this.client, this.channel.id, this.id);
+        return this._client.crosspostMessage.call(this.client, this.channel.id, this.id);
     }
 
     toJSON(props = []) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -360,10 +360,10 @@ class Message extends Base {
     }
 
     /**
-     * Publish the message (NewsChannel only)
+     * Publish a message to subscribed channels (NewsChannel only)
      * @returns {Promise<Message>}
      */
-    crosspost() { // Should we check if the message belongs in a NewsChannel first?
+    crosspost() {
         return this._client.crosspost.call(this.client, this.channel.id, this.id);
     }
 

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -359,6 +359,14 @@ class Message extends Base {
         return this._client.deleteMessage.call(this._client, this.channel.id, this.id, reason);
     }
 
+    /**
+     * Publish the message (NewsChannel only)
+     * @returns {Promise<Message>}
+     */
+    crosspost() { // Should we check if the message belongs in a NewsChannel first?
+        return this._client.crosspost.call(this.client, this.channel.id, this.id);
+    }
+
     toJSON(props = []) {
         return super.toJSON([
             "attachments",

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -27,7 +27,7 @@ class NewsChannel extends TextChannel {
         this.update(data);
     }
     /**
-     * Publish a message to subscribed channels
+     * Crosspost (publish) a message to subscribed channels
      * @arg {String} messageID The ID of the message
      * @returns {Promise<Message>}
      */

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -26,6 +26,14 @@ class NewsChannel extends TextChannel {
         this.rateLimitPerUser = 0;
         this.update(data);
     }
+    /**
+     * Publish a message
+     * @arg {String} messageID The ID of the message
+     * @returns {Promise<Message>}
+     */
+    crosspost(messageID) {
+        return this.client.crosspost.call(this.client, this.id, messageID);
+    }
 }
 
 module.exports = NewsChannel;

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -31,8 +31,8 @@ class NewsChannel extends TextChannel {
      * @arg {String} messageID The ID of the message
      * @returns {Promise<Message>}
      */
-    crosspost(messageID) {
-        return this.client.crosspost.call(this.client, this.id, messageID);
+    crosspostMessage(messageID) {
+        return this.client.crosspostMessage.call(this.client, this.id, messageID);
     }
 }
 

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -27,7 +27,7 @@ class NewsChannel extends TextChannel {
         this.update(data);
     }
     /**
-     * Publish a message
+     * Publish a message to subscribed channels
      * @arg {String} messageID The ID of the message
      * @returns {Promise<Message>}
      */


### PR DESCRIPTION
This is not yet documented, however please see [here](https://github.com/discord/discord-api-docs/issues/1510) for more details,
> The endpoint is now accessible to bots, but there’s a few things... which I need to fix up before I’d be comfortable documenting it.