### PR TITLE
Fixed cleanContent mention exploit

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -236,17 +236,17 @@ class Message extends Base {
                 authorName = member.nick;
             }
         }
-        cleanContent = cleanContent.replace(new RegExp(`<@!?${this.author.id}>`, "g"), "@" + authorName);
+        cleanContent = cleanContent.replace(new RegExp(`<@!?${this.author.id}>`, "g"), "@\u200b" + authorName);
 
         if(this.mentions) {
             this.mentions.forEach((mention) => {
                 if(this.channel.guild) {
                     const member = this.channel.guild.members.get(mention.id);
                     if(member && member.nick) {
-                        cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@" + member.nick);
+                        cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@\u200b" + member.nick);
                     }
                 }
-                cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@" + mention.username);
+                cleanContent = cleanContent.replace(new RegExp(`<@!?${mention.id}>`, "g"), "@\u200b" + mention.username);
             });
         }
 
@@ -254,7 +254,7 @@ class Message extends Base {
             for(const roleID of this.roleMentions) {
                 const role = this.channel.guild.roles.get(roleID);
                 const roleName = role ? role.name : "deleted-role";
-                cleanContent = cleanContent.replace(new RegExp(`<@&${roleID}>`, "g"), "@" + roleName);
+                cleanContent = cleanContent.replace(new RegExp(`<@&${roleID}>`, "g"), "@\u200b" + roleName);
             }
         }
 


### PR DESCRIPTION
People figured out a new exploit to mention roles using bots, although users can be mentioned using that too.

The scenario works as follows:

1. User sets it's nickname (or username) to `&<Role-ID>` i.e. `&371335384690327564`
2. They invoke a command in a bot that users `cleanContent` to display the user input back to the user with an input mentioning their own user surrounded by a pair of `<>` i.e. `<@&371335384690327564>` (As Displayed in Discord)
3. The role gets pinged

How did this happen?

The original message received from Discord will look like this: `<<@!108638204629925888>>`

The sanitization sees the inner mention and replaces it with the users username or nickname. Which in this case is `&371335384690327564` resulting in a `cleanContent` containing `<@&371335384690327564>` and therefore pinging a role (if the bot has permission to do so).

The fix I made basically just puts a ZWS between the @ and the Username/Nickname/Rolename. This was the best thing I could come up with right now. If there's any better solution let me know.