### PR TITLE
Guild embed is deprecated in favor of guild widget

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1378,6 +1378,8 @@ declare namespace Eris {
     explicitContentFilter: number;
     publicUpdatesChannelID: string;
     rulesChannelID: string;
+    widgetEnabled?: boolean | null;
+    widgetChannelID?: string | null;
     constructor(data: BaseData, client: Client);
     fetchAllMembers(timeout?: number): Promise<number>;
     dynamicIconURL(format?: string, size?: number): string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1331,12 +1331,31 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get a guild's embed object
+    * [DEPRECATED] Get a guild's embed object
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<Object>} A guild embed object
     */
     getGuildEmbed(guildID) {
         return this.requestHandler.request("GET", Endpoints.GUILD_EMBED(guildID), true);
+    }
+
+    /**
+    * Get a guild's widget object
+    * @arg {String} guildID The ID of the guild
+    * @returns {Promise<Object>} A guild widget object
+    */
+    getGuildWidget(guildID) {
+        return this.requestHandler.request("GET", Endpoints.GUILD_WIDGET(guildID), true);
+    }
+
+    /**
+    * Modify a guild's widget
+    * @arg {String} guildID The ID of the guild
+    * @arg {Object} options The widget object to modify (https://discord.com/developers/docs/resources/guild#modify-guild-widget)
+    * @returns {Promise<Object>} A guild widget object
+    */
+    editGuildWidget(guildID, options) {
+        return this.requestHandler.request("PATCH", Endpoints.GUILD_WIDGET(guildID), true, options);
     }
 
     /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -50,6 +50,7 @@ module.exports.GUILD_ROLE =                                    (guildID, roleID)
 module.exports.GUILD_ROLES =                                           (guildID) => `/guilds/${guildID}/roles`;
 module.exports.GUILD_VOICE_REGIONS =                                   (guildID) => `/guilds/${guildID}/regions`;
 module.exports.GUILD_WEBHOOKS =                                        (guildID) => `/guilds/${guildID}/webhooks`;
+module.exports.GUILD_WIDGET =                                          (guildID) => `/guilds/${guildID}/widget`;
 module.exports.GUILDS =                                                             "/guilds";
 module.exports.INVITE =                                               (inviteID) => `/invite/${inviteID}`;
 module.exports.OAUTH2_APPLICATION =                                      (appID) => `/oauth2/applications/${appID}`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -49,6 +49,8 @@ const VoiceState = require("./VoiceState");
 * @prop {Number} maxMembers The maximum amount of members for the guild
 * @prop {String?} publicUpdatesChannelID ID of the guild's updates channel if the guild has "PUBLIC" features
 * @prop {String?} rulesChannelID The channel where "PUBLIC" guilds display rules and/or guidelines
+* @prop {Boolean?} widgetEnabled Whether the guild widget is enabled. REST only.
+* @prop {Number?} widgetChannelID The channel id that the widget will generate an invite to. REST only.
 */
 class Guild extends Base {
     constructor(data, client) {
@@ -62,6 +64,13 @@ class Guild extends Base {
         this.members = new Collection(Member);
         this.memberCount = data.member_count;
         this.roles = new Collection(Role);
+
+        if(data.widget_enabled !== undefined) {
+            this.widgetEnabled = data.widget_enabled;
+        }
+        if(data.widget_channel_id !== undefined) {
+            this.widgetChannelID = data.widget_channel_id;
+        }
 
         if(data.roles) {
             for(const role of data.roles) {
@@ -393,11 +402,28 @@ class Guild extends Base {
     }
 
     /**
-    * Get a guild's embed object
+    * [DEPRECATED] Get a guild's embed object
     * @returns {Promise<Object>} A guild embed object
     */
     getEmbed() {
         return this._client.getGuildEmbed.call(this._client, this.id);
+    }
+
+    /**
+    * Get a guild's widget object
+    * @returns {Promise<Object>} A guild widget object
+    */
+    getWidget() {
+        return this._client.getGuildWidget.call(this._client, this.id);
+    }
+
+    /**
+    * Modify a guild's widget
+    * @arg {Object} options The widget object to modify (https://discord.com/developers/docs/resources/guild#modify-guild-widget)
+    * @returns {Promise<Object>} A guild widget object
+    */
+    editGuildWidget(options) {
+        return this._client.getGuildWidget.call(this._client, this.id, options);
     }
 
     /**


### PR DESCRIPTION
Ref: discord/discord-api-docs#1536
This PR:
- add the `/guilds/guildID/widget` endpoint
- deprecates `getGuildEmbed` 
- add `getGuildWidget` as replacement
- add `editGuildWidget`
- exposes `widgetEnabled` and `widgetChannelID` on Guild (REST only). `embed_enabled` and `embed_channel_id` are deprecated so haven't been added. However, they are right now property you could get in a guild object via REST.