### PR TITLE
allowedMentions in editMessage

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1088,6 +1088,10 @@ class Client extends EventEmitter {
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.allowedMentions] A list of mentions to allow (overrides default)
+    * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @returns {Promise<Message>}
     */
     editMessage(channelID, messageID, content) {
@@ -1101,6 +1105,7 @@ class Client extends EventEmitter {
             } else if(content.content === undefined && !content.embed && content.flags === undefined) {
                 return Promise.reject(new Error("No content, embed or flags"));
             }
+            content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
         }
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content).then((message) => new Message(message, this));
     }

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -279,6 +279,10 @@ class Message extends Base {
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.allowedMentions] A list of mentions to allow (overrides default)
+    * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @returns {Promise<Message>}
     */
     edit(content) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -121,6 +121,10 @@ class PrivateChannel extends Channel {
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.allowedMentions] A list of mentions to allow (overrides default)
+    * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -172,6 +172,10 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.allowedMentions] A list of mentions to allow (overrides default)
+    * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
+    * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {


### PR DESCRIPTION
This add supports for allowedMentions in editMessage.
This obviously doesn't actually trigger a mention but simply highlight the as if there was a mention.
Ref: discord/discord-api-docs#1483 