### PR TITLE
Added missing property types (commandAliases, guildPrefixes) for CommandClient

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2030,6 +2030,8 @@ declare namespace Eris {
 
   export class CommandClient extends Client {
     commands: { [s: string]: Command };
+    commandAliases: { [s: string]: string };
+    guildPrefixes: { [s: string]: string | string[] };
     constructor(token: string, options?: ClientOptions, commandOptions?: CommandClientOptions);
     onMessageCreate(msg: Message): void;
     registerGuildPrefix(guildID: string, prefix: string[] | string): void;


### PR DESCRIPTION
I noticed that CommandClient is missing its .commandAliases and .guildPrefixes properties when trying to use them in Typescript, thus I have added them to index.d.ts. 