### PR TITLE
Fix a crash caused by trying to delete opus instance on opusOnly connection

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -312,12 +312,14 @@ class VoiceConnection extends EventEmitter {
                     break;
                 }
                 case VoiceOPCodes.DISCONNECT: {
-                    // opusscript requires manual cleanup
-                    if(this.opus[packet.d.user_id] && this.opus[packet.d.user_id].delete) {
-                        this.opus[packet.d.user_id].delete();
-                    }
+                    if(this.opus) {
+                        // opusscript requires manual cleanup
+                        if(this.opus[packet.d.user_id] && this.opus[packet.d.user_id].delete) {
+                            this.opus[packet.d.user_id].delete();
+                        }
 
-                    delete this.opus[packet.d.user_id];
+                        delete this.opus[packet.d.user_id];
+                    }
 
                     /**
                     * Fired when a user disconnects from the voice server


### PR DESCRIPTION
Fix a regression introduced in #612

https://github.com/abalabahaha/eris/pull/612/files#diff-5b21df6d28c9602510c2f164c29aa99cR316-R320

A missing check here crash the program when the connection is opusOnly(hence no this.opus).