### PR TITLE
Improve invite typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1074,8 +1074,8 @@ declare namespace Eris {
     getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
     pruneMembers(guildID: string, options?: PruneMemberOptions): Promise<number>;
     getVoiceRegions(guildID: string): Promise<VoiceRegion[]>;
-    getInvite(inviteID: string, withCounts?: boolean): Promise<PrivateInvite | GuildInviteWithoutMetadata>;
-    acceptInvite(inviteID: string): Promise<PrivateInvite | GuildInviteWithoutMetadata>;
+    getInvite(inviteID: string, withCounts?: boolean): Promise<AnyInviteWithoutMetadata>;
+    acceptInvite(inviteID: string): Promise<AnyInviteWithoutMetadata>;
     deleteInvite(inviteID: string, reason?: string): Promise<void>;
     getSelf(): Promise<ExtendedUser>;
     editSelf(options: { username?: string; avatar?: string }): Promise<ExtendedUser>;
@@ -1715,6 +1715,7 @@ declare namespace Eris {
     temporary: null;
   }
 
+  type AnyInviteWithoutMetadata = Invite & InviteWithoutMetadata;
   type PrivateInvite = Invite & InviteWithoutGuild & InviteWithoutMetadata;
   type GuildInviteWithoutMetadata = Invite & InviteWithGuild & InviteWithoutMetadata;
   type GuildInviteWithMetadata = Invite & InviteWithGuild & InviteWithMetadata;


### PR DESCRIPTION
Rather than letting invites be typed as a mess of interfaces, the `Invite` class is actually typed as a class now. This class stores metadata properties as `null` in situations where metadata is not returned by the API, which is now reflected accurately. Additional types were added for specifying private invites and guild channel invites, both with and without the additional metadata.

In situations where an invite is possibly a guild or private invite, its type can now be deduced via `invite.guild` being truthy, rather than having to use `'guild' in invite` to check. This is a side effect of the way TS handles the distinction between omitted properties and properties with `undefined` as a value.

I'm unsure of a couple relevant API details; will leave comments asking about them.