### PR TITLE
Expose hoistedRole property on Member

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1750,7 +1750,7 @@ declare namespace Eris {
     status?: Status;
     clientStatus?: ClientStatus;
     activities?: Activity[];
-    hoistedRole?: String;
+    hoistedRole?: string;
     constructor(data: BaseData, guild: Guild);
     edit(options: MemberOptions, reason?: string): Promise<void>;
     addRole(roleID: string, reason?: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1750,6 +1750,7 @@ declare namespace Eris {
     status?: Status;
     clientStatus?: ClientStatus;
     activities?: Activity[];
+    hoistedRole?: String;
     constructor(data: BaseData, guild: Guild);
     edit(options: MemberOptions, reason?: string): Promise<void>;
     addRole(roleID: string, reason?: string): Promise<void>;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -37,6 +37,7 @@ const VoiceState = require("./VoiceState");
 * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
 * @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
 * @prop {Number} premiumSince Timestamp of when the member boosted the guild
+* @prop {String?} hoistedRole The role id of the member's hoisted role in the guild. Provided only on the author's member object obtained from MESSAGE_CREATE and MESSAGE_UPDATE
 */
 class Member extends Base {
     constructor(data, guild, client) {
@@ -97,6 +98,9 @@ class Member extends Base {
         }
         if(data.roles !== undefined) {
             this.roles = data.roles;
+        }
+        if(data.hoisted_role !== undefined) {
+            this.hoistedRole = data.hoisted_role;
         }
     }
 


### PR DESCRIPTION
Add support for the `hoistedRole` property on Member as specified in discord/discord-api-docs#1610
Only available on `message.member` through `MESSAGE_CREATE` / `MESSAGE_UPDATE`