### PR TITLE
Add GuildID property to message at reaction add/remove

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -713,7 +713,7 @@ declare namespace Eris {
     frameSize?: number;
     sampleRate?: number;
   }
-  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel | { id: string, guild: { id: string } } };
+  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel | { id: string; guild: { id: string } } };
   interface RawPacket {
     op: number;
     t?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -713,7 +713,7 @@ declare namespace Eris {
     frameSize?: number;
     sampleRate?: number;
   }
-  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel | { id: string } };
+  type PossiblyUncachedMessage = Message | { id: string; channel: TextableChannel | { id: string, guild: { id: string } } };
   interface RawPacket {
     op: number;
     t?: string;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -622,7 +622,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel`. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -640,15 +640,21 @@ class Shard extends EventEmitter {
                         message.reactions = {};
                     }
                 }
+                if(!message) {
+                    message = {
+                        id: packet.d.message_id,
+                        channel: channel || {id: packet.d.channel_id}
+                    };
+                    if(packet.d.guild_id) {
+                        message.guildID = packet.d.guild_id;
+                    }
+                }
                 /**
                 * Fired when all reactions are removed from a message
                 * @event Client#messageReactionRemoveAll
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and if inside a guild, `guildID` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 */
-                this.emit("messageReactionRemoveAll", message || {
-                    id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id}
-                });
+                this.emit("messageReactionRemoveAll", message);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_EMOJI": {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -622,7 +622,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID`. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel`. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -583,7 +583,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and `guildID`, if in guild, keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and if inside a guild, `guildID` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
@@ -622,7 +622,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and `guildID`, if in guild, keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and if inside a guild, `guildID` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -570,21 +570,26 @@ class Shard extends EventEmitter {
                             me: packet.d.user_id === this.client.user.id
                         };
                     }
-                }
+                } else {
+					message = {
+						id: packet.d.message_id,
+						channel: channel || {id: packet.d.channel_id}
+					};
+
+					if (packet.d.guild_id) {
+						message.guildID = packet.d.guild_id;
+					}
+				}
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
                 * @prop {String} userID The ID of the user that added the reaction
                 */
-                this.emit("messageReactionAdd", message || {
-                    id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id},
-                    guildID: packet.d.guild_id
-                }, packet.d.emoji, packet.d.user_id);
+                this.emit("messageReactionAdd", message, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
@@ -604,21 +609,26 @@ class Shard extends EventEmitter {
                             reactionObj.me = false;
                         }
                     }
-                }
+                } else {
+					message = {
+						id: packet.d.message_id,
+						channel: channel || {id: packet.d.channel_id}
+					};
+
+					if (packet.d.guild_id) {
+						message.guildID = packet.d.guild_id;
+					}
+				}
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID`. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID`. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
                 * @prop {String} userID The ID of the user that removed the reaction
                 */
-                this.emit("messageReactionRemove", message || {
-                    id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id},
-                    guildID: packet.d.guild_id
-                }, packet.d.emoji, packet.d.user_id);
+                this.emit("messageReactionRemove", message, packet.d.emoji, packet.d.user_id);
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_ALL": {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -578,6 +578,9 @@ class Shard extends EventEmitter {
 
                     if(packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
+                        if(!message.channel.guild) {
+                            message.channel.guild = {id: packet.d.guild_id};
+                        }
                     }
                 }
                 /**
@@ -617,6 +620,9 @@ class Shard extends EventEmitter {
 
                     if(packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
+                        if(!message.channel.guild) {
+                            message.channel.guild = {id: packet.d.guild_id};
+                        }
                     }
                 }
                 /**
@@ -647,6 +653,9 @@ class Shard extends EventEmitter {
                     };
                     if(packet.d.guild_id) {
                         message.guildID = packet.d.guild_id;
+                        if(!message.channel.guild) {
+                            message.channel.guild = {id: packet.d.guild_id};
+                        }
                     }
                 }
                 /**
@@ -667,16 +676,25 @@ class Shard extends EventEmitter {
                         delete message.reactions[reaction];
                     }
                 }
+                if(!message) {
+                    message = {
+                        id: packet.d.message_id,
+                        channel: channel || {id: packet.d.channel_id}
+                    };
+                    if(packet.d.guild_id) {
+                        message.guildID = packet.d.guild_id;
+                        if(!message.channel.guild) {
+                            message.channel.guild = {id: packet.d.guild_id};
+                        }
+                    }
+                }
                 /**
                 * Fired when someone removes all reactions from a message for a single emoji
                 * @event Client#messageReactionRemoveEmoji
                 * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The emoji object with a `name` prop. If the emoji is a custom emoji it will also have an `id` prop.
                 */
-                this.emit("messageReactionRemoveEmoji", message || {
-                    id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id}
-                }, packet.d.emoji);
+                this.emit("messageReactionRemoveEmoji", message, packet.d.emoji);
                 break;
             }
             case "GUILD_MEMBER_ADD": {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -583,7 +583,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and `guildID`, if in guild, keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
@@ -622,7 +622,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and `guildID`, if in guild, keys. If the channel is not cached, channel key will be an object with only an id. `guildID` will be present if the message was sent in a guild channel. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -571,15 +571,15 @@ class Shard extends EventEmitter {
                         };
                     }
                 } else {
-					message = {
-						id: packet.d.message_id,
-						channel: channel || {id: packet.d.channel_id}
-					};
+                    message = {
+                        id: packet.d.message_id,
+                        channel: channel || {id: packet.d.channel_id}
+                    };
 
-					if (packet.d.guild_id) {
-						message.guildID = packet.d.guild_id;
-					}
-				}
+                    if(packet.d.guild_id) {
+                        message.guildID = packet.d.guild_id;
+                    }
+                }
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
@@ -610,15 +610,15 @@ class Shard extends EventEmitter {
                         }
                     }
                 } else {
-					message = {
-						id: packet.d.message_id,
-						channel: channel || {id: packet.d.channel_id}
-					};
+                    message = {
+                        id: packet.d.message_id,
+                        channel: channel || {id: packet.d.channel_id}
+                    };
 
-					if (packet.d.guild_id) {
-						message.guildID = packet.d.guild_id;
-					}
-				}
+                    if(packet.d.guild_id) {
+                        message.guildID = packet.d.guild_id;
+                    }
+                }
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -691,7 +691,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes all reactions from a message for a single emoji
                 * @event Client#messageReactionRemoveEmoji
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel`, and if inside a guild, `guildID` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The emoji object with a `name` prop. If the emoji is a custom emoji it will also have an `id` prop.
                 */
                 this.emit("messageReactionRemoveEmoji", message, packet.d.emoji);

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -574,7 +574,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone adds a reaction to a message
                 * @event Client#messageReactionAdd
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The emoji ID (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
@@ -582,7 +582,8 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionAdd", message || {
                     id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id}
+                    channel: channel || {id: packet.d.channel_id},
+                    guildID: packet.d.guild_id
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }
@@ -607,7 +608,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when someone removes a reaction from a message
                 * @event Client#messageReactionRemove
-                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id` and `channel` keys. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
+                * @prop {Message | Object} message The message object. If the message is not cached, this will be an object with `id`, `channel` and `guildID`. If the channel is not cached, channel key will be an object with only an id. No other property is guaranteed
                 * @prop {Object} emoji The reaction emoji object
                 * @prop {String?} emoji.id The ID of the emoji (null for non-custom emojis)
                 * @prop {String} emoji.name The emoji name
@@ -615,7 +616,8 @@ class Shard extends EventEmitter {
                 */
                 this.emit("messageReactionRemove", message || {
                     id: packet.d.message_id,
-                    channel: channel || {id: packet.d.channel_id}
+                    channel: channel || {id: packet.d.channel_id},
+                    guildID: packet.d.guild_id
                 }, packet.d.emoji, packet.d.user_id);
                 break;
             }


### PR DESCRIPTION
If the channel is not cached for messageReactionAdd and messageReactionRemove the guild id isnt in the event at all.