### PR TITLE
Use _new permission fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1987,7 +1987,7 @@ declare namespace Eris {
     allow: number;
     deny: number;
     json: { [s: string]: boolean };
-    constructor(allow: number, deny: number);
+    constructor(allow: number | string, deny: number | string);
     has(permission: string): boolean;
   }
 

--- a/lib/structures/Permission.js
+++ b/lib/structures/Permission.js
@@ -23,8 +23,8 @@ const {Permissions} = require("../Constants");
 class Permission extends Base {
     constructor(allow, deny = 0) {
         super();
-        this.allow = allow;
-        this.deny = deny;
+        this.allow = Number(allow);
+        this.deny = Number(deny);
     }
 
     get json() {

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -10,7 +10,7 @@ const Permission = require("./Permission");
 */
 class PermissionOverwrite extends Permission {
     constructor(data) {
-        super(data.allow_new, data.deny_new);
+        super(data.allow_new || data.allow, data.deny_new || data.deny);
         this.id = data.id;
         this.type = data.type;
     }

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -10,7 +10,7 @@ const Permission = require("./Permission");
 */
 class PermissionOverwrite extends Permission {
     constructor(data) {
-        super(data.allow, data.deny);
+        super(data.allow_new, data.deny_new);
         this.id = data.id;
         this.type = data.type;
     }

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -44,8 +44,8 @@ class Role extends Base {
         if(data.position !== undefined) {
             this.position = data.position;
         }
-        if(data.permissions_new !== undefined) {
-            this.permissions = new Permission(data.permissions_new);
+        if(data.permissions !== undefined) {
+            this.permissions = new Permission(data.permissions_new || data.permissions);
         }
     }
 

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -44,8 +44,8 @@ class Role extends Base {
         if(data.position !== undefined) {
             this.position = data.position;
         }
-        if(data.permissions !== undefined) {
-            this.permissions = new Permission(data.permissions);
+        if(data.permissions_new !== undefined) {
+            this.permissions = new Permission(data.permissions_new);
         }
     }
 


### PR DESCRIPTION
As the legacy `allow`, `deny` and `permissions` will no longer be updated in case new permission bits are made, we should use the `_new` fields instead. This is only for response serialisation, requests should still use `allow`, `deny` and `permissions` as usual.

Also note for the future:
As permissions are now variable-length (not just 31bit), in theory, Discord could send us a permission bit that is >= 2^53 and thus cause issues when calculating permissions. We might want to consider using BigInt for this in the future. However, we seem to be okay for now, since the max Discord can currently send us is 4294967055 which is just over 2^22. If for some reason Discord does decide to send a permission bit larger than 2^53 then we'll need to apply the change to Eris as well.

Resolves #1009 