### PR TITLE
Add support for GuildPreview endpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1616,7 +1616,7 @@ declare namespace Eris {
     id: string;
     name: string;
     icon: string | null;
-    description: string;
+    description: string | null;
     splash: string | null;
     discovery_splash: string | null;
     features: string[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1612,7 +1612,7 @@ declare namespace Eris {
     sync(): Promise<void>;
   }
 
-  export class GuildPreview {
+  export class GuildPreview extends Base {
     id: string;
     name: string;
     icon: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1108,6 +1108,7 @@ declare namespace Eris {
       reason?: string
     ): Promise<number>;
     getGuildEmbed(guildID: string): Promise<GuildEmbed>;
+    getGuildPreview(guildID: string) : Promise<GuildPreview>;
     getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
     deleteGuildIntegration(guildID: string, integrationID: string): Promise<void>;
@@ -1609,6 +1610,19 @@ declare namespace Eris {
     edit(options: { expireBehavior: string; expireGracePeriod: string; enableEmoticons: string }): Promise<void>;
     delete(): Promise<void>;
     sync(): Promise<void>;
+  }
+
+  export interface GuildPreview {
+    id: string;
+    name: string;
+    icon: string;
+    description: string;
+    splash: string;
+    discovery_splash: string;
+    features: string[];
+    approximate_member_count: number;
+    approximate_presence_count: number;
+    emojis: Emoji[];
   }
 
   export class Invite implements SimpleJSON {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1615,7 +1615,7 @@ declare namespace Eris {
   export interface GuildPreview {
     id: string;
     name: string;
-    icon: string;
+    icon: string | null;
     description: string;
     splash: string;
     discovery_splash: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1617,7 +1617,7 @@ declare namespace Eris {
     name: string;
     icon: string | null;
     description: string;
-    splash: string;
+    splash: string | null;
     discovery_splash: string;
     features: string[];
     approximate_member_count: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1618,7 +1618,7 @@ declare namespace Eris {
     icon: string | null;
     description: string;
     splash: string | null;
-    discovery_splash: string;
+    discovery_splash: string | null;
     features: string[];
     approximate_member_count: number;
     approximate_presence_count: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1612,17 +1612,21 @@ declare namespace Eris {
     sync(): Promise<void>;
   }
 
-  export interface GuildPreview {
+  export class GuildPreview {
     id: string;
     name: string;
     icon: string | null;
+    iconURL: string | null;
     description: string | null;
     splash: string | null;
-    discovery_splash: string | null;
+    splashURL: string | null;
+    discoverySplash: string | null;
     features: string[];
-    approximate_member_count: number;
-    approximate_presence_count: number;
+    approximateMemberCount: number;
+    approximatePresenceCount: number;
     emojis: Emoji[];
+    dynamicIconURL(format?: string, size?: number): string;
+    dynamicSplashURL(format?: string, size?: number): string;
   }
 
   export class Invite implements SimpleJSON {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -10,6 +10,7 @@ const GroupChannel = require("./structures/GroupChannel");
 const Guild = require("./structures/Guild");
 const GuildAuditLogEntry = require("./structures/GuildAuditLogEntry");
 const GuildIntegration = require("./structures/GuildIntegration");
+const GuildPreview = require("./structures/GuildPreview");
 const Invite = require("./structures/Invite");
 const Member = require("./structures/Member");
 const Message = require("./structures/Message");
@@ -1329,7 +1330,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>}
     */
     getGuildPreview(guildID) {
-        return this.requestHandler.request("GET", Endpoints.GUILD_PREVIEW(guildID), true);
+        return this.requestHandler.request("GET", Endpoints.GUILD_PREVIEW(guildID), true).then((data) => new GuildPreview(data, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1324,6 +1324,15 @@ class Client extends EventEmitter {
     }
 
     /**
+    * Get a guild preview for a guild. Only available for public guilds.
+    * @arg {String} guildID The ID of the guild
+    * @returns {Promise<Object>}
+    */
+    getGuildPreview(guildID) {
+        return this.requestHandler.request("GET", Endpoints.GUILD_PREVIEW(guildID), true);
+    }
+
+    /**
     * Get a list of integrations for a guild
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<GuildIntegration[]>}

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -43,6 +43,7 @@ module.exports.GUILD_MEMBER_NICK =                           (guildID, memberID)
 module.exports.GUILD_MEMBER_ROLE =                   (guildID, memberID, roleID) => `/guilds/${guildID}/members/${memberID}/roles/${roleID}`;
 module.exports.GUILD_MEMBERS =                                         (guildID) => `/guilds/${guildID}/members`;
 module.exports.GUILD_MESSAGES_SEARCH =                                 (guildID) => `/guilds/${guildID}/messages/search`;
+module.exports.GUILD_PREVIEW =                                         (guildID) => `/guilds/${guildID}/preview`;
 module.exports.GUILD_PRUNE =                                           (guildID) => `/guilds/${guildID}/prune`;
 module.exports.GUILD_ROLE =                                    (guildID, roleID) => `/guilds/${guildID}/roles/${roleID}`;
 module.exports.GUILD_ROLES =                                           (guildID) => `/guilds/${guildID}/roles`;

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -1,0 +1,85 @@
+"use strict";
+
+const Base = require("./Base");
+const Endpoints = require("../rest/Endpoints.js");
+
+/**
+* Represents a GuildPreview structure
+* @extends Base
+* @prop {String} id The ID of the guild
+* @prop {String} name The name of the guild
+
+* @prop {String?} icon The hash of the guild icon, or null if no icon
+* @prop {String?} description The description for the guild (VIP only)
+* @prop {String?} splash The hash of the guild splash image, or null if no splash (VIP only)
+* @prop {String?} discoverySplash The description for the guild (VIP only)
+* @prop {String[]} features An array of guild feature strings
+* @prop {Number} approximateMemberCount The **approximate** number of members in the guild
+* @prop {Number} approximatePresenceCount The **approximate** number of presences in the guild
+* @prop {Object[]} emojis An array of guild emoji objects
+* @prop {String?} iconURL The URL of the guild's icon
+*/
+class GuildPreview extends Base {
+    constructor(data, client) {
+        super(data.id);
+        this._client = client;
+
+        this.name = data.name;
+        this.icon = data.icon;
+        this.description = data.description;
+        this.splash = data.splash;
+        this.discoverySplah = data.discovery_splash;
+        this.features = data.features;
+        this.approximateMemberCount = data.approximate_member_count;
+        this.approximatePresenceCount = data.approximate_presence_count;
+        this.emojis = data.emojis;
+    }
+
+    get iconURL() {
+        return this.icon ? this._client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon)) : null;
+    }
+
+    get splashURL() {
+        return this.splash ? this._client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash)) : null;
+    }
+
+    /**
+    * Get the guild's icon with the given format and size
+    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+    * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
+    */
+    dynamicIconURL(format, size) {
+        return this.icon ? this._client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
+    }
+
+    /**
+    * Get the guild's splash with the given format and size
+    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+    * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
+    */
+    dynamicSplashURL(format, size) {
+        return this.splash ? this._client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
+    }
+
+    toString() {
+        return `[GuildPreview ${this.id}]`;
+    }
+
+    toJSON(props = []) {
+        return super.toJSON([
+            "id",
+            "name",
+            "icon",
+            "description",
+            "splash",
+            "discoverySplah",
+            "features",
+            "approximateMemberCount",
+            "approximatePresenceCount",
+            "emojis",
+            ...props
+        ]);
+    }
+}
+
+module.exports = GuildPreview;

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -45,7 +45,7 @@ class GuildPreview extends Base {
 
     /**
     * Get the guild's icon with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
     * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicIconURL(format, size) {
@@ -54,7 +54,7 @@ class GuildPreview extends Base {
 
     /**
     * Get the guild's splash with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
     * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicSplashURL(format, size) {


### PR DESCRIPTION
This PR brings support for GuildPreview as documented in discord/discord-api-docs#1405
This endpoint can only be used on public guilds
- GuildPreview endpoint `guilds/:guildID/preview`
- `getGuildPreview` method
- updated typings