### PR TITLE
Fix voice events intents

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -526,6 +526,15 @@ class Shard extends EventEmitter {
                 let message;
                 if(channel) {
                     message = channel.messages.get(packet.d.message_id);
+                    if(channel.guild) {
+                        const member = channel.guild.members.get(packet.d.user_id);
+                        if(!member) {
+                            // Updates the member cache with this member for future events.
+                            channel.guild.memberCount++;
+                            packet.d.member.id = packet.d.user_id;
+                            channel.guild.members.add(packet.d.member, channel.guild);
+                        }
+                    }
                 }
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
@@ -561,6 +570,15 @@ class Shard extends EventEmitter {
                 let message;
                 if(channel) {
                     message = channel.messages.get(packet.d.message_id);
+                    if(channel.guild) {
+                        const member = channel.guild.members.get(packet.d.user_id);
+                        if(!member) {
+                            // Updates the member cache with this member for future events.
+                            channel.guild.memberCount++;
+                            packet.d.member.id = packet.d.user_id;
+                            channel.guild.members.add(packet.d.member, channel.guild);
+                        }
+                    }
                 }
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -338,7 +338,6 @@ class Shard extends EventEmitter {
                 let member = guild.members.get(packet.d.id = packet.d.user_id);
                 if(!member) {
                     // Updates the member cache with this member for future events.
-                    guild.memberCount++;
                     packet.d.member.id = packet.d.user_id;
                     member = guild.members.add(packet.d.member, guild);
 
@@ -530,7 +529,6 @@ class Shard extends EventEmitter {
                         const member = channel.guild.members.get(packet.d.user_id);
                         if(!member) {
                             // Updates the member cache with this member for future events.
-                            channel.guild.memberCount++;
                             packet.d.member.id = packet.d.user_id;
                             channel.guild.members.add(packet.d.member, channel.guild);
                         }
@@ -574,7 +572,6 @@ class Shard extends EventEmitter {
                         const member = channel.guild.members.get(packet.d.user_id);
                         if(!member) {
                             // Updates the member cache with this member for future events.
-                            channel.guild.memberCount++;
                             packet.d.member.id = packet.d.user_id;
                             channel.guild.members.add(packet.d.member, channel.guild);
                         }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -335,15 +335,18 @@ class Shard extends EventEmitter {
                     guild.pendingVoiceStates.push(packet.d);
                     break;
                 }
-                const member = guild.members.get(packet.d.id = packet.d.user_id);
+                let member = guild.members.get(packet.d.id = packet.d.user_id);
                 if(!member) {
+                    // Updates the member cache with this member for future events.
+                    guild.memberCount++;
+                    packet.d.member.id = packet.d.user_id;
+                    member = guild.members.add(packet.d.member, guild);
+
                     const channel = guild.channels.find((channel) => channel.type === ChannelTypes.GUILD_VOICE && channel.voiceMembers.get(packet.d.id));
                     if(channel) {
                         channel.voiceMembers.remove(packet.d);
                         this.emit("debug", "VOICE_STATE_UPDATE member null but in channel: " + packet.d.id, this.id);
-                        break;
                     }
-                    break;
                 }
                 const oldState = {
                     mute: member.voiceState.mute,
@@ -549,7 +552,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionAdd", message || {
                     id: packet.d.message_id,
-                    channel: channel || { id: packet.d.channel_id }
+                    channel: channel || {id: packet.d.channel_id}
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }
@@ -579,7 +582,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionRemove", message || {
                     id: packet.d.message_id,
-                    channel: channel || { id: packet.d.channel_id }
+                    channel: channel || {id: packet.d.channel_id}
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }


### PR DESCRIPTION
This PR should fix the issues related to members not being cached on VOICE_STATE_UPDATE and REACTION events which is a lot more evident and effects bots using intents. It also will help emit the voice events as well.

~~Note: There can be a slight confusion for when a user who is NOT cached switches channel it will be treated as joining the channel. Afterwards it will be fixed. I still think this is alot better then not emitting anything at all.~~ I may be wrong about this as I now think these members will be pre-cached on GUILD_CREATE through voice_states