### PR TITLE
Remove default status in Members

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,7 +107,7 @@ declare namespace Eris {
   interface Presence {
     activities?: Activity[];
     clientStatus?: ClientStatus;
-    status: Status;
+    status?: Status;
     game?: Activity;
   }
 
@@ -1736,7 +1736,7 @@ declare namespace Eris {
     avatarURL: string;
     staticAvatarURL: string;
     game?: Activity;
-    status: Status;
+    status?: Status;
     clientStatus?: ClientStatus;
     activities?: Activity[];
     constructor(data: BaseData, guild: Guild);

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -57,7 +57,7 @@ class Member extends Base {
         } else {
             this.user = null;
         }
-        this.status = "offline";
+
         this.game = null;
         this.nick = null;
         this.update(data);


### PR DESCRIPTION
As suggested in #936 , remove default `"offline"` status in Members.
Status won't be received at all if the presence intent is not enabled so we will now only assign `member.status` if we receive it.