### PR TITLE
Return void on 204

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -367,7 +367,7 @@ class RequestHandler {
                         }
 
                         cb();
-                        resolve(response);
+                        resolve(response || undefined);
                     });
                 });
 


### PR DESCRIPTION
We don't check if the string is empty or not. This can cause vague errors when returning a 204 endpoint in a command generator for instance.