### PR TITLE
Fix editing flags in messages authored by others.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1799,6 +1799,7 @@ declare namespace Eris {
     cleanContent: string;
     roleMentions: string[];
     channelMentions: string[];
+    flags: number;
     jumpLink: string;
     editedTimestamp?: number;
     tts: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1799,7 +1799,6 @@ declare namespace Eris {
     cleanContent: string;
     roleMentions: string[];
     channelMentions: string[];
-    flags: number;
     jumpLink: string;
     editedTimestamp?: number;
     tts: boolean;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1120,7 +1120,9 @@ class Client extends EventEmitter {
             } else if(content.content === undefined && !content.embed && content.flags === undefined) {
                 return Promise.reject(new Error("No content, embed or flags"));
             }
-            content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+            if(content.content !== undefined || content.embed || content.allowedMentions) {
+                content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+            }
         }
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content).then((message) => new Message(message, this));
     }


### PR DESCRIPTION
~~This fixes missing Message#flags in TypeScript projects~~ and also editing other people's messages to change flags e.g. if you want to edit another person's message to suppress/un-suppress the embeds in it, Eris causes a permission error since it tries to pass allowedMentions to Discord as well.

Note: I'm not entirely sure if we should pass allowedMentions to edits unless if specified in the first place, so if this needs changing, do reply and I will update the PR asap, which I think we should.