### PR TITLE
Optional auth for execWebhook

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1050,7 +1050,7 @@ declare namespace Eris {
     ): Promise<Webhook>;
     executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true }): Promise<Message>;
     executeWebhook(webhookID: string, token: string, options: WebhookPayload): Promise<void>;
-    executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean }): Promise<void>;
+    executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean, auth?: boolean }): Promise<void>;
     deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;
     getGuildWebhooks(guildID: string): Promise<Webhook[]>;
     getGuildAuditLogs(guildID: string, limit?: number, before?: string, actionType?: number): Promise<GuildAuditLog>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -366,6 +366,7 @@ declare namespace Eris {
   export const Constants: Constants;
 
   interface WebhookPayload {
+    auth?: boolean;
     content?: string;
     file?: { file: Buffer; name: string } | { file: Buffer; name: string }[];
     embeds?: EmbedOptions[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1050,7 +1050,7 @@ declare namespace Eris {
     ): Promise<Webhook>;
     executeWebhook(webhookID: string, token: string, options: WebhookPayload & { wait: true }): Promise<Message>;
     executeWebhook(webhookID: string, token: string, options: WebhookPayload): Promise<void>;
-    executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean, auth?: boolean }): Promise<void>;
+    executeSlackWebhook(webhookID: string, token: string, options?: { wait?: boolean; auth?: boolean }): Promise<void>;
     deleteWebhook(webhookID: string, token?: string, reason?: string): Promise<void>;
     getGuildWebhooks(guildID: string): Promise<Webhook[]>;
     getGuildAuditLogs(guildID: string, limit?: number, before?: string, actionType?: number): Promise<GuildAuditLog>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -642,6 +642,7 @@ class Client extends EventEmitter {
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Webhook execution options
+    * @arg {Boolean} [options.auth=false] Whether to auth with the bot token (allow to use other guilds custom emotes)
     * @arg {String} [options.content=""] A content string
     * @arg {Object | Object[]} [options.file] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data
@@ -661,7 +662,7 @@ class Client extends EventEmitter {
         if(!options.content && !options.file && !options.embeds) {
             return Promise.reject(new Error("No content, file, or embeds"));
         }
-        return this.requestHandler.request("POST", (token ? Endpoints.WEBHOOK_TOKEN(webhookID, token) : Endpoints.WEBHOOK(webhookID)) + (options.wait ? "?wait=true" : ""), !token, {
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), !!options.auth, {
             content: options.content,
             embeds: options.embeds,
             username: options.username,
@@ -682,7 +683,7 @@ class Client extends EventEmitter {
     executeSlackWebhook(webhookID, token, options) {
         const wait = !!options.wait;
         options.wait = undefined;
-        return this.requestHandler.request("POST", (token ? Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) : Endpoints.WEBHOOK_SLACK(webhookID)) + (wait ? "?wait=true" : ""), !token, options);
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), false, options);
     }
 
     /**
@@ -1929,13 +1930,14 @@ class Client extends EventEmitter {
     /**
     * Get a guild's data via the REST API. REST mode is required to use this endpoint.
     * @arg {String} guildID The ID of the guild
+    * @arg {Boolean} [withCounts=false] Whether the guild object will have approximateMemberCount and approximatePresenceCount
     * @returns {Promise<Guild>}
     */
-    getRESTGuild(guildID) {
+    getRESTGuild(guildID, withCounts = false) {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {with_counts: withCounts}).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -678,12 +678,15 @@ class Client extends EventEmitter {
     * @arg {String} token The token of the webhook
     * @arg {Object} options Slack webhook options
     * @arg {Boolean} [options.wait=false] Whether to wait for the server to confirm the message create or not
+    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @returns {Promise}
     */
     executeSlackWebhook(webhookID, token, options) {
         const wait = !!options.wait;
         options.wait = undefined;
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), false, options);
+        const auth = !!options.auth;
+        options.auth = undefined;
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), auth, options);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1930,14 +1930,13 @@ class Client extends EventEmitter {
     /**
     * Get a guild's data via the REST API. REST mode is required to use this endpoint.
     * @arg {String} guildID The ID of the guild
-    * @arg {Boolean} [withCounts=false] Whether the guild object will have approximateMemberCount and approximatePresenceCount
     * @returns {Promise<Guild>}
     */
-    getRESTGuild(guildID, withCounts = false) {
+    getRESTGuild(guildID) {
         if(!this.options.restMode) {
             return Promise.reject(new Error("Eris REST mode is not enabled"));
         }
-        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true, {with_counts: withCounts}).then((guild) => new Guild(guild, this));
+        return this.requestHandler.request("GET", Endpoints.GUILD(guildID), true).then((guild) => new Guild(guild, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -642,7 +642,7 @@ class Client extends EventEmitter {
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Webhook execution options
-    * @arg {Boolean} [options.auth=false] Whether to auth with the bot token (allow to use other guilds custom emotes)
+    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @arg {String} [options.content=""] A content string
     * @arg {Object | Object[]} [options.file] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data


### PR DESCRIPTION
- Remove executing webhook with no webhook token but bot auth (which is no longer possible).
- Add an option to auth with your bot token when executing a webhook. It allows to use custom emojis that are not in the current server 