### PR TITLE
Permission property name consistency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1755,6 +1755,7 @@ declare namespace Eris {
     roles: string[];
     user: User;
     permission: Permission;
+    permissions: Permission;
     defaultAvatar: string;
     createdAt: number;
     bot: boolean;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -26,7 +26,7 @@ const VoiceState = require("./VoiceState");
 * @prop {String?} nick The server nickname of the member
 * @prop {String[]} roles An array of role IDs this member is a part of
 * @prop {User} user The user object of the member
-* @prop {Permission} permission The guild-wide permissions of the member. Using this property is deprecated and will not be supported in future versions.
+* @prop {Permission} permission [DEPRECATED] The guild-wide permissions of the member. Use Member#permissions instead
 * @prop {Permission} permissions The guild-wide permissions of the member
 * @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
 * @prop {Number} createdAt Timestamp of user creation
@@ -112,7 +112,7 @@ class Member extends Base {
     }
 
     get permission() {
-        this.guild.shard.client.emit("warn", "[DEPRECATED] member.permission was used. Please use the member.permissions getter instead.");
+        this.guild.shard.client.emit("warn", "[DEPRECATED] Member#permission is deprecated. Use Member#permissions instead");
         return this.permissions;
     }
 

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -26,7 +26,8 @@ const VoiceState = require("./VoiceState");
 * @prop {String?} nick The server nickname of the member
 * @prop {String[]} roles An array of role IDs this member is a part of
 * @prop {User} user The user object of the member
-* @prop {Permission} permission The guild-wide permissions of the member
+* @prop {Permission} permission The guild-wide permissions of the member. Using this property is deprecated and will not be supported in future versions.
+* @prop {Permission} permissions The guild-wide permissions of the member
 * @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
 * @prop {Number} createdAt Timestamp of user creation
 * @prop {Boolean} bot Whether the user is an OAuth bot or not
@@ -111,6 +112,11 @@ class Member extends Base {
     }
 
     get permission() {
+        this.guild.shard.client.emit("warn", "[DEPRECATED] member.permission was used. Please use the member.permissions getter instead.");
+        return this.permissions;
+    }
+
+    get permissions() {
         if(this.id === this.guild.ownerID) {
             return new Permission(Permissions.all);
         } else {


### PR DESCRIPTION
Renames Member#permission to Member#permissions to match with Role#permissions and deprecated old getter