### PR TITLE
Support for guild/members/search members endpoint

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1200,6 +1200,7 @@ declare namespace Eris {
     getRESTGuildMember(guildID: string, memberID: string): Promise<Member>;
     getRESTGuildRoles(guildID: string): Promise<Role[]>;
     getRESTUser(userID: string): Promise<User>;
+    searchGuildMembers(guildID: string, query: string, limit?: number): Promise<Member[]>;
     searchChannelMessages(channelID: string, query: SearchOptions): Promise<SearchResults>;
     searchGuildMessages(guildID: string, query: SearchOptions): Promise<SearchResults>;
     on: ClientEvents<this>;
@@ -1429,6 +1430,7 @@ declare namespace Eris {
     getBan(userID: string): Promise<{ reason?: string; user: User }>;
     editNickname(nick: string): Promise<void>;
     getWebhooks(): Promise<Webhook[]>;
+    searchMembers(query: string, limit?: number): Promise<Member[]>;
   }
 
   export class GuildAuditLogEntry extends Base {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2049,7 +2049,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Search a member from a specific guild from the REST API via a query string to match against username and nickname.
+    * Search for guild members by partial nickname/username
     * @arg {String} guildID The ID of the guild
     * @arg {String} query The query string to match username(s) and nickname(s) against
     * @arg {Number} [limit=1] The maximum number of members you want returned, capped at 100

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2051,8 +2051,8 @@ class Client extends EventEmitter {
     /**
     * Search a member from a specific guild from the REST API via a query string to match against username and nickname.
     * @arg {String} guildID The ID of the guild
-    * @arg {String} query The query string to match username(s) and nickname(s) against.
-    * @arg {Number} [limit] The maximum number of member you want in return. Default to 1. Maximum to 100.
+    * @arg {String} query The query string to match username(s) and nickname(s) against
+    * @arg {Number} [limit=1] The maximum number of members you want returned, capped at 100
     * @returns {Promise<Member[]>}
     */
     searchGuildMembers(guildID, query, limit) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2049,6 +2049,23 @@ class Client extends EventEmitter {
     }
 
     /**
+    * Search a member from a specific guild from the REST API via a query string to match against username and nickname.
+    * @arg {String} guildID The ID of the guild
+    * @arg {String} query The query string to match username(s) and nickname(s) against.
+    * @arg {Number} [limit] The maximum number of member you want in return. Default to 1. Maximum to 100.
+    * @returns {Promise<Member[]>}
+    */
+    searchGuildMembers(guildID, query, limit) {
+        return this.requestHandler.request("GET", Endpoints.GUILD_MEMBERS_SEARCH(guildID), true, {
+            query,
+            limit
+        }).then((members) => {
+            const guild = this.guilds.get(guildID);
+            return members.map((member) => new Member(member, guild, this));
+        });
+    }
+
+    /**
     * [USER ACCOUNT] Search a channel's messages
     * @arg {String} channelID The ID of the channel
     * @arg {Object} query Search parameters

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -43,6 +43,7 @@ module.exports.GUILD_MEMBER =                                (guildID, memberID)
 module.exports.GUILD_MEMBER_NICK =                           (guildID, memberID) => `/guilds/${guildID}/members/${memberID}/nick`;
 module.exports.GUILD_MEMBER_ROLE =                   (guildID, memberID, roleID) => `/guilds/${guildID}/members/${memberID}/roles/${roleID}`;
 module.exports.GUILD_MEMBERS =                                         (guildID) => `/guilds/${guildID}/members`;
+module.exports.GUILD_MEMBERS_SEARCH =                                  (guildID) => `/guilds/${guildID}/members/search`;
 module.exports.GUILD_MESSAGES_SEARCH =                                 (guildID) => `/guilds/${guildID}/messages/search`;
 module.exports.GUILD_PREVIEW =                                         (guildID) => `/guilds/${guildID}/preview`;
 module.exports.GUILD_PRUNE =                                           (guildID) => `/guilds/${guildID}/prune`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -653,7 +653,7 @@ class Guild extends Base {
     }
 
     /**
-    * Search a member in this guild from the REST API via a query string to match against username and nickname.
+    * Search for guild members by partial nickname/username
     * @arg {String} query The query string to match username(s) and nickname(s) against
     * @arg {Number} [limit=1] The maximum number of members you want returned, capped at 100
     * @returns {Promise<Member[]>}

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -652,6 +652,16 @@ class Guild extends Base {
         return this._client.getGuildWebhooks.call(this._client, this.id);
     }
 
+    /**
+    * Search a member in this guild from the REST API via a query string to match against username and nickname.
+    * @arg {String} query The query string to match username(s) and nickname(s) against.
+    * @arg {Number} [limit] The maximum number of member you want in return. Default to 1. Maximum to 100.
+    * @returns {Promise<Member[]>}
+    */
+    searchMembers(query, limit) {
+        return this._client.searchGuildMembers.call(this._client, this.id, query, limit);
+    }
+
     toJSON(props = []) {
         return super.toJSON([
             "afkChannelID",

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -654,8 +654,8 @@ class Guild extends Base {
 
     /**
     * Search a member in this guild from the REST API via a query string to match against username and nickname.
-    * @arg {String} query The query string to match username(s) and nickname(s) against.
-    * @arg {Number} [limit] The maximum number of member you want in return. Default to 1. Maximum to 100.
+    * @arg {String} query The query string to match username(s) and nickname(s) against
+    * @arg {Number} [limit=1] The maximum number of members you want returned, capped at 100
     * @returns {Promise<Member[]>}
     */
     searchMembers(query, limit) {


### PR DESCRIPTION
Ref: discord/discord-api-docs#1577

This PR add support for the new guild/members/search endpoint: `GUILD_MEMBERS_SEARCH`.
It allows to get a list of guild members matching a string query (it matches against username and nickname)