### PR TITLE
Missing methods in typings and documentation fix

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1823,7 +1823,7 @@ declare namespace Eris {
     avatarURL: string;
     staticAvatarURL: string;
     system: boolean;
-    publicFlags: number;
+    publicFlags?: number;
     constructor(data: BaseData, client: Client);
     dynamicAvatarURL(format?: string, size?: number): string;
     getDMChannel(): Promise<PrivateChannel>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1367,6 +1367,8 @@ declare namespace Eris {
     constructor(data: BaseData, client: Client);
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;
+    dynamicBannerURL(format?: string, size?: number): string;
+    dynamicSplashURL(format?: string, size?: number): string;
     createChannel(name: string): Promise<TextChannel>;
     createChannel(name: string, type: 0, reason?: string, options?: CreateChannelOptions | string): Promise<TextChannel>;
     createChannel(name: string, type: 2, reason?: string, options?: CreateChannelOptions | string): Promise<VoiceChannel>;

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -76,8 +76,8 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
 
     /**
     * Get the group's icon with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
-    * @arg {Number} [size] The size of the icon (any power of two between 16 and 2048)
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
+    * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicIconURL(format, size) {
         return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -218,8 +218,8 @@ class Guild extends Base {
 
     /**
     * Get the guild's icon with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
-    * @arg {Number} [size] The size of the icon (any power of two between 16 and 2048)
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
+    * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicIconURL(format, size) {
         return this.icon ? this._client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
@@ -235,8 +235,8 @@ class Guild extends Base {
 
     /**
     * Get the guild's splash with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
-    * @param {Number} [size] The size of the icon (any power of two between 16 and 2048)
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
+    * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicSplashURL(format, size) {
         return this.splash ? this._client._formatImage(Endpoints.GUILD_SPLASH(this.id, this.splash), format, size) : null;
@@ -244,8 +244,8 @@ class Guild extends Base {
 
     /**
     * Get the guild's banner with the given format and size
-    * @arg {String} [format] The filetype of the icon ("jpg", "png", "gif", or "webp")
-    * @param {Number} [size] The size of the icon (any power of two between 16 and 2048)
+    * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
+    * @param {Number} [size] The size of the icon (any power of two between 16 and 4096)
     */
     dynamicBannerURL(format, size) {
         return this.banner ? this._client._formatImage(Endpoints.GUILD_BANNER(this.id, this.banner), format, size) : null;

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -75,8 +75,8 @@ class User extends Base {
 
     /**
     * Get the user's avatar with the given format and size
-    * @arg {String} [format] The filetype of the avatar ("jpg", "png", "gif", or "webp")
-    * @arg {Number} [size] The size of the avatar (any power of two between 16 and 2048)
+    * @arg {String} [format] The filetype of the avatar ("jpg", "jpeg", "png", "gif", or "webp")
+    * @arg {Number} [size] The size of the avatar (any power of two between 16 and 4096)
     */
     dynamicAvatarURL(format, size) {
         return this.avatar ? this._client._formatImage(Endpoints.USER_AVATAR(this.id, this.avatar), format, size) : this.defaultAvatarURL;


### PR DESCRIPTION
Fix missing `dynamicBannerURL` and `dynamicSplashURL` in Guild typings.
Fix missing documentation changes from #900 
Also fix incorrect typings for publicFlags (#897 )