### PR TITLE
Add support for include_roles in guild prune

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1066,7 +1066,7 @@ declare namespace Eris {
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
     deleteRole(guildID: string, roleID: string, reason?: string): Promise<void>;
     getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
-    pruneMembers(guildID: string, options: PruneMemberOptions): Promise<number>;
+    pruneMembers(guildID: string, options?: PruneMemberOptions): Promise<number>;
     getVoiceRegions(guildID: string): Promise<VoiceRegion[]>;
     getInvite(inviteID: string, withCounts?: boolean): Promise<RESTInvite>;
     acceptInvite(inviteID: string): Promise<RESTInvite>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1709,7 +1709,7 @@ declare namespace Eris {
   }
 
   interface PruneMemberOptions extends GetPruneOptions {
-    reason?: string
+    reason?: string;
   }
 
   type Status = "online" | "idle" | "dnd" | "offline";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1397,7 +1397,7 @@ declare namespace Eris {
     deleteEmoji(emojiID: string, reason?: string): Promise<void>;
     createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
     getPruneCount(options?: GetPruneOptions): Promise<number>;
-    pruneMembers(options: PruneMemberOptions): Promise<number>;
+    pruneMembers(options?: PruneMemberOptions): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;
     getRESTEmojis(): Promise<Emoji[]>;
     getRESTEmoji(emojiID: string): Promise<Emoji>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1705,7 +1705,7 @@ declare namespace Eris {
 
   interface GetPruneOptions {
     days?: number;
-    includeRoles?: string[]
+    includeRoles?: string[];
   }
 
   interface PruneMemberOptions extends GetPruneOptions {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1065,7 +1065,7 @@ declare namespace Eris {
     editRole(guildID: string, roleID: string, options: RoleOptions, reason?: string): Promise<Role>; // TODO not all options are available?
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
     deleteRole(guildID: string, roleID: string, reason?: string): Promise<void>;
-    getPruneCount(guildID: string, options: GetPruneOptions): Promise<number>;
+    getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
     pruneMembers(guildID: string, options: PruneMemberOptions): Promise<number>;
     getVoiceRegions(guildID: string): Promise<VoiceRegion[]>;
     getInvite(inviteID: string, withCounts?: boolean): Promise<RESTInvite>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1704,7 +1704,7 @@ declare namespace Eris {
   }
 
   interface GetPruneOptions {
-    days?: number,
+    days?: number;
     includeRoles?: string[]
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1065,8 +1065,8 @@ declare namespace Eris {
     editRole(guildID: string, roleID: string, options: RoleOptions, reason?: string): Promise<Role>; // TODO not all options are available?
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
     deleteRole(guildID: string, roleID: string, reason?: string): Promise<void>;
-    getPruneCount(guildID: string, days: number): Promise<number>;
-    pruneMembers(guildID: string, days: number, reason?: string): Promise<number>;
+    getPruneCount(guildID: string, days?: number, includeRoles?: string[]): Promise<number>;
+    pruneMembers(guildID: string, days?: number, includeRoles?: string[], reason?: string): Promise<number>;
     getVoiceRegions(guildID: string): Promise<VoiceRegion[]>;
     getInvite(inviteID: string, withCounts?: boolean): Promise<RESTInvite>;
     acceptInvite(inviteID: string): Promise<RESTInvite>;
@@ -1396,8 +1396,8 @@ declare namespace Eris {
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     deleteEmoji(emojiID: string, reason?: string): Promise<void>;
     createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
-    getPruneCount(days: number): Promise<number>;
-    pruneMembers(days: number, reason?: string): Promise<number>;
+    getPruneCount(days?: number, includeRoles?: string[]): Promise<number>;
+    pruneMembers(days?: number, includeRoles?: string[], reason?: string): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;
     getRESTEmojis(): Promise<Emoji[]>;
     getRESTEmoji(emojiID: string): Promise<Emoji>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1065,8 +1065,8 @@ declare namespace Eris {
     editRole(guildID: string, roleID: string, options: RoleOptions, reason?: string): Promise<Role>; // TODO not all options are available?
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
     deleteRole(guildID: string, roleID: string, reason?: string): Promise<void>;
-    getPruneCount(guildID: string, days?: number, includeRoles?: string[]): Promise<number>;
-    pruneMembers(guildID: string, days?: number, includeRoles?: string[], reason?: string): Promise<number>;
+    getPruneCount(guildID: string, options: GetPruneOptions): Promise<number>;
+    pruneMembers(guildID: string, options: PruneMemberOptions): Promise<number>;
     getVoiceRegions(guildID: string): Promise<VoiceRegion[]>;
     getInvite(inviteID: string, withCounts?: boolean): Promise<RESTInvite>;
     acceptInvite(inviteID: string): Promise<RESTInvite>;
@@ -1396,8 +1396,8 @@ declare namespace Eris {
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     deleteEmoji(emojiID: string, reason?: string): Promise<void>;
     createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
-    getPruneCount(days?: number, includeRoles?: string[]): Promise<number>;
-    pruneMembers(days?: number, includeRoles?: string[], reason?: string): Promise<number>;
+    getPruneCount(options: GetPruneOptions): Promise<number>;
+    pruneMembers(options: PruneMemberOptions): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;
     getRESTEmojis(): Promise<Emoji[]>;
     getRESTEmoji(emojiID: string): Promise<Emoji>;
@@ -1701,6 +1701,15 @@ declare namespace Eris {
       icon?: string;
       type: 3;
     };
+  }
+
+  interface GetPruneOptions {
+    days?: number,
+    includeRoles?: string[]
+  }
+
+  interface PruneMemberOptions extends GetPruneOptions {
+    reason?: string
   }
 
   type Status = "online" | "idle" | "dnd" | "offline";

--- a/index.d.ts
+++ b/index.d.ts
@@ -1396,7 +1396,7 @@ declare namespace Eris {
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     deleteEmoji(emojiID: string, reason?: string): Promise<void>;
     createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
-    getPruneCount(options: GetPruneOptions): Promise<number>;
+    getPruneCount(options?: GetPruneOptions): Promise<number>;
     pruneMembers(options: PruneMemberOptions): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;
     getRESTEmojis(): Promise<Emoji[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -870,8 +870,8 @@ class Client extends EventEmitter {
     * Get the prune count for a guild
     * @arg {String} guildID The ID of the guild
     * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
-    * @returns {Promise<Number>} Resolves with the number of users that would be pruned
+    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @returns {Promise<Number>} Resolves with the number of members that would be pruned
     */
     getPruneCount(guildID, days, includeRoles) {
         return this.requestHandler.request("GET", Endpoints.GUILD_PRUNE(guildID), true, {
@@ -884,9 +884,9 @@ class Client extends EventEmitter {
     * Begin pruning a guild
     * @arg {String} guildID The ID of the guild
     * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
+    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
     * @arg {String} [reason] The reason to be displayed in audit logs
-    * @returns {Promise<Number>} Resolves with the number of pruned users
+    * @returns {Promise<Number>} Resolves with the number of pruned members
     */
     pruneMembers(guildID, days, includeRoles, reason) {
         return this.requestHandler.request("POST", Endpoints.GUILD_PRUNE(guildID), true, {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -869,30 +869,32 @@ class Client extends EventEmitter {
     /**
     * Get the prune count for a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} [days=7] The number of days of inactivity to prune for
-    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @arg {Number} [options={}] The options to use to get number of prune members
+    * @arg {Number} [options.days=7] The number of days of inactivity to prune for
+    * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @returns {Promise<Number>} Resolves with the number of members that would be pruned
     */
-    getPruneCount(guildID, days, includeRoles) {
+    getPruneCount(guildID, options = {}) {
         return this.requestHandler.request("GET", Endpoints.GUILD_PRUNE(guildID), true, {
-            days: days,
-            include_roles: includeRoles
+            days: options.days,
+            include_roles: options.includeRoles
         }).then((data) => data.pruned);
     }
 
     /**
     * Begin pruning a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
-    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @arg {Number} [options={}] The options to pass to prune members
+    * @arg {Number} [options.days=7] The number of days of inactivity to prune for
+    * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @arg {String} [options.reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of pruned members
     */
-    pruneMembers(guildID, days, includeRoles, reason) {
+    pruneMembers(guildID, options = {}) {
         return this.requestHandler.request("POST", Endpoints.GUILD_PRUNE(guildID), true, {
-            days: days,
-            include_roles: includeRoles,
-            reason: reason
+            days: options.days,
+            include_roles: options.includeRoles,
+            reason: options.reason
         }).then((data) => data.pruned);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -869,26 +869,30 @@ class Client extends EventEmitter {
     /**
     * Get the prune count for a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} days The number of days of inactivity to prune for
+    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
+    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
     * @returns {Promise<Number>} Resolves with the number of users that would be pruned
     */
-    getPruneCount(guildID, days) {
+    getPruneCount(guildID, days, includeRoles) {
         return this.requestHandler.request("GET", Endpoints.GUILD_PRUNE(guildID), true, {
-            days
+            days: days,
+            include_roles: includeRoles
         }).then((data) => data.pruned);
     }
 
     /**
     * Begin pruning a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} days The number of days of inactivity to prune for
+    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
+    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of pruned users
     */
-    pruneMembers(guildID, days, reason) {
+    pruneMembers(guildID, days, includeRoles, reason) {
         return this.requestHandler.request("POST", Endpoints.GUILD_PRUNE(guildID), true, {
-            days,
-            reason
+            days: days,
+            include_roles: includeRoles,
+            reason: reason
         }).then((data) => data.pruned);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -869,7 +869,7 @@ class Client extends EventEmitter {
     /**
     * Get the prune count for a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
+    * @arg {Number} [days=7] The number of days of inactivity to prune for
     * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
     * @returns {Promise<Number>} Resolves with the number of members that would be pruned
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -869,7 +869,7 @@ class Client extends EventEmitter {
     /**
     * Get the prune count for a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} [options={}] The options to use to get number of prune members
+    * @arg {Number} [options] The options to use to get number of prune members
     * @arg {Number} [options.days=7] The number of days of inactivity to prune for
     * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @returns {Promise<Number>} Resolves with the number of members that would be pruned
@@ -884,7 +884,7 @@ class Client extends EventEmitter {
     /**
     * Begin pruning a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Number} [options={}] The options to pass to prune members
+    * @arg {Number} [options] The options to pass to prune members
     * @arg {Number} [options.days=7] The number of days of inactivity to prune for
     * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @arg {String} [options.reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -324,8 +324,8 @@ class Guild extends Base {
     /**
     * Get the prune count for the guild
     * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
-    * @returns {Promise<Number>} Resolves with the number of users that would be pruned
+    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @returns {Promise<Number>} Resolves with the number of members that would be pruned
     */
     getPruneCount(days, includeRoles) {
         return this._client.getPruneCount.call(this._client, this.id, days, includeRoles);
@@ -334,9 +334,9 @@ class Guild extends Base {
     /**
     * Begin pruning the guild
     * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
+    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
     * @arg {String} [reason] The reason to be displayed in audit logs
-    * @returns {Promise<Number>} Resolves with the number of pruned users
+    * @returns {Promise<Number>} Resolves with the number of pruned members
     */
     pruneMembers(days, includeRoles, reason) {
         return this._client.pruneMembers.call(this._client, this.id, days, includeRoles, reason);

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -323,21 +323,23 @@ class Guild extends Base {
 
     /**
     * Get the prune count for the guild
-    * @arg {Number} days The number of days of inactivity to prune for
+    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
+    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
     * @returns {Promise<Number>} Resolves with the number of users that would be pruned
     */
-    getPruneCount(days) {
-        return this._client.getPruneCount.call(this._client, this.id, days);
+    getPruneCount(days, includeRoles) {
+        return this._client.getPruneCount.call(this._client, this.id, days, includeRoles);
     }
 
     /**
     * Begin pruning the guild
-    * @arg {Number} days The number of days of inactivity to prune for
+    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
+    * @arg {Array<String>} [includeRoles] An array of role IDs. Any user with the roles in this array will be included in the prune, said user will only be pruned if they have all of the roles in this array
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of pruned users
     */
-    pruneMembers(days, reason) {
-        return this._client.pruneMembers.call(this._client, this.id, days, reason);
+    pruneMembers(days, includeRoles, reason) {
+        return this._client.pruneMembers.call(this._client, this.id, days, includeRoles, reason);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -323,7 +323,7 @@ class Guild extends Base {
 
     /**
     * Get the prune count for the guild
-    * @arg {Number} [options={}] The options to use to get number of prune members
+    * @arg {Number} [options] The options to use to get number of prune members
     * @arg {Number} [options.days=7] The number of days of inactivity to prune for
     * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @returns {Promise<Number>} Resolves with the number of members that would be pruned
@@ -334,7 +334,7 @@ class Guild extends Base {
 
     /**
     * Begin pruning the guild
-    * @arg {Number} [options={}] The options to pass to prune members
+    * @arg {Number} [options] The options to pass to prune members
     * @arg {Number} [options.days=7] The number of days of inactivity to prune for
     * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @arg {String} [options.reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -323,23 +323,25 @@ class Guild extends Base {
 
     /**
     * Get the prune count for the guild
-    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @arg {Number} [options={}] The options to use to get number of prune members
+    * @arg {Number} [options.days=7] The number of days of inactivity to prune for
+    * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
     * @returns {Promise<Number>} Resolves with the number of members that would be pruned
     */
-    getPruneCount(days, includeRoles) {
-        return this._client.getPruneCount.call(this._client, this.id, days, includeRoles);
+    getPruneCount(options) {
+        return this._client.getPruneCount.call(this._client, this.id, options);
     }
 
     /**
     * Begin pruning the guild
-    * @arg {Number} [days] The number of days of inactivity to prune for. Default to 7
-    * @arg {Array<String>} [includeRoles] An array of role IDs that members must have to be considered for pruning
-    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @arg {Number} [options={}] The options to pass to prune members
+    * @arg {Number} [options.days=7] The number of days of inactivity to prune for
+    * @arg {Array<String>} [options.includeRoles] An array of role IDs that members must have to be considered for pruning
+    * @arg {String} [options.reason] The reason to be displayed in audit logs
     * @returns {Promise<Number>} Resolves with the number of pruned members
     */
-    pruneMembers(days, includeRoles, reason) {
-        return this._client.pruneMembers.call(this._client, this.id, days, includeRoles, reason);
+    pruneMembers(options) {
+        return this._client.pruneMembers.call(this._client, this.id, options);
     }
 
     /**


### PR DESCRIPTION
Ref: discord/discord-api-docs#1563 

Add support for the includeRoles parameter in `getPruneCount` and `pruneMembers`.
I also fixed typings and jsdoc as all fields are optional.

⚠️  This is a breaking change as `includeRoles` is added before `reason` in pruneMembers.