### PR TITLE
Support for withCount field for GUILD endpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1177,7 +1177,7 @@ declare namespace Eris {
     addSelfPremiumSubscription(token: string, plan: string): Promise<void>;
     deleteSelfPremiumSubscription(): Promise<void>;
     getRESTChannel(channelID: string): Promise<AnyChannel>;
-    getRESTGuild(guildID: string): Promise<Guild>;
+    getRESTGuild(guildID: string, withCount?: boolean): Promise<Guild>;
     getRESTGuilds(limit?: number, before?: string, after?: string): Promise<Guild[]>;
     getRESTGuildChannels(guildID: string): Promise<AnyGuildChannel[]>;
     getRESTGuildEmojis(guildID: string): Promise<Emoji[]>;
@@ -1364,6 +1364,8 @@ declare namespace Eris {
     explicitContentFilter: number;
     publicUpdatesChannelID: string;
     rulesChannelID: string;
+    approximateMemberCount?: number;
+    approximatePresenceCount?: number;
     constructor(data: BaseData, client: Client);
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1177,7 +1177,7 @@ declare namespace Eris {
     addSelfPremiumSubscription(token: string, plan: string): Promise<void>;
     deleteSelfPremiumSubscription(): Promise<void>;
     getRESTChannel(channelID: string): Promise<AnyChannel>;
-    getRESTGuild(guildID: string, withCount?: boolean): Promise<Guild>;
+    getRESTGuild(guildID: string, withCounts?: boolean): Promise<Guild>;
     getRESTGuilds(limit?: number, before?: string, after?: string): Promise<Guild[]>;
     getRESTGuildChannels(guildID: string): Promise<AnyGuildChannel[]>;
     getRESTGuildEmojis(guildID: string): Promise<Emoji[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1919,7 +1919,7 @@ class Client extends EventEmitter {
     /**
     * Get a guild's data via the REST API. REST mode is required to use this endpoint.
     * @arg {String} guildID The ID of the guild
-    * @arg {Boolean} withCount Whether the guild object will have approximateMemberCount and approximatePresenceCount
+    * @arg {Boolean} [withCount=false] Whether the guild object will have approximateMemberCount and approximatePresenceCount
     * @returns {Promise<Guild>}
     */
     getRESTGuild(guildID, withCount = false) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1919,13 +1919,14 @@ class Client extends EventEmitter {
     /**
     * Get a guild's data via the REST API. REST mode is required to use this endpoint.
     * @arg {String} guildID The ID of the guild
+    * @arg {Boolean} withCount Whether the guild object will have approximateMemberCount and approximatePresenceCount
     * @returns {Promise<Guild>}
     */
-    getRESTGuild(guildID) {
+    getRESTGuild(guildID, withCount = false) {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, withCount).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1936,7 +1936,7 @@ class Client extends EventEmitter {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, { withCounts }).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {withCounts}).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1936,7 +1936,9 @@ class Client extends EventEmitter {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {with_counts: withCounts}).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {
+            with_counts: withCounts
+        }).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1919,14 +1919,14 @@ class Client extends EventEmitter {
     /**
     * Get a guild's data via the REST API. REST mode is required to use this endpoint.
     * @arg {String} guildID The ID of the guild
-    * @arg {Boolean} [withCount=false] Whether the guild object will have approximateMemberCount and approximatePresenceCount
+    * @arg {Boolean} [withCounts=false] Whether the guild object will have approximateMemberCount and approximatePresenceCount
     * @returns {Promise<Guild>}
     */
-    getRESTGuild(guildID, withCount = false) {
+    getRESTGuild(guildID, withCounts = false) {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, withCount).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, { withCounts }).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1936,7 +1936,7 @@ class Client extends EventEmitter {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {withCounts}).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {with_counts: withCounts}).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -74,10 +74,10 @@ class Guild extends Base {
             this.widgetChannelID = data.widget_channel_id;
         }
 
-        if(data.approximate_member_count) {
+        if(data.approximate_member_count !== undefined) {
             this.approximateMemberCount = data.approximate_member_count;
         }
-        if(data.approximate_presence_count) {
+        if(data.approximate_presence_count !== undefined) {
             this.approximatePresenceCount = data.approximate_presence_count;
         }
 

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -49,6 +49,8 @@ const VoiceState = require("./VoiceState");
 * @prop {Number} maxMembers The maximum amount of members for the guild
 * @prop {String?} publicUpdatesChannelID ID of the guild's updates channel if the guild has "PUBLIC" features
 * @prop {String?} rulesChannelID The channel where "PUBLIC" guilds display rules and/or guidelines
+* @prop {Number?} approximateMemberCount The approximate number of members in the guild (REST only)
+* @prop {Number?} approximatePresenceCount The approximate number of presences in the guild (REST only)
 */
 class Guild extends Base {
     constructor(data, client) {
@@ -62,6 +64,13 @@ class Guild extends Base {
         this.members = new Collection(Member);
         this.memberCount = data.member_count;
         this.roles = new Collection(Role);
+
+        if(data.approximate_member_count) {
+            this.approximateMemberCount = data.approximate_member_count;
+        }
+        if(data.approximate_presence_count) {
+            this.approximatePresenceCount = data.approximate_presence_count;
+        }
 
         if(data.roles) {
             for(const role of data.roles) {


### PR DESCRIPTION
Ref discord/discord-api-docs#1528

- `withCount` for `getRESTGuild` method
- `approximateMemberCount` property on Guild
- `approximatePresenceCount` property on Guild