### PR TITLE
fixes #911 allowedMentions.users to work w/o *.roles

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2169,7 +2169,7 @@ class Client extends EventEmitter {
         if(allowed.users === true) {
             result.parse.push("users");
         } else if(Array.isArray(allowed.users)) {
-            if(allowed.roles.length > 100) {
+            if(allowed.users.length > 100) {
                 throw new Error("Allowed user mentions cannot exceed 100.");
             }
             result.users = allowed.users;


### PR DESCRIPTION
fixes #911  length check in _formatAllowedMentions for object allowedMentions.users to check that object as opposed to allowedMentions.roles.