### PR TITLE
Fix MESSAGE_REACTION_REMOVE_ALL and MESSAGE_REACTION_REMOVE_EMOJI

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -583,7 +583,7 @@ class Shard extends EventEmitter {
                     if(reactionObj) {
                         --reactionObj.count;
                         if(reactionObj.count === 0) {
-                            message.reactions[reaction] = undefined;
+                            delete message.reactions[reaction];
                         } else if(packet.d.user_id === this.client.user.id) {
                             reactionObj.me = false;
                         }
@@ -631,7 +631,7 @@ class Shard extends EventEmitter {
                     message = channel.messages.get(packet.d.message_id);
                     if(message) {
                         const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                        message.reactions[reaction] = undefined;
+                        delete message.reactions[reaction];
                     }
                 }
                 /**

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -579,10 +579,13 @@ class Shard extends EventEmitter {
                 }
                 if(message) {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
-                    if(message.reactions[reaction]) {
-                        --message.reactions[reaction].count;
-                        if(packet.d.user_id === this.client.user.id) {
-                            message.reactions[reaction].me = false;
+                    const reactionObj = message.reactions[reaction];
+                    if(reactionObj) {
+                        --reactionObj.count;
+                        if(reactionObj.count === 0) {
+                            message.reactions[reaction] = undefined;
+                        } else if(packet.d.user_id === this.client.user.id) {
+                            reactionObj.me = false;
                         }
                     }
                 }
@@ -603,34 +606,43 @@ class Shard extends EventEmitter {
             }
             case "MESSAGE_REACTION_REMOVE_ALL": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
-                    break;
+                let message;
+                if(channel) {
+                    message = channel.messages.get(packet.d.message_id);
+                    if(message) {
+                        message.reactions = {};
+                    }
                 }
                 /**
                 * Fired when all reactions are removed from a message
                 * @event Client#messageReactionRemoveAll
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 */
-                this.emit("messageReactionRemoveAll", channel.messages.get(packet.d.message_id) || {
+                this.emit("messageReactionRemoveAll", message || {
                     id: packet.d.message_id,
-                    channel: channel
+                    channel: channel || {id: packet.d.channel_id}
                 });
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_EMOJI": {
                 const channel = this.client.getChannel(packet.d.channel_id);
-                if(!channel) {
-                    break;
+                let message;
+                if(channel) {
+                    message = channel.messages.get(packet.d.message_id);
+                    if(message) {
+                        const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
+                        message.reactions[reaction] = undefined;
+                    }
                 }
                 /**
                 * Fired when someone removes all reactions from a message for a single emoji
                 * @event Client#messageReactionRemoveEmoji
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The emoji object with a `name` prop. If the emoji is a custom emoji it will also have an `id` prop.
                 */
-                this.emit("messageReactionRemoveEmoji", channel.messages.get(packet.d.message_id) || {
+                this.emit("messageReactionRemoveEmoji", message || {
                     id: packet.d.message_id,
-                    channel: channel
+                    channel: channel || {id: packet.d.channel_id}
                 }, packet.d.emoji);
                 break;
             }


### PR DESCRIPTION
This PR is a follow up to #672 and allow the event to be fired even if the channel is not cached.

This PR also fix `MESSAGE_REACTION_REMOVE_ALL` and `MESSAGE_REACTION_REMOVE_EMOJI` behaviour. These 2 events were not updating reaction cache at all which could lead to invalid cache.

Additionally this PR makes `REACTION_REMOVE` remove the reaction object from `message.reaction` for this specific emoji if there are no emoji. (I explicitely assign undefined instead of deleting directly)