### PR TITLE
Fix dynamic role name check

### DIFF
--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -212,7 +212,7 @@ class Command {
             }
             if(this.requirements.roleNames) {
                 const roleNames = roleIDs.map((roleID) => msg.channel.guild.roles.get(roleID).name);
-                const requiredRoleNames = this.requirements.roleNames === "function" ? await this.requirements.roleNames(msg) : this.requirements.roleNames;
+                const requiredRoleNames = typeof this.requirements.roleNames === "function" ? await this.requirements.roleNames(msg) : this.requirements.roleNames;
                 if(!Array.isArray(roleNames)) {
                     throw new Error("Role names requirement is not an array");
                 }


### PR DESCRIPTION
Fixes the case when a function is passed to `Command#requirements.roleNames`, seems to be a typo :/