### PR TITLE
Change references from discordapp.com to discord.com

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1051,7 +1051,7 @@ class Client extends EventEmitter {
     * @arg {String} channelID The ID of the channel
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object} [content.allowedMentions] A list of mentions to allow (overrides default)
     * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
@@ -1086,8 +1086,8 @@ class Client extends EventEmitter {
     * @arg {String} messageID The ID of the message
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(channelID, messageID, content) {
@@ -1628,7 +1628,7 @@ class Client extends EventEmitter {
     /**
     * Get data on an OAuth2 application
     * @arg {String} [appID="@me"] The client ID of the application to get data for. "@me" refers to the logged in user's own application
-    * @returns {Promise<Object>} The bot's application data. Refer to [the official Discord API documentation entry](https://discordapp.com/developers/docs/topics/oauth2#get-current-application-information) for object structure
+    * @returns {Promise<Object>} The bot's application data. Refer to [the official Discord API documentation entry](https://discord.com/developers/docs/topics/oauth2#get-current-application-information) for object structure
     */
     getOAuthApplication(appID) {
         return this.requestHandler.request("GET", Endpoints.OAUTH2_APPLICATION(appID || "@me"), true);

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -3,7 +3,7 @@
 const {REST_VERSION} = require("../Constants");
 
 module.exports.BASE_URL = "/api/v" + REST_VERSION;
-module.exports.CDN_URL = "https://cdn.discordapp.com";
+module.exports.CDN_URL = "https://cdn.discord.com";
 
 module.exports.CHANNEL =                                                (chanID) => `/channels/${chanID}`;
 module.exports.CHANNEL_BULK_DELETE =                                    (chanID) => `/channels/${chanID}/messages/bulk-delete`;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -146,7 +146,7 @@ class RequestHandler {
 
                 const req = HTTPS.request({
                     method: method,
-                    host: "discordapp.com",
+                    host: "discord.com",
                     path: this.baseURL + finalURL,
                     headers: headers,
                     agent: this.agent

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -277,8 +277,8 @@ class Message extends Base {
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     edit(content) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -103,7 +103,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
     * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data
     * @arg {String} file.name What to name the file
@@ -119,8 +119,8 @@ class PrivateChannel extends Channel {
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -154,7 +154,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [content.allowedMentions.everyone] Whether or not to allow @everyone/@here.
     * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data
     * @arg {String} file.name What to name the file
@@ -170,8 +170,8 @@ class TextChannel extends GuildChannel {
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discordapp.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
+    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {


### PR DESCRIPTION
Discord recently changed its base domain from `discordapp.com` to `discord.com`. This PR fixes all references to `discordapp.com` to the new `discord.com`.