### PR TITLE
rawREST event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from "events";
 import { Readable as ReadableStream } from "stream";
 import { Agent as HTTPSAgent } from "https";
+import { IncomingMessage } from "http";
 
 declare function Eris(token: string, options?: Eris.ClientOptions): Eris.Client;
 
@@ -823,6 +824,17 @@ declare namespace Eris {
     reason?: string;
   }
 
+  interface RawRESTRequest {
+    method: string;
+    url: string;
+    auth: boolean;
+    body: unknown;
+    file: MessageFile;
+    route: string;
+    short: boolean;
+    resp: IncomingMessage;
+  }
+
   interface EventListeners<T> {
     (event: "ready" | "disconnect", listener: () => void): T;
     (event: "callCreate" | "callRing" | "callDelete", listener: (call: Call) => void): T;
@@ -865,6 +877,7 @@ declare namespace Eris {
     (event: "messageUpdate", listener: (message: Message, oldMessage?: OldMessage) => void
     ): T;
     (event: "presenceUpdate", listener: (other: Member | Relationship, oldPresence?: Presence) => void): T;
+    (event: "rawREST", listener: (request: RawRESTRequest) => void): T;
     (event: "rawWS" | "unknown", listener: (packet: RawPacket, id: number) => void): T;
     (event: "relationshipAdd" | "relationshipRemove", listener: (relationship: Relationship) => void): T;
     (

--- a/index.d.ts
+++ b/index.d.ts
@@ -829,7 +829,7 @@ declare namespace Eris {
     url: string;
     auth: boolean;
     body: unknown;
-    file: MessageFile;
+    file?: MessageFile;
     route: string;
     short: boolean;
     resp: IncomingMessage;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -167,6 +167,24 @@ class RequestHandler {
                 let latency = Date.now();
 
                 req.once("response", (resp) => {
+                    if(this._client.listeners("rawREST").length) {
+                        /**
+                         * Fired when a request is sent through the RequestHandler.
+                         * @event Client#rawREST
+                         * @arg {Object} [request] The data for the request.
+                         * @arg {String} request.method Uppercase HTTP method
+                         * @arg {String} request.url URL of the endpoint
+                         * @arg {Boolean} request.auth Whether to add the Authorization header and token or not
+                         * @arg {Object} [request.body] Request payload
+                         * @arg {Object} [request.file] File object
+                         * @arg {Buffer} request.file.file A buffer containing file data
+                         * @arg {String} request.file.name What to name the file
+                         * @arg {String} request.route The route that was passed to override.
+                         * @arg {Boolean} request.short Whether or not to shorten the request in the queue.
+                         * @arg {Object} request.resp The full response to the request.
+                         */
+                        this._client.emit("rawREST", {method, url, auth, body, file, route, short, resp});
+                    }
                     latency = Date.now() - latency;
                     this.latencyRef.raw.push(latency);
                     this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -169,19 +169,19 @@ class RequestHandler {
                 req.once("response", (resp) => {
                     if(this._client.listeners("rawREST").length) {
                         /**
-                         * Fired when a request is sent through the RequestHandler.
+                         * Fired when the Client's RuquestHandler receives a response
                          * @event Client#rawREST
                          * @arg {Object} [request] The data for the request.
                          * @arg {String} request.method Uppercase HTTP method
                          * @arg {String} request.url URL of the endpoint
-                         * @arg {Boolean} request.auth Whether to add the Authorization header and token or not
-                         * @arg {Object} [request.body] Request payload
-                         * @arg {Object} [request.file] File object
+                         * @arg {Boolean} request.auth True if the request required an authorization token
+                         * @arg {Object} [request.body] The request payload
+                         * @arg {Object} [request.file] The file object sent in the request
                          * @arg {Buffer} request.file.file A buffer containing file data
-                         * @arg {String} request.file.name What to name the file
-                         * @arg {String} request.route The route that was passed to override.
-                         * @arg {Boolean} request.short Whether or not to shorten the request in the queue.
-                         * @arg {Object} request.resp The full response to the request.
+                         * @arg {String} request.file.name The name of the file
+                         * @arg {String} request.route The calculated ratelimiting route for the request
+                         * @arg {Boolean} request.short Whether or not the request was prioritized in its ratelimiting queue
+                         * @arg {IncomingMessage} request.resp The HTTP response to the request
                          */
                         this._client.emit("rawREST", {method, url, auth, body, file, route, short, resp});
                     }


### PR DESCRIPTION
Rebase to dev branch for #914 

This PR adds an event called rawREST.

Purpose: Recently, I had a lot of trouble trying to edit node_module folders and restarting the bot just to be able to listen to which events my bot was triggering. Everytime i wanted to make a tiny change it would cause me to have to restart the entire bot. An event would be very crucial for debugging major Rate Limit issues such as the one I had recently. This allows full customization of how you want to handle request limits. I could for example even set up an alert system to ping me and my dev team on discord when requests are being spammed or potentially hitting Global for example.