### PR TITLE
Correct reason property removal

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -78,7 +78,7 @@ class RequestHandler {
                     }
                     if(body && body.reason) { // Audit log reason sniping
                         headers["X-Audit-Log-Reason"] = body.reason;
-                        if(method !== "POST" || !url.includes("/prune")) {
+                        if(method !== "PUT" || !url.includes("/bans")) {
                             delete body.reason;
                         }
                     }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -78,7 +78,7 @@ class RequestHandler {
                     }
                     if(body && body.reason) { // Audit log reason sniping
                         headers["X-Audit-Log-Reason"] = body.reason;
-                        if(method !== "PUT" || !url.includes("/bans")) {
+                        if((method !== "PUT" || !url.includes("/bans")) && (method !== "POST" || !url.includes("/prune"))) {
                             delete body.reason;
                         }
                     }


### PR DESCRIPTION
[Create Guild Ban](https://discord.com/developers/docs/resources/guild#create-guild-ban) takes a reason json param, ~~not [Begin Guild Prune](https://discord.com/developers/docs/resources/guild#begin-guild-prune)~~ actually Discord still hasn't fixed that bug yet