### PR TITLE
Fix docs and typings for MESSAGE_REACTION_ADD and MESSAGE_REACTION_REMOVE events

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -721,7 +721,7 @@ declare namespace Eris {
     frameSize?: number;
     sampleRate?: number;
   }
-  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel };
+  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel } | { id: string; channel: { id: string } };
   interface RawPacket {
     op: number;
     t?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -721,7 +721,7 @@ declare namespace Eris {
     frameSize?: number;
     sampleRate?: number;
   }
-  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel } | { id: string; channel: { id: string } };
+  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel | { id: string } };
   interface RawPacket {
     op: number;
     t?: string;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -540,7 +540,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
@@ -570,7 +570,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name


### PR DESCRIPTION
This correct missing typing and docs update in #672 
Looking at this again, I was also wondering why the same behaviour has not been added to `MESSAGE_REACTION_REMOVE_ALL` and `MESSAGE_REACTION_REMOVE_EMOJI`

I also don't know if I fixed typings the correct way so please, review!