### PR TITLE
Added <Message>.guild

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -37,6 +37,7 @@ const User = require("./User");
 * @prop {Boolean} reactions.me Whether or not the bot user did the reaction
 * @prop {Boolean} pinned Whether the message is pinned or not
 * @prop {Command?} command The Command used in the Message, if any (CommandClient only)
+* @prop {Guild?} guild The guild this message was sent in
 */
 class Message extends Base {
     constructor(data, client) {
@@ -275,7 +276,11 @@ class Message extends Base {
 
         return (this._channelMentions = (this.content.match(/<#[0-9]+>/g) || []).map((mention) => mention.substring(2, mention.length - 1)));
     }
-
+    
+    get guild() {
+        return this.channel.guild   
+    }
+    
     /**
     * Edit the message
     * @arg {String | Array | Object} content A string, array of strings, or object. If an object is passed:


### PR DESCRIPTION
Decided we need this.

I think we should add this as some people may be moving here from discord.js (like I did), and wonder why message.guild returns an error.