### PR TITLE
Args splitter for CommandClient

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -749,6 +749,7 @@ declare namespace Eris {
     reconnectDelay?: ReconnectDelayFunction;
   }
   interface CommandClientOptions {
+    argsSplitter?: (str: string) => string[];
     defaultHelpCommand?: boolean;
     description?: string;
     ignoreBots?: boolean;

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -17,6 +17,7 @@ class CommandClient extends Client {
     * @arg {String} token bot token
     * @arg {Object} [options] Eris options (same as Client)
     * @arg {Object} [commandOptions] Command options
+    * @arg {Function} [argsSplitter] The function used to split args. This passes a string and should return an array of strings. You should not override this unless you know what you are doing
     * @arg {Boolean} [commandOptions.defaultHelpCommand=true] Whether to register the default help command or not
     * @arg {String} [commandOptions.description="An Eris-based Discord bot"] The description to show in the default help command
     * @arg {Boolean} [commandOptions.ignoreBots=true] Whether to ignore bot accounts or not
@@ -29,6 +30,7 @@ class CommandClient extends Client {
     constructor(token, options, commandOptions) {
         super(token, options);
         this.commandOptions = Object.assign({
+            argsSplitter: (str) => str.split(/\s+/g),
             defaultHelpCommand: true,
             description: "An Eris-based Discord bot",
             ignoreBots: true,
@@ -141,7 +143,7 @@ class CommandClient extends Client {
 
         msg.command = false;
         if((!this.commandOptions.ignoreSelf || msg.author.id !== this.user.id) && (!this.commandOptions.ignoreBots || !msg.author.bot) && (msg.prefix = this.checkPrefix(msg))) {
-            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).trim().split(/\s+/g);
+            const args = this.commandOptions.argsSplitter(msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).trim());
             const label = args.shift();
             const command = this.resolveCommand(label);
             if(command !== undefined) {

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -17,7 +17,7 @@ class CommandClient extends Client {
     * @arg {String} token bot token
     * @arg {Object} [options] Eris options (same as Client)
     * @arg {Object} [commandOptions] Command options
-    * @arg {Function} [argsSplitter] The function used to split args. This passes a string and should return an array of strings. You should not override this unless you know what you are doing
+    * @arg {Function} [argsSplitter] The function used to split args. The function is given a string with the contents of the command message (without the prefix) and should return an array of strings. By default, args are split by consecutive whitespace
     * @arg {Boolean} [commandOptions.defaultHelpCommand=true] Whether to register the default help command or not
     * @arg {String} [commandOptions.description="An Eris-based Discord bot"] The description to show in the default help command
     * @arg {Boolean} [commandOptions.ignoreBots=true] Whether to ignore bot accounts or not


### PR DESCRIPTION
Resolves #969 
Adds a function prop to command client options allowing people to split args however they want it