### PR TITLE
Add fallbacks for typingStart event arguments

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -885,7 +885,7 @@ declare namespace Eris {
       event: "relationshipUpdate",
       listener: (relationship: Relationship, oldRelationship: { type: number }) => void
     ): T;
-    (event: "typingStart", listener: (channel: TextableChannel, user: User) => void): T;
+    (event: "typingStart", listener: (channel: TextableChannel | { id: string }, user: User | { id: string }) => void): T;
     (event: "unavailableGuildCreate", listener: (guild: UnavailableGuild) => void): T;
     (
       event: "userUpdate",

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -442,8 +442,8 @@ class Shard extends EventEmitter {
                     /**
                     * Fired when a user begins typing
                     * @event Client#typingStart
-                    * @prop {PrivateChannel | TextChannel} channel The text channel the user is typing in
-                    * @prop {User} user The user
+                    * @prop {PrivateChannel | TextChannel | Object} channel The text channel the user is typing in. If the channel is not cached, this will be an object with an `id` key. No other property is guaranteed
+                    * @prop {User | Object} user The user. If the user is not cached, this will be an object with an `id` key. No other property is guaranteed
                     */
                     this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id});
                 }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -445,7 +445,7 @@ class Shard extends EventEmitter {
                     * @prop {PrivateChannel | TextChannel} channel The text channel the user is typing in
                     * @prop {User} user The user
                     */
-                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id), this.client.users.get(packet.d.user_id));
+                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id});
                 }
                 break;
             }


### PR DESCRIPTION
This PR adds fallbacks for typingStart event arguments (channel, user) in case the channel or user is not found in the cache.
