### PR TITLE
Update documentation for options.auth

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -640,11 +640,12 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Execute a webhook
+    * Execute a webhook.
+    * A webhook can use all existing custom emojis as long as the everyone role has the "use external emojis" permission.
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Webhook execution options
-    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
+    * @arg {Boolean} [options.auth=false] Whether or not to authenticate with the bot token.
     * @arg {String} [options.content=""] A content string
     * @arg {Object | Object[]} [options.file] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data
@@ -675,12 +676,13 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Execute a slack-style webhook
+    * Execute a slack-style webhook.
+    * A webhook can use all existing custom emojis as long as the everyone role has the "use external emojis" permission.
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Slack webhook options
     * @arg {Boolean} [options.wait=false] Whether to wait for the server to confirm the message create or not
-    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
+    * @arg {Boolean} [options.auth=false] Whether or not to authenticate with the bot token
     * @returns {Promise}
     */
     executeSlackWebhook(webhookID, token, options) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -644,7 +644,6 @@ class Client extends EventEmitter {
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Webhook execution options
-    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @arg {String} [options.content=""] A content string
     * @arg {Object | Object[]} [options.file] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data
@@ -664,7 +663,7 @@ class Client extends EventEmitter {
         if(!options.content && !options.file && !options.embeds) {
             return Promise.reject(new Error("No content, file, or embeds"));
         }
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), !!options.auth, {
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), false, {
             content: options.content,
             embeds: options.embeds,
             username: options.username,
@@ -680,15 +679,12 @@ class Client extends EventEmitter {
     * @arg {String} token The token of the webhook
     * @arg {Object} options Slack webhook options
     * @arg {Boolean} [options.wait=false] Whether to wait for the server to confirm the message create or not
-    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @returns {Promise}
     */
     executeSlackWebhook(webhookID, token, options) {
         const wait = !!options.wait;
         options.wait = undefined;
-        const auth = !!options.auth;
-        options.auth = undefined;
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), auth, options);
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), false, options);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -644,6 +644,7 @@ class Client extends EventEmitter {
     * @arg {String} webhookID The ID of the webhook
     * @arg {String} token The token of the webhook
     * @arg {Object} options Webhook execution options
+    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @arg {String} [options.content=""] A content string
     * @arg {Object | Object[]} [options.file] A file object (or an Array of them)
     * @arg {Buffer} options.file.file A buffer containing file data
@@ -663,7 +664,7 @@ class Client extends EventEmitter {
         if(!options.content && !options.file && !options.embeds) {
             return Promise.reject(new Error("No content, file, or embeds"));
         }
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), false, {
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (options.wait ? "?wait=true" : ""), !!options.auth, {
             content: options.content,
             embeds: options.embeds,
             username: options.username,
@@ -679,12 +680,15 @@ class Client extends EventEmitter {
     * @arg {String} token The token of the webhook
     * @arg {Object} options Slack webhook options
     * @arg {Boolean} [options.wait=false] Whether to wait for the server to confirm the message create or not
+    * @arg {Boolean} [options.auth=false] Whether or not to authorize the request with the bot token (allowing custom emotes from other guilds)
     * @returns {Promise}
     */
     executeSlackWebhook(webhookID, token, options) {
         const wait = !!options.wait;
         options.wait = undefined;
-        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), false, options);
+        const auth = !!options.auth;
+        options.auth = undefined;
+        return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN_SLACK(webhookID, token) + (wait ? "?wait=true" : ""), auth, options);
     }
 
     /**


### PR DESCRIPTION
Webhooks now by default can use all emoji if the everyone role has the use external emojis permission. This can be safely removed