### PR TITLE
Consistant Message.guildID When In A Guild

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -83,6 +83,10 @@ class Message extends Base {
             } else {
                 this.member = null;
             }
+
+            if(!this.guildID) {
+                this.guildID = this.channel.guild.id;
+            }
         } else {
             this.member = null;
         }


### PR DESCRIPTION
This PR helps add more support for message.guildID when it is missing from Discord's payloads. For example when you try and do `getMessage()` it will not provide guildID even if the message is inside a guild. This should help make it easier to use message.guildID.