### PR TITLE
gateway shard: check undocumented field before accessing

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1409,9 +1409,11 @@ class Shard extends EventEmitter {
                 } else {
                     this.client.bot = false;
                     this.client.userGuildSettings = {};
-                    packet.d.user_guild_settings.forEach((guildSettings) => {
-                        this.client.userGuildSettings[guildSettings.guild_id] = guildSettings;
-                    });
+                    if(packet.d.user_guild_settings) {
+                        packet.d.user_guild_settings.forEach((guildSettings) => {
+                            this.client.userGuildSettings[guildSettings.guild_id] = guildSettings;
+                        });
+                    }
                     this.client.userSettings = packet.d.user_settings;
                 }
 


### PR DESCRIPTION
`user_guild_settings` is not documented in the 'ready' event. https://discord.com/developers/docs/topics/gateway#ready

Most such fields we already check if they exist before calling a method on them or something. This adds that check for `user_guild_settings`, where we previously would call `.forEach` immediately.