### PR TITLE
Optional Timeout argument to the delete function

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -353,9 +353,15 @@ class Message extends Base {
     /**
     * Delete the message
     * @arg {String} [reason] The reason to be displayed in audit logs
+    * @arg {Number} [timeout] The amount of time in ms to wait before before deleting the message
     * @returns {Promise}
     */
-    delete(reason) {
+    delete(reason, timeout) {
+        if (timeout) {
+            setTimeout(() => {
+                return this._client.deleteMessage.call(this._client, this.channel.id, this.id, reason);
+            }, timeout);
+        }
         return this._client.deleteMessage.call(this._client, this.channel.id, this.id, reason);
     }
 


### PR DESCRIPTION
This just adds a timeout option where you specify the delay in ms for a message to be deleted. This makes it easier in general to set timeouts/delays without having to call setTimeout manually. This may not be the best way to implement it either, but it gets the job done