### PR TITLE
Fix broken ratelimiter

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -196,7 +196,7 @@ class RequestHandler {
                         if(this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold) {
                             this._client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
                         }
-                        this.latencyRef.timeOffset = ~~(this.latencyRef.timeOffset - this.latencyRef.timeOffsets.shift() / 10 + timeOffset / 10);
+                        this.latencyRef.timeOffset = this.latencyRef.timeOffset - ~~(this.latencyRef.timeOffsets.shift() / 10) + ~~(timeOffset / 10);
                         this.latencyRef.timeOffsets.push(timeOffset);
                     }
 

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -192,7 +192,7 @@ class RequestHandler {
 
                     const headerNow = Date.parse(resp.headers["date"]);
                     if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
-                        const timeOffset = headerNow - (this.latencyRef.lastTimeOffsetCheck = Date.now());
+                        const timeOffset = headerNow + 500 - (this.latencyRef.lastTimeOffsetCheck = Date.now());
                         if(this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold) {
                             this._client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
                         }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -192,7 +192,7 @@ class RequestHandler {
 
                     const headerNow = Date.parse(resp.headers["date"]);
                     if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {
-                        const timeOffset = ~~((this.latencyRef.lastTimeOffsetCheck = Date.now()) - headerNow);
+                        const timeOffset = headerNow - (this.latencyRef.lastTimeOffsetCheck = Date.now());
                         if(this.latencyRef.timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold && timeOffset - this.latencyRef.latency >= this._client.options.latencyThreshold) {
                             this._client.emit("warn", new Error(`Your clock is ${this.latencyRef.timeOffset}ms behind Discord's server clock. Please check your connection and system time.`));
                         }
@@ -243,9 +243,6 @@ class RequestHandler {
                         this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
 
                         let retryAfter = parseInt(resp.headers["retry-after"]);
-                        if(retryAfter !== 0 && !retryAfter) {
-                            retryAfter = null;
-                        }
                         // Discord breaks RFC here, using milliseconds instead of seconds (╯°□°）╯︵ ┻━┻
                         // This is the unofficial Discord dev-recommended way of detecting that
                         if(retryAfter && (typeof resp.headers["via"] !== "string" || !resp.headers["via"].includes("1.1 google"))) {
@@ -263,7 +260,7 @@ class RequestHandler {
                             }
                         } else if(resp.headers["x-ratelimit-reset"]) {
                             if((~route.lastIndexOf("/reactions/:id")) && (+resp.headers["x-ratelimit-reset"] * 1000 - headerNow) === 1000) {
-                                this.ratelimits[route].reset = Math.max(now + 250 - this.latencyRef.timeOffset, now);
+                                this.ratelimits[route].reset = now + 250;
                             } else {
                                 this.ratelimits[route].reset = Math.max(+resp.headers["x-ratelimit-reset"] * 1000 - this.latencyRef.timeOffset, now);
                             }

--- a/lib/util/SequentialBucket.js
+++ b/lib/util/SequentialBucket.js
@@ -16,7 +16,6 @@ class SequentialBucket {
     */
     constructor(limit, latencyRef = {latency: 0}) {
         this.limit = this.remaining = limit;
-        this.resetInterval = 0;
         this.reset = 0;
         this.processing = false;
         this.latencyRef = latencyRef;
@@ -49,11 +48,8 @@ class SequentialBucket {
         }
         const now = Date.now();
         const offset = this.latencyRef.latency + (this.latencyRef.offset || 0);
-        if(!this.reset) {
+        if(!this.reset || this.reset < now - offset) {
             this.reset = now - offset;
-            this.remaining = this.limit;
-        } else if(this.reset < now - offset) {
-            this.reset = now - offset + (this.resetInterval || 0);
             this.remaining = this.limit;
         }
         this.last = now;
@@ -61,7 +57,7 @@ class SequentialBucket {
             this.processing = setTimeout(() => {
                 this.processing = false;
                 this.check(true);
-            }, Math.max(0, (this.reset || 0) - now) + offset);
+            }, Math.max(0, (this.reset || 0) - now + offset) + 1);
             return;
         }
         --this.remaining;


### PR DESCRIPTION
- timeOffset must be positive if local clock is behind (see [#L197](https://github.com/abalabahaha/eris/blob/dev/lib/rest/RequestHandler.js#L197)).
offset = serverTime - clientTime
reset = serverResetTime - offset
serverResetTime == serverTime + resetAfter
So for reactions: reset = clientTime + resetAfter (compatibility in case of disabled millisecond precision).
Reset calculations broken since 2017, how no one noticed?
- retryAfter >= 0 is true if retryAfter === null [#L257](https://github.com/abalabahaha/eris/blob/dev/lib/rest/RequestHandler.js#L257)
Just leave it as a possible NaN after parseInt.