### PR TITLE
Request handled event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -881,6 +881,10 @@ declare namespace Eris {
       event: "relationshipUpdate",
       listener: (relationship: Relationship, oldRelationship: { type: number }) => void
     ): T;
+    (
+      event: "requestHandled",
+      listener: (method: string, url: string, auth: boolean, body: unknown, file: MessageFile, route: string, short: boolean) => void
+    ): T;
     (event: "typingStart", listener: (channel: TextableChannel, user: User) => void): T;
     (event: "unavailableGuildCreate", listener: (guild: UnavailableGuild) => void): T;
     (

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare namespace Eris {
 
   // TODO there's also toJSON(): JSONCache, though, SimpleJSON should suffice
 
-  type GuildTextableChannel = TextChannel | NewsChannel
+  type GuildTextableChannel = TextChannel | NewsChannel;
   type TextableChannel = GuildTextableChannel | PrivateChannel;
   type AnyChannel = AnyGuildChannel | PrivateChannel;
   type AnyGuildChannel = GuildTextableChannel | VoiceChannel | CategoryChannel | StoreChannel;
@@ -110,7 +110,7 @@ declare namespace Eris {
     game?: Activity;
   }
 
-  type BotActivityType = 0 | 1 | 2 | 3
+  type BotActivityType = 0 | 1 | 2 | 3;
   type ActivityType = BotActivityType & 4;
 
   interface ActivityPartial<T extends BotActivityType> {
@@ -567,7 +567,7 @@ declare namespace Eris {
     allowedMentions?: AllowedMentions;
     embed?: EmbedOptions;
     flags?: number;
-  }
+  };
 
   interface MessageFile {
     file: Buffer | string;
@@ -842,10 +842,7 @@ declare namespace Eris {
       event: "channelPinUpdate",
       listener: (channel: TextableChannel, timestamp: number, oldTimestamp: number) => void
     ): T;
-    (
-      event: "channelRecipientAdd" | "channelRecipientRemove",
-      listener: (channel: GroupChannel, user: User) => void
-    ): T;
+    (event: "channelRecipientAdd" | "channelRecipientRemove", listener: (channel: GroupChannel, user: User) => void): T;
     (event: "channelUpdate", listener: (channel: AnyGuildChannel, oldChannel: OldGuildChannel) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
@@ -872,18 +869,22 @@ declare namespace Eris {
       event: "messageReactionAdd" | "messageReactionRemove",
       listener: (message: PossiblyUncachedMessage, emoji: Emoji, userID: string) => void
     ): T;
-    (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void
-    ): T;
+    (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void): T;
     (event: "presenceUpdate", listener: (other: Member | Relationship, oldPresence?: Presence) => void): T;
     (event: "rawWS" | "unknown", listener: (packet: RawPacket, id: number) => void): T;
     (event: "relationshipAdd" | "relationshipRemove", listener: (relationship: Relationship) => void): T;
+    (event: "relationshipUpdate", listener: (relationship: Relationship, oldRelationship: { type: number }) => void): T;
     (
-      event: "relationshipUpdate",
-      listener: (relationship: Relationship, oldRelationship: { type: number }) => void
-    ): T;
-    (
-      event: "requestHandled",
-      listener: (method: string, url: string, auth: boolean, body: unknown, file: MessageFile, route: string, short: boolean) => void
+      event: "rawREST",
+      listener: (
+        method: string,
+        url: string,
+        auth: boolean,
+        body: unknown,
+        file: MessageFile,
+        route: string,
+        short: boolean
+      ) => void
     ): T;
     (event: "typingStart", listener: (channel: TextableChannel, user: User) => void): T;
     (event: "unavailableGuildCreate", listener: (guild: UnavailableGuild) => void): T;
@@ -903,10 +904,7 @@ declare namespace Eris {
   }
 
   interface ClientEvents<T> extends EventListeners<T> {
-    (
-      event: "shardDisconnect" | "error" | "shardPreReady" | "connect",
-      listener: (err: Error, id: number) => void
-    ): T;
+    (event: "shardDisconnect" | "error" | "shardPreReady" | "connect", listener: (err: Error, id: number) => void): T;
     (event: "shardReady" | "shardResume", listener: (id: number) => void): T;
   }
 
@@ -941,7 +939,11 @@ declare namespace Eris {
     constructor(token: string, options?: ClientOptions);
     connect(): Promise<void>;
     getGateway(): Promise<{ url: string }>;
-    getBotGateway(): Promise<{ url: string; shards: number; session_start_limit: { total: number; remaining: number; reset_after: number } }>;
+    getBotGateway(): Promise<{
+      url: string;
+      shards: number;
+      session_start_limit: { total: number; remaining: number; reset_after: number };
+    }>;
     disconnect(options: { reconnect: boolean }): void;
     joinVoiceChannel(channelID: string, options?: { shared?: boolean; opusOnly?: boolean }): Promise<VoiceConnection>;
     leaveVoiceChannel(channelID: string): void;
@@ -978,30 +980,10 @@ declare namespace Eris {
       reason?: string,
       options?: CreateChannelOptions | string
     ): Promise<unknown>;
-    createChannel(
-      guildID: string,
-      name: string,
-      type: 0,
-      options?: CreateChannelOptions
-    ): Promise<TextChannel>;
-    createChannel(
-      guildID: string,
-      name: string,
-      type: 2,
-      options?: CreateChannelOptions
-    ): Promise<VoiceChannel>;
-    createChannel(
-      guildID: string,
-      name: string,
-      type: 4,
-      options?: CreateChannelOptions
-    ): Promise<CategoryChannel>;
-    createChannel(
-      guildID: string,
-      name: string,
-      type?: number,
-      options?: CreateChannelOptions
-    ): Promise<unknown>;
+    createChannel(guildID: string, name: string, type: 0, options?: CreateChannelOptions): Promise<TextChannel>;
+    createChannel(guildID: string, name: string, type: 2, options?: CreateChannelOptions): Promise<VoiceChannel>;
+    createChannel(guildID: string, name: string, type: 4, options?: CreateChannelOptions): Promise<CategoryChannel>;
+    createChannel(guildID: string, name: string, type?: number, options?: CreateChannelOptions): Promise<unknown>;
     editChannel(
       channelID: string,
       options: {
@@ -1085,7 +1067,11 @@ declare namespace Eris {
       around?: string
     ): Promise<Message[]>;
     getPins(channelID: string): Promise<Message[]>;
-    createMessage<T extends Textable = TextableChannel>(channelID: string, content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<T>>;
+    createMessage<T extends Textable = TextableChannel>(
+      channelID: string,
+      content: MessageContent,
+      file?: MessageFile | MessageFile[]
+    ): Promise<Message<T>>;
     editMessage(channelID: string, messageID: string, content: MessageContent): Promise<Message>;
     pinMessage(channelID: string, messageID: string): Promise<void>;
     unpinMessage(channelID: string, messageID: string): Promise<void>;
@@ -1290,7 +1276,11 @@ declare namespace Eris {
     lastSend: number;
     tokenLimit: number;
     interval: number;
-    constructor(tokenLimit: number, interval: number, options: { reservedTokens: number; latencyRef: { latency: number } });
+    constructor(
+      tokenLimit: number,
+      interval: number,
+      options: { reservedTokens: number; latencyRef: { latency: number } }
+    );
     queue(func: Function, priority?: boolean): void;
   }
 
@@ -1381,10 +1371,30 @@ declare namespace Eris {
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;
     createChannel(name: string): Promise<TextChannel>;
-    createChannel(name: string, type: 0, reason?: string, options?: CreateChannelOptions | string): Promise<TextChannel>;
-    createChannel(name: string, type: 2, reason?: string, options?: CreateChannelOptions | string): Promise<VoiceChannel>;
-    createChannel(name: string, type: 4, reason?: string, options?: CreateChannelOptions | string): Promise<CategoryChannel>;
-    createChannel(name: string, type?: number, reason?: string, options?: CreateChannelOptions | string): Promise<unknown>;
+    createChannel(
+      name: string,
+      type: 0,
+      reason?: string,
+      options?: CreateChannelOptions | string
+    ): Promise<TextChannel>;
+    createChannel(
+      name: string,
+      type: 2,
+      reason?: string,
+      options?: CreateChannelOptions | string
+    ): Promise<VoiceChannel>;
+    createChannel(
+      name: string,
+      type: 4,
+      reason?: string,
+      options?: CreateChannelOptions | string
+    ): Promise<CategoryChannel>;
+    createChannel(
+      name: string,
+      type?: number,
+      reason?: string,
+      options?: CreateChannelOptions | string
+    ): Promise<unknown>;
     createChannel(name: string, type: 0, options?: CreateChannelOptions): Promise<TextChannel>;
     createChannel(name: string, type: 2, options?: CreateChannelOptions): Promise<VoiceChannel>;
     createChannel(name: string, type: 4, options?: CreateChannelOptions): Promise<CategoryChannel>;
@@ -1488,7 +1498,13 @@ declare namespace Eris {
     getWebhooks(): Promise<Webhook[]>;
     createWebhook(options: { name: string; avatar: string }, reason?: string): Promise<Webhook>;
     sendTyping(): Promise<void>;
-    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
+    purge(
+      limit: number,
+      filter?: (message: Message) => boolean,
+      before?: string,
+      after?: string,
+      reason?: string
+    ): Promise<number>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
@@ -1572,7 +1588,13 @@ declare namespace Eris {
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
-    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
+    purge(
+      limit: number,
+      filter?: (message: Message) => boolean,
+      before?: string,
+      after?: string,
+      reason?: string
+    ): Promise<number>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
@@ -1913,13 +1935,15 @@ declare namespace Eris {
     invalidUsageMessage: string | boolean | GenericCheckFunction<string>;
     permissionMessage: string | boolean | GenericCheckFunction<string>;
     errorMessage: string | GenericCheckFunction<string>;
-    reactionButtons: null | {
-      emoji: string;
-      type: string;
-      response: CommandGenerator;
-      execute?: () => string;
-      responses?: (() => string)[];
-    }[];
+    reactionButtons:
+      | null
+      | {
+          emoji: string;
+          type: string;
+          response: CommandGenerator;
+          execute?: () => string;
+          responses?: (() => string)[];
+        }[];
     reactionButtonTimeout: number;
     defaultSubcommandOptions: CommandOptions;
     hidden: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ declare namespace Eris {
 
   // TODO there's also toJSON(): JSONCache, though, SimpleJSON should suffice
 
-  type GuildTextableChannel = TextChannel | NewsChannel;
+  type GuildTextableChannel = TextChannel | NewsChannel
   type TextableChannel = GuildTextableChannel | PrivateChannel;
   type AnyChannel = AnyGuildChannel | PrivateChannel;
   type AnyGuildChannel = GuildTextableChannel | VoiceChannel | CategoryChannel | StoreChannel;
@@ -110,7 +110,7 @@ declare namespace Eris {
     game?: Activity;
   }
 
-  type BotActivityType = 0 | 1 | 2 | 3;
+  type BotActivityType = 0 | 1 | 2 | 3
   type ActivityType = BotActivityType & 4;
 
   interface ActivityPartial<T extends BotActivityType> {
@@ -166,9 +166,9 @@ declare namespace Eris {
   interface Constants {
     ImageSizeBoundaries: {
       MINIMUM: 16;
-      MAXIMUM: 2048;
+      MAXIMUM: 4096;
     };
-    ImageFormats: ["jpg", "png", "webp", "gif"];
+    ImageFormats: ["jpg", "jpeg", "png", "webp", "gif"];
     GatewayOPCodes: {
       EVENT: 0;
       HEARTBEAT: 1;
@@ -251,45 +251,19 @@ declare namespace Eris {
       directMessageTyping: 16384;
     };
     SystemJoinMessages: [
-      "%user% just joined the server - glhf!",
-      "%user% just joined. Everyone, look busy!",
-      "%user% just joined. Can I get a heal?",
-      "%user% joined your party.",
-      "%user% joined. You must construct additional pylons.",
-      "Ermagherd. %user% is here.",
-      "Welcome, %user%. Stay awhile and listen.",
-      "Welcome, %user%. We were expecting you ( ͡° ͜ʖ ͡°)",
+      "%user% joined the party.",
+      "%user% is here.",
       "Welcome, %user%. We hope you brought pizza.",
-      "Welcome %user%. Leave your weapons by the door.",
       "A wild %user% appeared.",
-      "Swoooosh. %user% just landed.",
-      "Brace yourselves. %user% just joined the server.",
-      "%user% just joined... or did they?",
-      "%user% just arrived. Seems OP - please nerf.",
+      "%user% just landed.",
       "%user% just slid into the server.",
-      "A %user% has spawned in the server.",
-      "Big %user% showed up!",
-      "Where’s %user%? In the server!",
-      "%user% hopped into the server. Kangaroo!!",
-      "%user% just showed up. Hold my beer.",
-      "Challenger approaching - %user% has appeared!",
-      "It's a bird! It's a plane! Nevermind, it's just %user%.",
-      "It's %user%! Praise the sun! \\\\[T]/",
-      "Never gonna give %user% up. Never gonna let %user% down.",
-      "%user% has joined the battle bus.",
-      "Cheers, love! %user%'s here!",
-      "Hey! Listen! %user% has joined!",
-      "We've been expecting you %user%",
-      "It's dangerous to go alone, take %user%!",
-      "%user% has joined the server! It's super effective!",
-      "Cheers, love! %user% is here!",
-      "%user% is here, as the prophecy foretold.",
-      "%user% has arrived. Party's over.",
-      "Ready player %user%",
-      "%user% is here to kick butt and chew bubblegum. And %user% is all out of gum.",
-      "Hello. Is it %user% you're looking for?",
-      "%user% has joined. Stay a while and listen!",
-      "Roses are red, violets are blue, %user% joined this server with you"
+      "%user% just showed up!",
+      "Welcome %user%. Say hi!",
+      "%user% hopped into the server.",
+      "Everyone welcome %user%!",
+      "Glad you're here, %user%.",
+      "Good to see you, %user%.",
+      "Yay you made it, %user%!"
     ];
     AuditLogActions: {
       GUILD_UPDATE: 1;
@@ -370,6 +344,22 @@ declare namespace Eris {
       GUILD_NEWS: 5;
       GUILD_STORE: 6;
     };
+    UserFlags: {
+      NONE: 0;
+      DISCORD_EMPLOYEE: 1;
+      DISCORD_PARTNER: 2;
+      HYPESQUAD_EVENTS: 4;
+      BUG_HUNTER_LEVEL_1: 8;
+      HOUSE_BRAVERY: 64;
+      HOUSE_BRILLIANCE: 128;
+      HOUSE_BALANCE: 256;
+      EARLY_SUPPORTER: 512;
+      TEAM_USER: 1024;
+      SYSTEM: 4096
+      BUG_HUNTER_LEVEL_2: 16384;
+      VERIFIED_BOT: 65536;
+      VERIFIED_BOT_DEVELOPER: 131072;
+    }
   }
 
   export const Constants: Constants;
@@ -567,7 +557,7 @@ declare namespace Eris {
     allowedMentions?: AllowedMentions;
     embed?: EmbedOptions;
     flags?: number;
-  };
+  }
 
   interface MessageFile {
     file: Buffer | string;
@@ -842,7 +832,10 @@ declare namespace Eris {
       event: "channelPinUpdate",
       listener: (channel: TextableChannel, timestamp: number, oldTimestamp: number) => void
     ): T;
-    (event: "channelRecipientAdd" | "channelRecipientRemove", listener: (channel: GroupChannel, user: User) => void): T;
+    (
+      event: "channelRecipientAdd" | "channelRecipientRemove",
+      listener: (channel: GroupChannel, user: User) => void
+    ): T;
     (event: "channelUpdate", listener: (channel: AnyGuildChannel, oldChannel: OldGuildChannel) => void): T;
     (event: "friendSuggestionCreate", listener: (user: User, reasons: FriendSuggestionReasons) => void): T;
     (event: "friendSuggestionDelete", listener: (user: User) => void): T;
@@ -869,23 +862,16 @@ declare namespace Eris {
       event: "messageReactionAdd" | "messageReactionRemove",
       listener: (message: PossiblyUncachedMessage, emoji: Emoji, userID: string) => void
     ): T;
-    (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void): T;
+    (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void
+    ): T;
     (event: "presenceUpdate", listener: (other: Member | Relationship, oldPresence?: Presence) => void): T;
     (event: "rawWS" | "unknown", listener: (packet: RawPacket, id: number) => void): T;
     (event: "relationshipAdd" | "relationshipRemove", listener: (relationship: Relationship) => void): T;
-    (event: "relationshipUpdate", listener: (relationship: Relationship, oldRelationship: { type: number }) => void): T;
     (
-      event: "rawREST",
-      listener: (
-        method: string,
-        url: string,
-        auth: boolean,
-        body: unknown,
-        file: MessageFile,
-        route: string,
-        short: boolean
-      ) => void
+      event: "relationshipUpdate",
+      listener: (relationship: Relationship, oldRelationship: { type: number }) => void
     ): T;
+    (event: "rawREST", listener: (method: string, url: string, auth: boolean, body: unknown, file: MessageFile, route: string, short: boolean) => void): T;
     (event: "typingStart", listener: (channel: TextableChannel, user: User) => void): T;
     (event: "unavailableGuildCreate", listener: (guild: UnavailableGuild) => void): T;
     (
@@ -904,7 +890,10 @@ declare namespace Eris {
   }
 
   interface ClientEvents<T> extends EventListeners<T> {
-    (event: "shardDisconnect" | "error" | "shardPreReady" | "connect", listener: (err: Error, id: number) => void): T;
+    (
+      event: "shardDisconnect" | "error" | "shardPreReady" | "connect",
+      listener: (err: Error, id: number) => void
+    ): T;
     (event: "shardReady" | "shardResume", listener: (id: number) => void): T;
   }
 
@@ -939,11 +928,7 @@ declare namespace Eris {
     constructor(token: string, options?: ClientOptions);
     connect(): Promise<void>;
     getGateway(): Promise<{ url: string }>;
-    getBotGateway(): Promise<{
-      url: string;
-      shards: number;
-      session_start_limit: { total: number; remaining: number; reset_after: number };
-    }>;
+    getBotGateway(): Promise<{ url: string; shards: number; session_start_limit: { total: number; remaining: number; reset_after: number } }>;
     disconnect(options: { reconnect: boolean }): void;
     joinVoiceChannel(channelID: string, options?: { shared?: boolean; opusOnly?: boolean }): Promise<VoiceConnection>;
     leaveVoiceChannel(channelID: string): void;
@@ -980,10 +965,30 @@ declare namespace Eris {
       reason?: string,
       options?: CreateChannelOptions | string
     ): Promise<unknown>;
-    createChannel(guildID: string, name: string, type: 0, options?: CreateChannelOptions): Promise<TextChannel>;
-    createChannel(guildID: string, name: string, type: 2, options?: CreateChannelOptions): Promise<VoiceChannel>;
-    createChannel(guildID: string, name: string, type: 4, options?: CreateChannelOptions): Promise<CategoryChannel>;
-    createChannel(guildID: string, name: string, type?: number, options?: CreateChannelOptions): Promise<unknown>;
+    createChannel(
+      guildID: string,
+      name: string,
+      type: 0,
+      options?: CreateChannelOptions
+    ): Promise<TextChannel>;
+    createChannel(
+      guildID: string,
+      name: string,
+      type: 2,
+      options?: CreateChannelOptions
+    ): Promise<VoiceChannel>;
+    createChannel(
+      guildID: string,
+      name: string,
+      type: 4,
+      options?: CreateChannelOptions
+    ): Promise<CategoryChannel>;
+    createChannel(
+      guildID: string,
+      name: string,
+      type?: number,
+      options?: CreateChannelOptions
+    ): Promise<unknown>;
     editChannel(
       channelID: string,
       options: {
@@ -1067,11 +1072,7 @@ declare namespace Eris {
       around?: string
     ): Promise<Message[]>;
     getPins(channelID: string): Promise<Message[]>;
-    createMessage<T extends Textable = TextableChannel>(
-      channelID: string,
-      content: MessageContent,
-      file?: MessageFile | MessageFile[]
-    ): Promise<Message<T>>;
+    createMessage<T extends Textable = TextableChannel>(channelID: string, content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<T>>;
     editMessage(channelID: string, messageID: string, content: MessageContent): Promise<Message>;
     pinMessage(channelID: string, messageID: string): Promise<void>;
     unpinMessage(channelID: string, messageID: string): Promise<void>;
@@ -1097,6 +1098,7 @@ declare namespace Eris {
       after?: string,
       reason?: string
     ): Promise<number>;
+    crosspostMessage(channelID: string, messageID: string): Promise<Message>;
     getGuildEmbed(guildID: string): Promise<GuildEmbed>;
     getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
@@ -1276,11 +1278,7 @@ declare namespace Eris {
     lastSend: number;
     tokenLimit: number;
     interval: number;
-    constructor(
-      tokenLimit: number,
-      interval: number,
-      options: { reservedTokens: number; latencyRef: { latency: number } }
-    );
+    constructor(tokenLimit: number, interval: number, options: { reservedTokens: number; latencyRef: { latency: number } });
     queue(func: Function, priority?: boolean): void;
   }
 
@@ -1371,30 +1369,10 @@ declare namespace Eris {
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;
     createChannel(name: string): Promise<TextChannel>;
-    createChannel(
-      name: string,
-      type: 0,
-      reason?: string,
-      options?: CreateChannelOptions | string
-    ): Promise<TextChannel>;
-    createChannel(
-      name: string,
-      type: 2,
-      reason?: string,
-      options?: CreateChannelOptions | string
-    ): Promise<VoiceChannel>;
-    createChannel(
-      name: string,
-      type: 4,
-      reason?: string,
-      options?: CreateChannelOptions | string
-    ): Promise<CategoryChannel>;
-    createChannel(
-      name: string,
-      type?: number,
-      reason?: string,
-      options?: CreateChannelOptions | string
-    ): Promise<unknown>;
+    createChannel(name: string, type: 0, reason?: string, options?: CreateChannelOptions | string): Promise<TextChannel>;
+    createChannel(name: string, type: 2, reason?: string, options?: CreateChannelOptions | string): Promise<VoiceChannel>;
+    createChannel(name: string, type: 4, reason?: string, options?: CreateChannelOptions | string): Promise<CategoryChannel>;
+    createChannel(name: string, type?: number, reason?: string, options?: CreateChannelOptions | string): Promise<unknown>;
     createChannel(name: string, type: 0, options?: CreateChannelOptions): Promise<TextChannel>;
     createChannel(name: string, type: 2, options?: CreateChannelOptions): Promise<VoiceChannel>;
     createChannel(name: string, type: 4, options?: CreateChannelOptions): Promise<CategoryChannel>;
@@ -1498,13 +1476,7 @@ declare namespace Eris {
     getWebhooks(): Promise<Webhook[]>;
     createWebhook(options: { name: string; avatar: string }, reason?: string): Promise<Webhook>;
     sendTyping(): Promise<void>;
-    purge(
-      limit: number,
-      filter?: (message: Message) => boolean,
-      before?: string,
-      after?: string,
-      reason?: string
-    ): Promise<number>;
+    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
@@ -1588,13 +1560,7 @@ declare namespace Eris {
     removeMessageReaction(messageID: string, reaction: string, userID?: string): Promise<void>;
     removeMessageReactions(messageID: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;
-    purge(
-      limit: number,
-      filter?: (message: Message) => boolean,
-      before?: string,
-      after?: string,
-      reason?: string
-    ): Promise<number>;
+    purge(limit: number, filter?: (message: Message) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     unsendMessage(messageID: string): Promise<void>;
@@ -1603,6 +1569,7 @@ declare namespace Eris {
   export class NewsChannel extends TextChannel {
     type: 5;
     rateLimitPerUser: 0;
+    crosspostMessage(messageID: string): Promise<Message>;
   }
 
   export class VoiceChannel extends GuildChannel implements Invitable {
@@ -1737,6 +1704,7 @@ declare namespace Eris {
     removeReactions(): Promise<void>;
     removeMessageReactionEmoji(reaction: string): Promise<void>;
     delete(reason?: string): Promise<void>;
+    crosspost(): Promise<Message>;
   }
 
   export class Permission {
@@ -1854,6 +1822,7 @@ declare namespace Eris {
     avatarURL: string;
     staticAvatarURL: string;
     system: boolean;
+    publicFlags: number;
     constructor(data: BaseData, client: Client);
     dynamicAvatarURL(format?: string, size?: number): string;
     getDMChannel(): Promise<PrivateChannel>;
@@ -1935,15 +1904,13 @@ declare namespace Eris {
     invalidUsageMessage: string | boolean | GenericCheckFunction<string>;
     permissionMessage: string | boolean | GenericCheckFunction<string>;
     errorMessage: string | GenericCheckFunction<string>;
-    reactionButtons:
-      | null
-      | {
-          emoji: string;
-          type: string;
-          response: CommandGenerator;
-          execute?: () => string;
-          responses?: (() => string)[];
-        }[];
+    reactionButtons: null | {
+      emoji: string;
+      type: string;
+      response: CommandGenerator;
+      execute?: () => string;
+      responses?: (() => string)[];
+    }[];
     reactionButtonTimeout: number;
     defaultSubcommandOptions: CommandOptions;
     hidden: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { Readable as ReadableStream } from "stream";
 import { Agent as HTTPSAgent } from "https";
+import { IncomingMessage } from "http";
 
 declare function Eris(token: string, options?: Eris.ClientOptions): Eris.Client;
 
@@ -833,6 +834,17 @@ declare namespace Eris {
     reason?: string;
   }
 
+  interface RawRESTRequest {
+    method: string;
+    url: string;
+    auth: boolean;
+    body: unknown;
+    file: MessageFile
+    route: string
+    short: boolean
+    resp: IncomingMessage
+  }
+
   interface EventListeners<T> {
     (event: "ready" | "disconnect", listener: () => void): T;
     (event: "callCreate" | "callRing" | "callDelete", listener: (call: Call) => void): T;
@@ -875,6 +887,7 @@ declare namespace Eris {
     (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void
     ): T;
     (event: "presenceUpdate", listener: (other: Member | Relationship, oldPresence?: Presence) => void): T;
+    (event: "rawREST", listener: (request: RawRESTRequest) => void): T;
     (event: "rawWS" | "unknown", listener: (packet: RawPacket, id: number) => void): T;
     (event: "relationshipAdd" | "relationshipRemove", listener: (relationship: Relationship) => void): T;
     (

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -68,7 +68,6 @@ class RequestHandler {
         /**
         * Fired when a request is sent through the RequestHandler.
         * @event Client#requestHandled
-        * @prop {Error} err The error
         * @arg {String} method Uppercase HTTP method
         * @arg {String} url URL of the endpoint
         * @arg {Boolean} auth Whether to add the Authorization header and token or not

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -67,7 +67,7 @@ class RequestHandler {
     request(method, url, auth, body, file, _route, short) {
         /**
         * Fired when a request is sent through the RequestHandler.
-        * @event Client#requestHandled
+        * @event Client#rawREST
         * @arg {String} method Uppercase HTTP method
         * @arg {String} url URL of the endpoint
         * @arg {Boolean} auth Whether to add the Authorization header and token or not
@@ -75,8 +75,8 @@ class RequestHandler {
         * @arg {Object} [file] File object
         * @arg {Buffer} file.file A buffer containing file data
         * @arg {String} file.name What to name the file
-        */
-        this._client.emit("requestHandled", method, url, auth, body, file, _route, short);
+         */
+        this._client.emit("rawREST", method, url, auth, body, file, _route, short);
         const route = _route || this.routefy(url, method);
 
         const _stackHolder = {}; // Preserve async stack

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -10,365 +10,431 @@ const SequentialBucket = require("../util/SequentialBucket");
 const Zlib = require("zlib");
 
 /**
-* Handles API requests
-*/
+ * Handles API requests
+ */
 class RequestHandler {
-    constructor(client, forceQueueing) {
-        this._client = client;
-        this.baseURL = Endpoints.BASE_URL;
-        this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
-        this.ratelimits = {};
-        this.requestTimeout = client.options.requestTimeout;
-        this.agent = client.options.agent;
-        this.latencyRef = {
-            latency: 500,
-            offset: client.options.ratelimiterOffset,
-            raw: new Array(10).fill(500),
-            timeOffset: 0,
-            timeOffsets: new Array(10).fill(0),
-            lastTimeOffsetCheck: 0
-        };
-        this.globalBlock = false;
-        this.readyQueue = [];
-        if(forceQueueing) {
-            this.globalBlock = true;
-            this._client.once("shardPreReady", () => this.globalUnblock());
-        }
+  constructor(client, forceQueueing) {
+    this._client = client;
+    this.baseURL = Endpoints.BASE_URL;
+    this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
+    this.ratelimits = {};
+    this.requestTimeout = client.options.requestTimeout;
+    this.agent = client.options.agent;
+    this.latencyRef = {
+      latency: 500,
+      offset: client.options.ratelimiterOffset,
+      raw: new Array(10).fill(500),
+      timeOffset: 0,
+      timeOffsets: new Array(10).fill(0),
+      lastTimeOffsetCheck: 0,
+    };
+    this.globalBlock = false;
+    this.readyQueue = [];
+    if (forceQueueing) {
+      this.globalBlock = true;
+      this._client.once("shardPreReady", () => this.globalUnblock());
     }
+  }
 
-    globalUnblock() {
-        this.globalBlock = false;
-        while(this.readyQueue.length > 0) {
-            this.readyQueue.shift()();
-        }
+  globalUnblock() {
+    this.globalBlock = false;
+    while (this.readyQueue.length > 0) {
+      this.readyQueue.shift()();
     }
+  }
 
-    routefy(url, method) {
-        let route = url.replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function(match, p) {
-            return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
-        }).replace(/\/reactions\/[^/]+/g, "/reactions/:id").replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
-        if(method === "DELETE" && route.endsWith("/messages/:id")) { // Delete Messsage endpoint has its own ratelimit
-            route = method + route;
-        }
-        return route;
+  routefy(url, method) {
+    let route = url
+      .replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function (match, p) {
+        return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
+      })
+      .replace(/\/reactions\/[^/]+/g, "/reactions/:id")
+      .replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
+    if (method === "DELETE" && route.endsWith("/messages/:id")) {
+      // Delete Messsage endpoint has its own ratelimit
+      route = method + route;
     }
+    return route;
+  }
 
+  /**
+   * Make an API request
+   * @arg {String} method Uppercase HTTP method
+   * @arg {String} url URL of the endpoint
+   * @arg {Boolean} auth Whether to add the Authorization header and token or not
+   * @arg {Object} [body] Request payload
+   * @arg {Object} [file] File object
+   * @arg {Buffer} file.file A buffer containing file data
+   * @arg {String} file.name What to name the file
+   * @returns {Promise<Object>} Resolves with the returned JSON data
+   */
+  request(method, url, auth, body, file, _route, short) {
     /**
-    * Make an API request
-    * @arg {String} method Uppercase HTTP method
-    * @arg {String} url URL of the endpoint
-    * @arg {Boolean} auth Whether to add the Authorization header and token or not
-    * @arg {Object} [body] Request payload
-    * @arg {Object} [file] File object
-    * @arg {Buffer} file.file A buffer containing file data
-    * @arg {String} file.name What to name the file
-    * @returns {Promise<Object>} Resolves with the returned JSON data
-    */
-    request(method, url, auth, body, file, _route, short) {
-        /**
-        * Fired when a request is sent through the RequestHandler.
-        * @event Client#requestHandled
-        * @arg {String} method Uppercase HTTP method
-        * @arg {String} url URL of the endpoint
-        * @arg {Boolean} auth Whether to add the Authorization header and token or not
-        * @arg {Object} [body] Request payload
-        * @arg {Object} [file] File object
-        * @arg {Buffer} file.file A buffer containing file data
-        * @arg {String} file.name What to name the file
-        */
-        this._client.emit("requestHandled", method, url, auth, body, file, _route, short);
-        const route = _route || this.routefy(url, method);
+     * Fired when a request is sent through the RequestHandler.
+     * @event Client#rawREST
+     * @arg {String} method Uppercase HTTP method
+     * @arg {String} url URL of the endpoint
+     * @arg {Boolean} auth Whether to add the Authorization header and token or not
+     * @arg {Object} [body] Request payload
+     * @arg {Object} [file] File object
+     * @arg {Buffer} file.file A buffer containing file data
+     * @arg {String} file.name What to name the file
+     */
+    this._client.emit("rawREST", method, url, auth, body, file, _route, short);
+    const route = _route || this.routefy(url, method);
 
-        const _stackHolder = {}; // Preserve async stack
-        Error.captureStackTrace(_stackHolder);
+    const _stackHolder = {}; // Preserve async stack
+    Error.captureStackTrace(_stackHolder);
 
-        return new Promise((resolve, reject) => {
-            let attempts = 0;
+    return new Promise((resolve, reject) => {
+      let attempts = 0;
 
-            const actualCall = (cb) => {
-                const headers = {
-                    "User-Agent": this.userAgent,
-                    "Accept-Encoding": "gzip,deflate"
-                };
-                let data;
-                let finalURL = url;
+      const actualCall = (cb) => {
+        const headers = {
+          "User-Agent": this.userAgent,
+          "Accept-Encoding": "gzip,deflate",
+        };
+        let data;
+        let finalURL = url;
 
-                try {
-                    if(auth) {
-                        headers.Authorization = this._client.token;
+        try {
+          if (auth) {
+            headers.Authorization = this._client.token;
+          }
+          if (body && body.reason) {
+            // Audit log reason sniping
+            headers["X-Audit-Log-Reason"] = body.reason;
+            delete body.reason;
+          }
+          if (body && body.queryReason) {
+            body.reason = body.queryReason;
+            delete body.queryReason;
+          }
+          if (file) {
+            if (Array.isArray(file)) {
+              data = new MultipartData();
+              headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
+              file.forEach(function (f) {
+                if (!f.file) {
+                  return;
+                }
+                data.attach(f.name, f.file, f.name);
+              });
+              if (body) {
+                data.attach("payload_json", body);
+              }
+              data = data.finish();
+            } else if (file.file) {
+              data = new MultipartData();
+              headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
+              data.attach("file", file.file, file.name);
+              if (body) {
+                data.attach("payload_json", body);
+              }
+              data = data.finish();
+            } else {
+              throw new Error("Invalid file object");
+            }
+          } else if (body) {
+            if (
+              method === "GET" ||
+              (method === "PUT" && url.includes("/bans/")) ||
+              (method === "POST" && url.includes("/prune"))
+            ) {
+              // Special PUT&POST case (╯°□°）╯︵ ┻━┻
+              let qs = "";
+              Object.keys(body).forEach(function (key) {
+                if (body[key] != undefined) {
+                  if (Array.isArray(body[key])) {
+                    body[key].forEach(function (val) {
+                      qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
+                    });
+                  } else {
+                    qs += `&${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`;
+                  }
+                }
+              });
+              finalURL += "?" + qs.substring(1);
+            } else {
+              data = JSON.stringify(body);
+              headers["Content-Type"] = "application/json";
+            }
+          }
+        } catch (err) {
+          cb();
+          reject(err);
+          return;
+        }
+
+        const req = HTTPS.request({
+          method: method,
+          host: "discordapp.com",
+          path: this.baseURL + finalURL,
+          headers: headers,
+          agent: this.agent,
+        });
+
+        let reqError;
+
+        req
+          .once("abort", () => {
+            cb();
+            reqError = reqError || new Error(`Request aborted by client on ${method} ${url}`);
+            reqError.req = req;
+            reject(reqError);
+          })
+          .once("error", (err) => {
+            reqError = err;
+            req.abort();
+          });
+
+        let latency = Date.now();
+
+        req.once("response", (resp) => {
+          latency = Date.now() - latency;
+          this.latencyRef.raw.push(latency);
+          this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
+
+          const headerNow = Date.parse(resp.headers["date"]);
+          if (this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
+            const timeOffset = ~~((this.latencyRef.lastTimeOffsetCheck = Date.now()) - headerNow);
+            if (
+              this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold &&
+              timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold
+            ) {
+              this._client.emit(
+                "warn",
+                new Error(
+                  `Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`
+                )
+              );
+            }
+            this.latencyRef.timeOffset = ~~(
+              this.latencyRef.timeOffset -
+              this.latencyRef.timeOffsets.shift() / 10 +
+              timeOffset / 10
+            );
+            this.latencyRef.timeOffsets.push(timeOffset);
+          }
+
+          resp.once("aborted", () => {
+            cb();
+            reqError = reqError || new Error(`Request aborted by server on ${method} ${url}`);
+            reqError.req = req;
+            reject(reqError);
+          });
+
+          let response = "";
+
+          let _respStream = resp;
+          if (resp.headers["content-encoding"]) {
+            if (resp.headers["content-encoding"].includes("gzip")) {
+              _respStream = resp.pipe(Zlib.createGunzip());
+            } else if (resp.headers["content-encoding"].includes("deflate")) {
+              _respStream = resp.pipe(Zlib.createInflate());
+            }
+          }
+
+          _respStream
+            .on("data", (str) => {
+              response += str;
+            })
+            .on("error", (err) => {
+              reqError = err;
+              req.abort();
+            })
+            .once("end", () => {
+              const now = Date.now();
+
+              if (resp.headers["x-ratelimit-limit"]) {
+                this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
+              }
+
+              if (
+                method !== "GET" &&
+                (resp.headers["x-ratelimit-remaining"] == undefined ||
+                  resp.headers["x-ratelimit-limit"] == undefined) &&
+                this.ratelimits[route].limit !== 1
+              ) {
+                this._client.emit(
+                  "debug",
+                  `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n` +
+                    `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n` +
+                    "content-type = " +
+                    +"\n" +
+                    "x-ratelimit-remaining = " +
+                    resp.headers["x-ratelimit-remaining"] +
+                    "\n" +
+                    "x-ratelimit-limit = " +
+                    resp.headers["x-ratelimit-limit"] +
+                    "\n" +
+                    "x-ratelimit-reset = " +
+                    resp.headers["x-ratelimit-reset"] +
+                    "\n" +
+                    "x-ratelimit-global = " +
+                    resp.headers["x-ratelimit-global"]
+                );
+              }
+
+              this.ratelimits[route].remaining =
+                resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
+
+              if (resp.headers["retry-after"]) {
+                if (resp.headers["x-ratelimit-global"]) {
+                  this.globalBlock = true;
+                  setTimeout(() => this.globalUnblock(), +resp.headers["retry-after"] || 1);
+                } else {
+                  this.ratelimits[route].reset = (+resp.headers["retry-after"] || 1) + now;
+                }
+              } else if (resp.headers["x-ratelimit-reset"]) {
+                if (
+                  ~route.lastIndexOf("/reactions/:id") &&
+                  +resp.headers["x-ratelimit-reset"] * 1000 - headerNow === 1000
+                ) {
+                  this.ratelimits[route].reset = Math.max(now + 250 - this.latencyRef.timeOffset, now);
+                } else {
+                  this.ratelimits[route].reset = Math.max(
+                    +resp.headers["x-ratelimit-reset"] * 1000 - this.latencyRef.timeOffset,
+                    now
+                  );
+                }
+              } else {
+                this.ratelimits[route].reset = now;
+              }
+
+              if (resp.statusCode !== 429) {
+                this._client.emit(
+                  "debug",
+                  `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${
+                    this.latencyRef.latency
+                  }ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${
+                    this.ratelimits[route].reset
+                  } (${this.ratelimits[route].reset - now}ms left)`
+                );
+              }
+
+              if (resp.statusCode >= 300) {
+                if (resp.statusCode === 429) {
+                  this._client.emit(
+                    "debug",
+                    `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${
+                      body && body.content
+                    } ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${
+                      this.ratelimits[route].remaining
+                    }/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${
+                      this.ratelimits[route].reset - now
+                    }ms left)`
+                  );
+                  if (resp.headers["retry-after"]) {
+                    setTimeout(() => {
+                      cb();
+                      this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                    }, +resp.headers["retry-after"]);
+                    return;
+                  } else {
+                    cb();
+                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                    return;
+                  }
+                } else if (resp.statusCode === 502 && ++attempts < 4) {
+                  this._client.emit("debug", "A wild 502 appeared! Thanks CloudFlare!");
+                  setTimeout(() => {
+                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                  }, Math.floor(Math.random() * 1900 + 100));
+                  return cb();
+                }
+                cb();
+
+                if (response.length > 0) {
+                  if (resp.headers["content-type"] === "application/json") {
+                    try {
+                      response = JSON.parse(response);
+                    } catch (err) {
+                      reject(err);
+                      return;
                     }
-                    if(body && body.reason) { // Audit log reason sniping
-                        headers["X-Audit-Log-Reason"] = body.reason;
-                        delete body.reason;
-                    }
-                    if(body && body.queryReason) {
-                        body.reason = body.queryReason;
-                        delete body.queryReason;
-                    }
-                    if(file) {
-                        if(Array.isArray(file)) {
-                            data = new MultipartData();
-                            headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
-                            file.forEach(function(f) {
-                                if(!f.file) {
-                                    return;
-                                }
-                                data.attach(f.name, f.file, f.name);
-                            });
-                            if(body) {
-                                data.attach("payload_json", body);
-                            }
-                            data = data.finish();
-                        } else if(file.file) {
-                            data = new MultipartData();
-                            headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
-                            data.attach("file", file.file, file.name);
-                            if(body) {
-                                data.attach("payload_json", body);
-                            }
-                            data = data.finish();
-                        } else {
-                            throw new Error("Invalid file object");
-                        }
-                    } else if(body) {
-                        if(method === "GET" || (method === "PUT" && url.includes("/bans/")) || (method === "POST" && url.includes("/prune"))) { // Special PUT&POST case (╯°□°）╯︵ ┻━┻
-                            let qs = "";
-                            Object.keys(body).forEach(function(key) {
-                                if(body[key] != undefined) {
-                                    if(Array.isArray(body[key])) {
-                                        body[key].forEach(function(val) {
-                                            qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
-                                        });
-                                    } else {
-                                        qs += `&${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`;
-                                    }
-                                }
-                            });
-                            finalURL += "?" + qs.substring(1);
-                        } else {
-                            data = JSON.stringify(body);
-                            headers["Content-Type"] = "application/json";
-                        }
-                    }
-                } catch(err) {
+                  }
+                }
+
+                let { stack } = _stackHolder;
+                if (stack.startsWith("Error\n")) {
+                  stack = stack.substring(6);
+                }
+                let err;
+                if (response.code) {
+                  err = new DiscordRESTError(req, resp, response, stack);
+                } else {
+                  err = new DiscordHTTPError(req, resp, response, stack);
+                }
+                reject(err);
+                return;
+              }
+
+              if (response.length > 0) {
+                if (resp.headers["content-type"] === "application/json") {
+                  try {
+                    response = JSON.parse(response);
+                  } catch (err) {
                     cb();
                     reject(err);
                     return;
+                  }
                 }
+              }
 
-                const req = HTTPS.request({
-                    method: method,
-                    host: "discordapp.com",
-                    path: this.baseURL + finalURL,
-                    headers: headers,
-                    agent: this.agent
-                });
-
-                let reqError;
-
-                req.once("abort", () => {
-                    cb();
-                    reqError = reqError || new Error(`Request aborted by client on ${method} ${url}`);
-                    reqError.req = req;
-                    reject(reqError);
-                }).once("error", (err) => {
-                    reqError = err;
-                    req.abort();
-                });
-
-                let latency = Date.now();
-
-                req.once("response", (resp) => {
-                    latency = Date.now() - latency;
-                    this.latencyRef.raw.push(latency);
-                    this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
-
-                    const headerNow = Date.parse(resp.headers["date"]);
-                    if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
-                        const timeOffset = ~~((this.latencyRef.lastTimeOffsetCheck = Date.now()) - headerNow);
-                        if(this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold) {
-                            this._client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
-                        }
-                        this.latencyRef.timeOffset = ~~(this.latencyRef.timeOffset - this.latencyRef.timeOffsets.shift() / 10 + timeOffset / 10);
-                        this.latencyRef.timeOffsets.push(timeOffset);
-                    }
-
-                    resp.once("aborted", () => {
-                        cb();
-                        reqError = reqError || new Error(`Request aborted by server on ${method} ${url}`);
-                        reqError.req = req;
-                        reject(reqError);
-                    });
-
-                    let response = "";
-
-                    let _respStream = resp;
-                    if(resp.headers["content-encoding"]) {
-                        if(resp.headers["content-encoding"].includes("gzip")) {
-                            _respStream = resp.pipe(Zlib.createGunzip());
-                        } else if(resp.headers["content-encoding"].includes("deflate")) {
-                            _respStream = resp.pipe(Zlib.createInflate());
-                        }
-                    }
-
-                    _respStream.on("data", (str) => {
-                        response += str;
-                    }).on("error", (err) => {
-                        reqError = err;
-                        req.abort();
-                    }).once("end", () => {
-                        const now = Date.now();
-
-                        if(resp.headers["x-ratelimit-limit"]) {
-                            this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
-                        }
-
-                        if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == undefined || resp.headers["x-ratelimit-limit"] == undefined) && this.ratelimits[route].limit !== 1) {
-                            this._client.emit("debug", `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n`
-                                + `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
-                                + "content-type = " +  + "\n"
-                                + "x-ratelimit-remaining = " + resp.headers["x-ratelimit-remaining"] + "\n"
-                                + "x-ratelimit-limit = " + resp.headers["x-ratelimit-limit"] + "\n"
-                                + "x-ratelimit-reset = " + resp.headers["x-ratelimit-reset"] + "\n"
-                                + "x-ratelimit-global = " + resp.headers["x-ratelimit-global"]);
-                        }
-
-                        this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
-
-                        if(resp.headers["retry-after"]) {
-                            if(resp.headers["x-ratelimit-global"]) {
-                                this.globalBlock = true;
-                                setTimeout(() => this.globalUnblock(), +resp.headers["retry-after"] || 1);
-                            } else {
-                                this.ratelimits[route].reset = (+resp.headers["retry-after"] || 1) + now;
-                            }
-                        } else if(resp.headers["x-ratelimit-reset"]) {
-                            if((~route.lastIndexOf("/reactions/:id")) && (+resp.headers["x-ratelimit-reset"] * 1000 - headerNow) === 1000) {
-                                this.ratelimits[route].reset = Math.max(now + 250 - this.latencyRef.timeOffset, now);
-                            } else {
-                                this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * 1000 - this.latencyRef.timeOffset, now);
-                            }
-                        } else {
-                            this.ratelimits[route].reset = now;
-                        }
-
-                        if(resp.statusCode !== 429) {
-                            this._client.emit("debug", `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
-                        }
-
-                        if(resp.statusCode >= 300) {
-                            if(resp.statusCode === 429) {
-                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
-                                if(resp.headers["retry-after"]) {
-                                    setTimeout(() => {
-                                        cb();
-                                        this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                                    }, +resp.headers["retry-after"]);
-                                    return;
-                                } else {
-                                    cb();
-                                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                                    return;
-                                }
-                            } else if(resp.statusCode === 502 && ++attempts < 4) {
-                                this._client.emit("debug", "A wild 502 appeared! Thanks CloudFlare!");
-                                setTimeout(() => {
-                                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                                }, Math.floor(Math.random() * 1900 + 100));
-                                return cb();
-                            }
-                            cb();
-
-                            if(response.length > 0) {
-                                if(resp.headers["content-type"] === "application/json") {
-                                    try {
-                                        response = JSON.parse(response);
-                                    } catch(err) {
-                                        reject(err);
-                                        return;
-                                    }
-                                }
-                            }
-
-                            let {stack} = _stackHolder;
-                            if(stack.startsWith("Error\n")) {
-                                stack = stack.substring(6);
-                            }
-                            let err;
-                            if(response.code) {
-                                err = new DiscordRESTError(req, resp, response, stack);
-                            } else {
-                                err = new DiscordHTTPError(req, resp, response, stack);
-                            }
-                            reject(err);
-                            return;
-                        }
-
-                        if(response.length > 0) {
-                            if(resp.headers["content-type"] === "application/json") {
-                                try {
-                                    response = JSON.parse(response);
-                                } catch(err) {
-                                    cb();
-                                    reject(err);
-                                    return;
-                                }
-                            }
-                        }
-
-                        cb();
-                        resolve(response);
-                    });
-                });
-
-                req.setTimeout(this.requestTimeout, () => {
-                    reqError = new Error(`Request timed out (>${this.requestTimeout}ms) on ${method} ${url}`);
-                    req.abort();
-                });
-
-                if(Array.isArray(data)) {
-                    for(const chunk of data) {
-                        req.write(chunk);
-                    }
-                    req.end();
-                } else {
-                    req.end(data);
-                }
-            };
-
-            if(this.globalBlock && auth) {
-                this.readyQueue.push(() => {
-                    if(!this.ratelimits[route]) {
-                        this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
-                    }
-                    this.ratelimits[route].queue(actualCall, short);
-                });
-            } else {
-                if(!this.ratelimits[route]) {
-                    this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
-                }
-                this.ratelimits[route].queue(actualCall, short);
-            }
+              cb();
+              resolve(response);
+            });
         });
-    }
 
-    toString() {
-        return "[RequestHandler]";
-    }
+        req.setTimeout(this.requestTimeout, () => {
+          reqError = new Error(`Request timed out (>${this.requestTimeout}ms) on ${method} ${url}`);
+          req.abort();
+        });
 
-    toJSON(props = []) {
-        return Base.prototype.toJSON.call(this, [
-            "baseURL",
-            "userAgent",
-            "ratelimits",
-            "requestTimeout",
-            "agent",
-            "latencyRef",
-            "globalBlock",
-            "readyQueue",
-            ...props
-        ]);
-    }
+        if (Array.isArray(data)) {
+          for (const chunk of data) {
+            req.write(chunk);
+          }
+          req.end();
+        } else {
+          req.end(data);
+        }
+      };
+
+      if (this.globalBlock && auth) {
+        this.readyQueue.push(() => {
+          if (!this.ratelimits[route]) {
+            this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
+          }
+          this.ratelimits[route].queue(actualCall, short);
+        });
+      } else {
+        if (!this.ratelimits[route]) {
+          this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
+        }
+        this.ratelimits[route].queue(actualCall, short);
+      }
+    });
+  }
+
+  toString() {
+    return "[RequestHandler]";
+  }
+
+  toJSON(props = []) {
+    return Base.prototype.toJSON.call(this, [
+      "baseURL",
+      "userAgent",
+      "ratelimits",
+      "requestTimeout",
+      "agent",
+      "latencyRef",
+      "globalBlock",
+      "readyQueue",
+      ...props,
+    ]);
+  }
 }
 
 module.exports = RequestHandler;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -10,65 +10,49 @@ const SequentialBucket = require("../util/SequentialBucket");
 const Zlib = require("zlib");
 
 /**
- * Handles API requests
- */
+* Handles API requests
+*/
 class RequestHandler {
-  constructor(client, forceQueueing) {
-    this._client = client;
-    this.baseURL = Endpoints.BASE_URL;
-    this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
-    this.ratelimits = {};
-    this.requestTimeout = client.options.requestTimeout;
-    this.agent = client.options.agent;
-    this.latencyRef = {
-      latency: 500,
-      offset: client.options.ratelimiterOffset,
-      raw: new Array(10).fill(500),
-      timeOffset: 0,
-      timeOffsets: new Array(10).fill(0),
-      lastTimeOffsetCheck: 0,
-    };
-    this.globalBlock = false;
-    this.readyQueue = [];
-    if (forceQueueing) {
-      this.globalBlock = true;
-      this._client.once("shardPreReady", () => this.globalUnblock());
+    constructor(client, forceQueueing) {
+        this._client = client;
+        this.baseURL = Endpoints.BASE_URL;
+        this.userAgent = `DiscordBot (https://github.com/abalabahaha/eris, ${require("../../package.json").version})`;
+        this.ratelimits = {};
+        this.requestTimeout = client.options.requestTimeout;
+        this.agent = client.options.agent;
+        this.latencyRef = {
+            latency: 500,
+            offset: client.options.ratelimiterOffset,
+            raw: new Array(10).fill(500),
+            timeOffset: 0,
+            timeOffsets: new Array(10).fill(0),
+            lastTimeOffsetCheck: 0
+        };
+        this.globalBlock = false;
+        this.readyQueue = [];
+        if(forceQueueing) {
+            this.globalBlock = true;
+            this._client.once("shardPreReady", () => this.globalUnblock());
+        }
     }
-  }
 
-  globalUnblock() {
-    this.globalBlock = false;
-    while (this.readyQueue.length > 0) {
-      this.readyQueue.shift()();
+    globalUnblock() {
+        this.globalBlock = false;
+        while(this.readyQueue.length > 0) {
+            this.readyQueue.shift()();
+        }
     }
-  }
 
-  routefy(url, method) {
-    let route = url
-      .replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function (match, p) {
-        return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
-      })
-      .replace(/\/reactions\/[^/]+/g, "/reactions/:id")
-      .replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
-    if (method === "DELETE" && route.endsWith("/messages/:id")) {
-      // Delete Messsage endpoint has its own ratelimit
-      route = method + route;
+    routefy(url, method) {
+        let route = url.replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function(match, p) {
+            return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
+        }).replace(/\/reactions\/[^/]+/g, "/reactions/:id").replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
+        if(method === "DELETE" && route.endsWith("/messages/:id")) { // Delete Messsage endpoint has its own ratelimit
+            route = method + route;
+        }
+        return route;
     }
-    return route;
-  }
 
-  /**
-   * Make an API request
-   * @arg {String} method Uppercase HTTP method
-   * @arg {String} url URL of the endpoint
-   * @arg {Boolean} auth Whether to add the Authorization header and token or not
-   * @arg {Object} [body] Request payload
-   * @arg {Object} [file] File object
-   * @arg {Buffer} file.file A buffer containing file data
-   * @arg {String} file.name What to name the file
-   * @returns {Promise<Object>} Resolves with the returned JSON data
-   */
-  request(method, url, auth, body, file, _route, short) {
     /**
     * Make an API request
     * @arg {String} method Uppercase HTTP method
@@ -91,7 +75,7 @@ class RequestHandler {
         * @arg {Object} [file] File object
         * @arg {Buffer} file.file A buffer containing file data
         * @arg {String} file.name What to name the file
-         */
+        */
         this._client.emit("rawREST", method, url, auth, body, file, _route, short);
         const route = _route || this.routefy(url, method);
 
@@ -171,323 +155,220 @@ class RequestHandler {
                     reject(err);
                     return;
                 }
-                data.attach(f.name, f.file, f.name);
-              });
-              if (body) {
-                data.attach("payload_json", body);
-              }
-              data = data.finish();
-            } else if (file.file) {
-              data = new MultipartData();
-              headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
-              data.attach("file", file.file, file.name);
-              if (body) {
-                data.attach("payload_json", body);
-              }
-              data = data.finish();
-            } else {
-              throw new Error("Invalid file object");
-            }
-          } else if (body) {
-            if (
-              method === "GET" ||
-              (method === "PUT" && url.includes("/bans/")) ||
-              (method === "POST" && url.includes("/prune"))
-            ) {
-              // Special PUT&POST case (╯°□°）╯︵ ┻━┻
-              let qs = "";
-              Object.keys(body).forEach(function (key) {
-                if (body[key] != undefined) {
-                  if (Array.isArray(body[key])) {
-                    body[key].forEach(function (val) {
-                      qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
-                    });
-                  } else {
-                    qs += `&${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`;
-                  }
-                }
-              });
-              finalURL += "?" + qs.substring(1);
-            } else {
-              data = JSON.stringify(body);
-              headers["Content-Type"] = "application/json";
-            }
-          }
-        } catch (err) {
-          cb();
-          reject(err);
-          return;
-        }
 
-        const req = HTTPS.request({
-          method: method,
-          host: "discordapp.com",
-          path: this.baseURL + finalURL,
-          headers: headers,
-          agent: this.agent,
-        });
+                const req = HTTPS.request({
+                    method: method,
+                    host: "discordapp.com",
+                    path: this.baseURL + finalURL,
+                    headers: headers,
+                    agent: this.agent
+                });
 
-        let reqError;
+                let reqError;
 
-        req
-          .once("abort", () => {
-            cb();
-            reqError = reqError || new Error(`Request aborted by client on ${method} ${url}`);
-            reqError.req = req;
-            reject(reqError);
-          })
-          .once("error", (err) => {
-            reqError = err;
-            req.abort();
-          });
-
-        let latency = Date.now();
-
-        req.once("response", (resp) => {
-          latency = Date.now() - latency;
-          this.latencyRef.raw.push(latency);
-          this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
-
-          const headerNow = Date.parse(resp.headers["date"]);
-          if (this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
-            const timeOffset = ~~((this.latencyRef.lastTimeOffsetCheck = Date.now()) - headerNow);
-            if (
-              this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold &&
-              timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold
-            ) {
-              this._client.emit(
-                "warn",
-                new Error(
-                  `Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`
-                )
-              );
-            }
-            this.latencyRef.timeOffset = ~~(
-              this.latencyRef.timeOffset -
-              this.latencyRef.timeOffsets.shift() / 10 +
-              timeOffset / 10
-            );
-            this.latencyRef.timeOffsets.push(timeOffset);
-          }
-
-          resp.once("aborted", () => {
-            cb();
-            reqError = reqError || new Error(`Request aborted by server on ${method} ${url}`);
-            reqError.req = req;
-            reject(reqError);
-          });
-
-          let response = "";
-
-          let _respStream = resp;
-          if (resp.headers["content-encoding"]) {
-            if (resp.headers["content-encoding"].includes("gzip")) {
-              _respStream = resp.pipe(Zlib.createGunzip());
-            } else if (resp.headers["content-encoding"].includes("deflate")) {
-              _respStream = resp.pipe(Zlib.createInflate());
-            }
-          }
-
-          _respStream
-            .on("data", (str) => {
-              response += str;
-            })
-            .on("error", (err) => {
-              reqError = err;
-              req.abort();
-            })
-            .once("end", () => {
-              const now = Date.now();
-
-              if (resp.headers["x-ratelimit-limit"]) {
-                this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
-              }
-
-              if (
-                method !== "GET" &&
-                (resp.headers["x-ratelimit-remaining"] == undefined ||
-                  resp.headers["x-ratelimit-limit"] == undefined) &&
-                this.ratelimits[route].limit !== 1
-              ) {
-                this._client.emit(
-                  "debug",
-                  `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n` +
-                    `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n` +
-                    "content-type = " +
-                    +"\n" +
-                    "x-ratelimit-remaining = " +
-                    resp.headers["x-ratelimit-remaining"] +
-                    "\n" +
-                    "x-ratelimit-limit = " +
-                    resp.headers["x-ratelimit-limit"] +
-                    "\n" +
-                    "x-ratelimit-reset = " +
-                    resp.headers["x-ratelimit-reset"] +
-                    "\n" +
-                    "x-ratelimit-global = " +
-                    resp.headers["x-ratelimit-global"]
-                );
-              }
-
-              this.ratelimits[route].remaining =
-                resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
-
-              if (resp.headers["retry-after"]) {
-                if (resp.headers["x-ratelimit-global"]) {
-                  this.globalBlock = true;
-                  setTimeout(() => this.globalUnblock(), +resp.headers["retry-after"] || 1);
-                } else {
-                  this.ratelimits[route].reset = (+resp.headers["retry-after"] || 1) + now;
-                }
-              } else if (resp.headers["x-ratelimit-reset"]) {
-                if (
-                  ~route.lastIndexOf("/reactions/:id") &&
-                  +resp.headers["x-ratelimit-reset"] * 1000 - headerNow === 1000
-                ) {
-                  this.ratelimits[route].reset = Math.max(now + 250 - this.latencyRef.timeOffset, now);
-                } else {
-                  this.ratelimits[route].reset = Math.max(
-                    +resp.headers["x-ratelimit-reset"] * 1000 - this.latencyRef.timeOffset,
-                    now
-                  );
-                }
-              } else {
-                this.ratelimits[route].reset = now;
-              }
-
-              if (resp.statusCode !== 429) {
-                this._client.emit(
-                  "debug",
-                  `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${
-                    this.latencyRef.latency
-                  }ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${
-                    this.ratelimits[route].reset
-                  } (${this.ratelimits[route].reset - now}ms left)`
-                );
-              }
-
-              if (resp.statusCode >= 300) {
-                if (resp.statusCode === 429) {
-                  this._client.emit(
-                    "debug",
-                    `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${
-                      body && body.content
-                    } ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${
-                      this.ratelimits[route].remaining
-                    }/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${
-                      this.ratelimits[route].reset - now
-                    }ms left)`
-                  );
-                  if (resp.headers["retry-after"]) {
-                    setTimeout(() => {
-                      cb();
-                      this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                    }, +resp.headers["retry-after"]);
-                    return;
-                  } else {
+                req.once("abort", () => {
                     cb();
-                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                    return;
-                  }
-                } else if (resp.statusCode === 502 && ++attempts < 4) {
-                  this._client.emit("debug", "A wild 502 appeared! Thanks CloudFlare!");
-                  setTimeout(() => {
-                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                  }, Math.floor(Math.random() * 1900 + 100));
-                  return cb();
-                }
-                cb();
+                    reqError = reqError || new Error(`Request aborted by client on ${method} ${url}`);
+                    reqError.req = req;
+                    reject(reqError);
+                }).once("error", (err) => {
+                    reqError = err;
+                    req.abort();
+                });
 
-                if (response.length > 0) {
-                  if (resp.headers["content-type"] === "application/json") {
-                    try {
-                      response = JSON.parse(response);
-                    } catch (err) {
-                      reject(err);
-                      return;
+                let latency = Date.now();
+
+                req.once("response", (resp) => {
+                    latency = Date.now() - latency;
+                    this.latencyRef.raw.push(latency);
+                    this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
+
+                    const headerNow = Date.parse(resp.headers["date"]);
+                    if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
+                        const timeOffset = ~~((this.latencyRef.lastTimeOffsetCheck = Date.now()) - headerNow);
+                        if(this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold) {
+                            this._client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
+                        }
+                        this.latencyRef.timeOffset = ~~(this.latencyRef.timeOffset - this.latencyRef.timeOffsets.shift() / 10 + timeOffset / 10);
+                        this.latencyRef.timeOffsets.push(timeOffset);
                     }
-                  }
-                }
 
-                let { stack } = _stackHolder;
-                if (stack.startsWith("Error\n")) {
-                  stack = stack.substring(6);
-                }
-                let err;
-                if (response.code) {
-                  err = new DiscordRESTError(req, resp, response, stack);
+                    resp.once("aborted", () => {
+                        cb();
+                        reqError = reqError || new Error(`Request aborted by server on ${method} ${url}`);
+                        reqError.req = req;
+                        reject(reqError);
+                    });
+
+                    let response = "";
+
+                    let _respStream = resp;
+                    if(resp.headers["content-encoding"]) {
+                        if(resp.headers["content-encoding"].includes("gzip")) {
+                            _respStream = resp.pipe(Zlib.createGunzip());
+                        } else if(resp.headers["content-encoding"].includes("deflate")) {
+                            _respStream = resp.pipe(Zlib.createInflate());
+                        }
+                    }
+
+                    _respStream.on("data", (str) => {
+                        response += str;
+                    }).on("error", (err) => {
+                        reqError = err;
+                        req.abort();
+                    }).once("end", () => {
+                        const now = Date.now();
+
+                        if(resp.headers["x-ratelimit-limit"]) {
+                            this.ratelimits[route].limit = +resp.headers["x-ratelimit-limit"];
+                        }
+
+                        if(method !== "GET" && (resp.headers["x-ratelimit-remaining"] == undefined || resp.headers["x-ratelimit-limit"] == undefined) && this.ratelimits[route].limit !== 1) {
+                            this._client.emit("debug", `Missing ratelimit headers for SequentialBucket(${this.ratelimits[route].remaining}/${this.ratelimits[route].limit}) with non-default limit\n`
+                                + `${resp.statusCode} ${resp.headers["content-type"]}: ${method} ${route} | ${resp.headers["cf-ray"]}\n`
+                                + "content-type = " +  + "\n"
+                                + "x-ratelimit-remaining = " + resp.headers["x-ratelimit-remaining"] + "\n"
+                                + "x-ratelimit-limit = " + resp.headers["x-ratelimit-limit"] + "\n"
+                                + "x-ratelimit-reset = " + resp.headers["x-ratelimit-reset"] + "\n"
+                                + "x-ratelimit-global = " + resp.headers["x-ratelimit-global"]);
+                        }
+
+                        this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
+
+                        if(resp.headers["retry-after"]) {
+                            if(resp.headers["x-ratelimit-global"]) {
+                                this.globalBlock = true;
+                                setTimeout(() => this.globalUnblock(), +resp.headers["retry-after"] || 1);
+                            } else {
+                                this.ratelimits[route].reset = (+resp.headers["retry-after"] || 1) + now;
+                            }
+                        } else if(resp.headers["x-ratelimit-reset"]) {
+                            if((~route.lastIndexOf("/reactions/:id")) && (+resp.headers["x-ratelimit-reset"] * 1000 - headerNow) === 1000) {
+                                this.ratelimits[route].reset = Math.max(now + 250 - this.latencyRef.timeOffset, now);
+                            } else {
+                                this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * 1000 - this.latencyRef.timeOffset, now);
+                            }
+                        } else {
+                            this.ratelimits[route].reset = now;
+                        }
+
+                        if(resp.statusCode !== 429) {
+                            this._client.emit("debug", `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                        }
+
+                        if(resp.statusCode >= 300) {
+                            if(resp.statusCode === 429) {
+                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                                if(resp.headers["retry-after"]) {
+                                    setTimeout(() => {
+                                        cb();
+                                        this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                                    }, +resp.headers["retry-after"]);
+                                    return;
+                                } else {
+                                    cb();
+                                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                                    return;
+                                }
+                            } else if(resp.statusCode === 502 && ++attempts < 4) {
+                                this._client.emit("debug", "A wild 502 appeared! Thanks CloudFlare!");
+                                setTimeout(() => {
+                                    this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
+                                }, Math.floor(Math.random() * 1900 + 100));
+                                return cb();
+                            }
+                            cb();
+
+                            if(response.length > 0) {
+                                if(resp.headers["content-type"] === "application/json") {
+                                    try {
+                                        response = JSON.parse(response);
+                                    } catch(err) {
+                                        reject(err);
+                                        return;
+                                    }
+                                }
+                            }
+
+                            let {stack} = _stackHolder;
+                            if(stack.startsWith("Error\n")) {
+                                stack = stack.substring(6);
+                            }
+                            let err;
+                            if(response.code) {
+                                err = new DiscordRESTError(req, resp, response, stack);
+                            } else {
+                                err = new DiscordHTTPError(req, resp, response, stack);
+                            }
+                            reject(err);
+                            return;
+                        }
+
+                        if(response.length > 0) {
+                            if(resp.headers["content-type"] === "application/json") {
+                                try {
+                                    response = JSON.parse(response);
+                                } catch(err) {
+                                    cb();
+                                    reject(err);
+                                    return;
+                                }
+                            }
+                        }
+
+                        cb();
+                        resolve(response);
+                    });
+                });
+
+                req.setTimeout(this.requestTimeout, () => {
+                    reqError = new Error(`Request timed out (>${this.requestTimeout}ms) on ${method} ${url}`);
+                    req.abort();
+                });
+
+                if(Array.isArray(data)) {
+                    for(const chunk of data) {
+                        req.write(chunk);
+                    }
+                    req.end();
                 } else {
-                  err = new DiscordHTTPError(req, resp, response, stack);
+                    req.end(data);
                 }
-                reject(err);
-                return;
-              }
+            };
 
-              if (response.length > 0) {
-                if (resp.headers["content-type"] === "application/json") {
-                  try {
-                    response = JSON.parse(response);
-                  } catch (err) {
-                    cb();
-                    reject(err);
-                    return;
-                  }
+            if(this.globalBlock && auth) {
+                this.readyQueue.push(() => {
+                    if(!this.ratelimits[route]) {
+                        this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
+                    }
+                    this.ratelimits[route].queue(actualCall, short);
+                });
+            } else {
+                if(!this.ratelimits[route]) {
+                    this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
                 }
-              }
-
-              cb();
-              resolve(response);
-            });
+                this.ratelimits[route].queue(actualCall, short);
+            }
         });
+    }
 
-        req.setTimeout(this.requestTimeout, () => {
-          reqError = new Error(`Request timed out (>${this.requestTimeout}ms) on ${method} ${url}`);
-          req.abort();
-        });
+    toString() {
+        return "[RequestHandler]";
+    }
 
-        if (Array.isArray(data)) {
-          for (const chunk of data) {
-            req.write(chunk);
-          }
-          req.end();
-        } else {
-          req.end(data);
-        }
-      };
-
-      if (this.globalBlock && auth) {
-        this.readyQueue.push(() => {
-          if (!this.ratelimits[route]) {
-            this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
-          }
-          this.ratelimits[route].queue(actualCall, short);
-        });
-      } else {
-        if (!this.ratelimits[route]) {
-          this.ratelimits[route] = new SequentialBucket(1, this.latencyRef);
-        }
-        this.ratelimits[route].queue(actualCall, short);
-      }
-    });
-  }
-
-  toString() {
-    return "[RequestHandler]";
-  }
-
-  toJSON(props = []) {
-    return Base.prototype.toJSON.call(this, [
-      "baseURL",
-      "userAgent",
-      "ratelimits",
-      "requestTimeout",
-      "agent",
-      "latencyRef",
-      "globalBlock",
-      "readyQueue",
-      ...props,
-    ]);
-  }
+    toJSON(props = []) {
+        return Base.prototype.toJSON.call(this, [
+            "baseURL",
+            "userAgent",
+            "ratelimits",
+            "requestTimeout",
+            "agent",
+            "latencyRef",
+            "globalBlock",
+            "readyQueue",
+            ...props
+        ]);
+    }
 }
 
 module.exports = RequestHandler;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -65,6 +65,19 @@ class RequestHandler {
     * @returns {Promise<Object>} Resolves with the returned JSON data
     */
     request(method, url, auth, body, file, _route, short) {
+        /**
+        * Fired when a request is sent through the RequestHandler.
+        * @event Client#requestHandled
+        * @prop {Error} err The error
+        * @arg {String} method Uppercase HTTP method
+        * @arg {String} url URL of the endpoint
+        * @arg {Boolean} auth Whether to add the Authorization header and token or not
+        * @arg {Object} [body] Request payload
+        * @arg {Object} [file] File object
+        * @arg {Buffer} file.file A buffer containing file data
+        * @arg {String} file.name What to name the file
+        */
+        this._client.emit("requestHandled", method, url, auth, body, file, _route, short);
         const route = _route || this.routefy(url, method);
 
         const _stackHolder = {}; // Preserve async stack

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -167,6 +167,24 @@ class RequestHandler {
                 let latency = Date.now();
 
                 req.once("response", (resp) => {
+                    if(this._client.listeners("rawREST").length) {
+                        /**
+                         * Fired when a request is sent through the RequestHandler.
+                         * @event Client#rawREST
+                         * @arg {Object} [request] The data for the request.
+                         * @arg {String} request.method Uppercase HTTP method
+                         * @arg {String} request.url URL of the endpoint
+                         * @arg {Boolean} request.auth Whether to add the Authorization header and token or not
+                         * @arg {Object} [request.body] Request payload
+                         * @arg {Object} [request.file] File object
+                         * @arg {Buffer} request.file.file A buffer containing file data
+                         * @arg {String} request.file.name What to name the file
+                         * @arg {String} request.route The route that was passed to override.
+                         * @arg {Boolean} request.short Whether or not to shorten the request in the queue.
+                         * @arg {Object} request.resp The full response to the request.
+                         */
+                        this._client.emit("rawREST", {method, url, auth, body, file, route, short, resp});
+                    }
                     latency = Date.now() - latency;
                     this.latencyRef.raw.push(latency);
                     this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eris",
-  "version": "0.11.2",
+  "version": "0.12.0",
   "description": "A NodeJS Discord library",
   "main": "./index.js",
   "exports": {


### PR DESCRIPTION
This PR adds an event called `requestHandled`. The name is up for discussion ofcourse. It is just a placeholder.

Purpose: Recently, I had a lot of trouble trying to edit node_module folders and restarting the bot just to be able to listen to which events my bot was triggering. Everytime i wanted to make a tiny change it would cause me to have to restart the entire bot. An event would be very crucial for debugging major Rate Limit issues such as the one I had recently. This allows full customization of how you want to handle request limits. I could for example even set up an alert system to ping me and my dev team on discord when requests are being spammed or potentially hitting Global for example.