### PR TITLE
Fix Not Authenticated Errors

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -64,6 +64,8 @@ class Shard extends EventEmitter {
         this._onWSError = this._onWSError.bind(this);
         this._onWSClose = this._onWSClose.bind(this);
 
+        this.identified = false;
+
         this.hardReset();
     }
 
@@ -176,6 +178,7 @@ class Shard extends EventEmitter {
         this.lastHeartbeatReceived = null;
         this.lastHeartbeatSent = null;
         this.status = "disconnected";
+        this.identified = false;
         if(this.connectTimeout) {
             clearTimeout(this.connectTimeout);
         }
@@ -1930,6 +1933,7 @@ class Shard extends EventEmitter {
             case GatewayOPCodes.INVALID_SESSION: {
                 this.seq = 0;
                 this.sessionID = null;
+                this.identified = false;
                 this.emit("warn", "Invalid session, reidentifying!", this.id);
                 this.identify();
                 break;
@@ -1956,8 +1960,10 @@ class Shard extends EventEmitter {
                 this.connectTimeout = null;
 
                 if(this.sessionID) {
+                    this.identified = true;
                     this.resume();
                 } else {
+                    this.identified = false;
                     this.identify();
                     // Cannot heartbeat when resuming, discord/discord-api-docs#1619
                     this.heartbeat();
@@ -2009,7 +2015,7 @@ class Shard extends EventEmitter {
     }
 
     sendWS(op, _data, priority = false) {
-        if(this.ws && this.ws.readyState === WebSocket.OPEN) {
+        if(this.ws && this.ws.readyState === WebSocket.OPEN && (this.identified || op === GatewayOPCodes.IDENTIFY)) {
             let i = 0;
             let waitFor = 1;
             const func = () => {


### PR DESCRIPTION
After receiving a few "Not Authenticated" errors and resetting my token a few times. I checked discord docs to find out it had nothing to do with tokens and was due to packets being sent before hello was received. Added some logic to stop packets from being sent before hello is received. 

Been running on prod with no errors so far but others should check it on larger bots to see if it affects/breaks anything.