### PR TITLE
Expose latency in rawREST event

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -837,6 +837,7 @@ declare namespace Eris {
     route: string;
     short: boolean;
     resp: IncomingMessage;
+    latency: number;
   }
 
   interface EventListeners<T> {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -166,6 +166,10 @@ class RequestHandler {
                 let latency = Date.now();
 
                 req.once("response", (resp) => {
+                    latency = Date.now() - latency;
+                    this.latencyRef.raw.push(latency);
+                    this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
+
                     if(this._client.listeners("rawREST").length) {
                         /**
                          * Fired when the Client's RuquestHandler receives a response
@@ -181,12 +185,10 @@ class RequestHandler {
                          * @arg {String} request.route The calculated ratelimiting route for the request
                          * @arg {Boolean} request.short Whether or not the request was prioritized in its ratelimiting queue
                          * @arg {IncomingMessage} request.resp The HTTP response to the request
+                         * @arg {Number} request.latency The HTTP response latency
                          */
-                        this._client.emit("rawREST", {method, url, auth, body, file, route, short, resp});
+                        this._client.emit("rawREST", {method, url, auth, body, file, route, short, resp, latency});
                     }
-                    latency = Date.now() - latency;
-                    this.latencyRef.raw.push(latency);
-                    this.latencyRef.latency = this.latencyRef.latency - ~~(this.latencyRef.raw.shift() / 10) + ~~(latency / 10);
 
                     const headerNow = Date.parse(resp.headers["date"]);
                     if(this.latencyRef.lastTimeOffsetCheck < Date.now() - 5000) {


### PR DESCRIPTION
For statistics/graphing purposes I thought it would be useful to expose the request latency in the emitted rawREST event.