### PR TITLE
Correct error event types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,6 +2,7 @@ import { EventEmitter } from "events";
 import { Readable as ReadableStream } from "stream";
 import { Agent as HTTPSAgent } from "https";
 import { IncomingMessage } from "http";
+import { ErrorEvent } from "ws";
 
 declare function Eris(token: string, options?: Eris.ClientOptions): Eris.Client;
 
@@ -903,11 +904,12 @@ declare namespace Eris {
   }
 
   interface ClientEvents<T> extends EventListeners<T> {
+    (event: "error", listener: (error: Error | ErrorEvent, id: number) => void): T;
+    (event: "shardDisconnect", listener: (err: Error, id: number) => void): T;
     (
-      event: "shardDisconnect" | "error" | "shardPreReady" | "connect",
-      listener: (err: Error, id: number) => void
+      event: "shardReady" | "shardResume" | "shardPreReady" | "connect",
+      listener: (id: number) => void
     ): T;
-    (event: "shardReady" | "shardResume", listener: (id: number) => void): T;
   }
 
   interface ShardEvents<T> extends EventListeners<T> {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -209,7 +209,7 @@ class Shard extends EventEmitter {
             /**
             * Fired when the shard encounters an error
             * @event Client#error
-            * @prop {Error} err The error
+            * @prop {Error | Object} err The error
             * @prop {Number} id The ID of the shard
             */
             this.emit("error", new Error("pako/zlib-sync not found, cannot decompress data"));

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "devDependencies": {
     "@types/node": "^13.9.0",
+    "@types/ws": "^7.2.4",
     "@typescript-eslint/eslint-plugin": "^2.14.0",
     "@typescript-eslint/parser": "^2.14.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
Websocket errors do not use the error object itself, instead is used inside its own ErrorEvent object. Fired at `this.ws.onerror(event)` on L1798 in Shard.js
This fixes #944 