### PR TITLE
Raise bitrate to 90kbps (Encoder)

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -95,7 +95,7 @@ class VoiceConnection extends EventEmitter {
         this.frameDuration = 20;
         this.frameSize = this.samplingRate * this.frameDuration / 1000;
         this.pcmSize = this.frameSize * this.channels * 2;
-        this.bitrate = 64000;
+        this.bitrate = 90000;
         this.shared = !!options.shared;
         this.shard = options.shard || {};
         this.opusOnly = !!options.opusOnly;


### PR DESCRIPTION
As to why 90kbps, this page shows the results of opus at certain bitrates
http://soundexpert.org/encoders

90k has better results than 64k and is still considered accurate at 1% (read description at bottom)
128k is beyond the threshold of 5%

This isn't a huge jump in bitrate and most files go beyond 90kbps so it should be considered.