### PR TITLE
Encapsulate Textable channels in relevant interfaces

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Eris {
   // TODO there's also toJSON(): JSONCache, though, SimpleJSON should suffice
 
   type GuildTextableChannel = TextChannel | NewsChannel
-  type TextableChannel = Textable & (GuildTextableChannel | PrivateChannel);
+  type TextableChannel = (GuildTextable & GuildTextableChannel) | (Textable & PrivateChannel)
   type AnyChannel = AnyGuildChannel | PrivateChannel;
   type AnyGuildChannel = GuildTextableChannel | VoiceChannel | CategoryChannel | StoreChannel;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -24,7 +24,7 @@ declare namespace Eris {
   // TODO there's also toJSON(): JSONCache, though, SimpleJSON should suffice
 
   type GuildTextableChannel = TextChannel | NewsChannel
-  type TextableChannel = Textable & GuildTextableChannel | PrivateChannel;
+  type TextableChannel = Textable & (GuildTextableChannel | PrivateChannel);
   type AnyChannel = AnyGuildChannel | PrivateChannel;
   type AnyGuildChannel = GuildTextableChannel | VoiceChannel | CategoryChannel | StoreChannel;
 


### PR DESCRIPTION
This is very use case specific to what I'm doing but it makes more sense to do this anyways, I don't know why I didn't in my original PR to fix union types (#949) - Shouldn't affect anything functionalitywise