### PR TITLE
REST V8, Gateway v8

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -723,9 +723,9 @@ declare namespace Eris {
     summary: string;
   }
   interface IntegrationOptions {
-    enableEmoticons: string;
-    expireBehavior: string;
-    expireGracePeriod: string;
+    enableEmoticons?: string;
+    expireBehavior?: string;
+    expireGracePeriod?: string;
   }
   interface PruneMemberOptions extends GetPruneOptions {
     computePruneCount?: boolean;
@@ -2124,21 +2124,21 @@ declare namespace Eris {
     application?: IntegrationApplication;
     createdAt: number;
     enabled: boolean;
-    enableEmoticons: boolean;
-    expireBehavior: number;
-    expireGracePeriod: number;
+    enableEmoticons?: boolean;
+    expireBehavior?: number;
+    expireGracePeriod?: number;
     id: string;
     name: string;
-    revoked: boolean;
-    roleID: string;
-    subscriberCount: number;
-    syncedAt: number;
-    syncing: boolean;
+    revoked?: boolean;
+    roleID?: string;
+    subscriberCount?: number;
+    syncedAt?: number;
+    syncing?: boolean;
     type: string;
     user?: User;
     constructor(data: BaseData, guild: Guild);
     delete(): Promise<void>;
-    edit(options: { enableEmoticons: string; expireBehavior: string; expireGracePeriod: string }): Promise<void>;
+    edit(options: IntegrationOptions): Promise<void>;
     sync(): Promise<void>;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1477,7 +1477,7 @@ declare namespace Eris {
     users: Collection<User>;
     userSettings: UserSettings;
     voiceConnections: VoiceConnectionManager;
-    constructor(token: string, options?: ClientOptions);
+    constructor(token: string, options: ClientOptions);
     acceptInvite(inviteID: string): Promise<Invite<"withoutCount">>;
     addGroupRecipient(groupID: string, userID: string): Promise<void>;
     addGuildDiscoverySubcategory(guildID: string, categoryID: string, reason?: string): Promise<DiscoverySubcategoryResponse>;
@@ -1880,7 +1880,7 @@ declare namespace Eris {
     commands: { [s: string]: Command };
     guildPrefixes: { [s: string]: string | string[] };
     preReady?: true;
-    constructor(token: string, options?: ClientOptions, commandOptions?: CommandClientOptions);
+    constructor(token: string, options: ClientOptions, commandOptions?: CommandClientOptions);
     checkPrefix(msg: Message): string;
     onMessageCreate(msg: Message): Promise<void>;
     onMessageReactionEvent(msg: Message, emoji: Emoji, reactor: Member | Uncached | string): Promise<void>

--- a/index.d.ts
+++ b/index.d.ts
@@ -2218,6 +2218,7 @@ declare namespace Eris {
     defaultAvatar: string;
     defaultAvatarURL: string;
     discriminator: string;
+    game: Activity | null;
     guild: Guild;
     id: string;
     joinedAt: number;
@@ -2375,8 +2376,8 @@ declare namespace Eris {
     unsendMessage(messageID: string): Promise<void>;
   }
 
-  export class Relationship extends Base implements Presence {
-    activities?: Activity[];
+  export class Relationship extends Base implements Omit<Presence, "activities"> {
+    activities: Activity[] | null;
     clientStatus?: ClientStatus;
     id: string;
     status: Status;

--- a/index.d.ts
+++ b/index.d.ts
@@ -929,6 +929,12 @@ declare namespace Eris {
     type: T;
     url?: string;
   }
+  interface ClientPresence {
+    activities: Activity[] | null;
+    afk: boolean;
+    since: number | null;
+    status: Status;
+  }
   interface ClientStatus {
     desktop: Status;
     mobile: Status;
@@ -1455,7 +1461,7 @@ declare namespace Eris {
     lastReconnectDelay: number;
     notes: { [s: string]: string };
     options: ClientOptions;
-    presence: Presence;
+    presence: ClientPresence;
     privateChannelMap: { [s: string]: string };
     privateChannels: Collection<PrivateChannel>;
     ready: boolean;
@@ -2447,7 +2453,7 @@ declare namespace Eris {
     lastHeartbeatSent: number | null;
     latency: number;
     preReady: boolean;
-    presence: Presence;
+    presence: ClientPresence;
     presenceUpdateBucket: Bucket;
     ready: boolean;
     reconnectInterval: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -205,7 +205,7 @@ declare namespace Eris {
     firstShardID?: number;
     getAllUsers?: boolean;
     guildCreateTimeout?: number;
-    intents?: number | IntentStrings[];
+    intents: number | IntentStrings[];
     largeThreshold?: number;
     lastShardID?: number;
     /** @deprecated */

--- a/index.d.ts
+++ b/index.d.ts
@@ -663,9 +663,6 @@ declare namespace Eris {
     limit?: number;
     userID?: string;
   }
-  interface GetGuildIntegrationsOptions {
-    includeApplications?: boolean;
-  }
   interface GetPruneOptions {
     days?: number;
     includeRoles?: string[];
@@ -1702,7 +1699,7 @@ declare namespace Eris {
     getGuildDiscovery(guildID: string): Promise<DiscoveryMetadata>;
     /** @deprecated */
     getGuildEmbed(guildID: string): Promise<Widget>;
-    getGuildIntegrations(guildID: string, options?: GetGuildIntegrationsOptions): Promise<GuildIntegration[]>;
+    getGuildIntegrations(guildID: string): Promise<GuildIntegration[]>;
     getGuildInvites(guildID: string): Promise<Invite[]>;
     getGuildPreview(guildID: string): Promise<GuildPreview>;
     getGuildTemplate(code: string): Promise<GuildTemplate>;
@@ -2045,7 +2042,7 @@ declare namespace Eris {
     getDiscovery(): Promise<DiscoveryMetadata>;
     /** @deprecated */
     getEmbed(): Promise<Widget>;
-    getIntegrations(options?: GetGuildIntegrationsOptions): Promise<GuildIntegration>;
+    getIntegrations(): Promise<GuildIntegration>;
     getInvites(): Promise<Invite[]>;
     getPruneCount(options?: GetPruneOptions): Promise<number>;
     getRESTChannels(): Promise<AnyGuildChannel[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1646,7 +1646,7 @@ declare namespace Eris {
       reason?: string
     ): Promise<Emoji>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
-    editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<void>;
+    editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
     editGuildTemplate(guildID: string, code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;
     editGuildVanity(guildID: string, code: string | null): Promise<GuildVanity>;
     editGuildVoiceState(guildID: string, options: VoiceStateOptions, userID?: string): Promise<void>;
@@ -2026,7 +2026,7 @@ declare namespace Eris {
     editDiscovery(options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     editIntegration(integrationID: string, options: IntegrationOptions): Promise<void>;
-    editMember(memberID: string, options: MemberOptions, reason?: string): Promise<void>;
+    editMember(memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
     editNickname(nick: string): Promise<void>;
     editRole(roleID: string, options: RoleOptions): Promise<Role>;
     editTemplate(code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -928,8 +928,8 @@ declare namespace Eris {
     [key: string]: unknown;
   }
   interface ActivityPartial<T extends ActivityType = BotActivityType> {
-    name?: string;
-    type?: T;
+    name: string;
+    type: T;
     url?: string;
   }
   interface ClientStatus {
@@ -1663,7 +1663,8 @@ declare namespace Eris {
       data: { friendSync: boolean; visibility: number }
     ): Promise<Connection>;
     editSelfSettings(data: UserSettings): Promise<UserSettings>;
-    editStatus(status?: Status, game?: ActivityPartial<BotActivityType>): void;
+    editStatus(status: Status, activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
+    editStatus(activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
     editUserNote(userID: string, note: string): Promise<void>;
     editWebhook(
       webhookID: string,
@@ -2214,7 +2215,6 @@ declare namespace Eris {
     defaultAvatar: string;
     defaultAvatarURL: string;
     discriminator: string;
-    game: Activity | null;
     guild: Guild;
     id: string;
     joinedAt: number;
@@ -2375,7 +2375,6 @@ declare namespace Eris {
   export class Relationship extends Base implements Presence {
     activities?: Activity[];
     clientStatus?: ClientStatus;
-    game: Activity | null;
     id: string;
     status: Status;
     type: number;
@@ -2467,8 +2466,8 @@ declare namespace Eris {
     createGuild(_guild: Guild): Guild;
     disconnect(options?: { reconnect?: boolean | "auto" }, error?: Error): void;
     editAFK(afk: boolean): void;
-    editStatus(status?: Status, game?: ActivityPartial<BotActivityType>): void;
-    editStatus(game?: ActivityPartial<BotActivityType>): void;
+    editStatus(status: Status, activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
+    editStatus(activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
     // @ts-ignore: Method override
     emit(event: string, ...args: any[]): void;
     getGuildMembers(guildID: string, timeout: number): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -205,7 +205,6 @@ declare namespace Eris {
     firstShardID?: number;
     getAllUsers?: boolean;
     guildCreateTimeout?: number;
-    guildSubscriptions?: boolean;
     intents?: number | IntentStrings[];
     largeThreshold?: number;
     lastShardID?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -680,7 +680,7 @@ declare namespace Eris {
     entries: GuildAuditLogEntry[];
     integrations: GuildIntegration[];
     users: User[];
-    webhooks: Webhook[]
+    webhooks: Webhook[];
   }
   interface GuildOptions {
     afkChannelID?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare namespace Eris {
   type InteractionType = 1 | 2;
 
   // Permission
-  type PermissionType = "role" | "member";
+  type PermissionType = 0 | 1;
 
   // Presence/Relationship
   type ActivityType = BotActivityType | 4;
@@ -686,6 +686,27 @@ declare namespace Eris {
     users: User[];
     webhooks: Webhook[];
   }
+  interface WidgetChannel {
+    id: string;
+    name: string;
+    position: number;
+  }
+  interface WidgetMember {
+    id: string;
+    username: string;
+    discriminator: string;
+    avatar: null;
+    status: string;
+    avatar_url: string;
+  }
+  interface WidgetData {
+    id: string;
+    name: string;
+    instant_invite: string;
+    channels: WidgetChannel[];
+    members: WidgetMember[];
+    presence_count: number;
+  }
   interface GuildOptions {
     afkChannelID?: string;
     afkTimeout?: number;
@@ -920,7 +941,6 @@ declare namespace Eris {
   interface Presence {
     activities?: Activity[];
     clientStatus?: ClientStatus;
-    game: Activity | null;
     status?: Status;
   }
 
@@ -945,7 +965,7 @@ declare namespace Eris {
     hoist?: boolean;
     mentionable?: boolean;
     name?: string;
-    permissions?: bigint | number;
+    permissions?: bigint | number | Permission;
   }
   interface RoleTags {
     bot_id?: string;
@@ -1107,7 +1127,7 @@ declare namespace Eris {
       GUILD_STORE: 6;
       GUILD_STAGE: 13;
     };
-    GATEWAY_VERSION: 6;
+    GATEWAY_VERSION: 8;
     GatewayOPCodes: {
       EVENT: 0;
       HEARTBEAT: 1;
@@ -1230,7 +1250,7 @@ declare namespace Eris {
       allVoice: 4629464849n;
       all: 8589934591n;
     };
-    REST_VERSION: 7;
+    REST_VERSION: 8;
     StickerFormats: {
       PNG: 1;
       APNG: 2;
@@ -1614,7 +1634,7 @@ declare namespace Eris {
       overwriteID: string,
       allow: bigint | number,
       deny: bigint | number,
-      type: string,
+      type: PermissionType,
       reason?: string
     ): Promise<void>;
     editChannelPosition(channelID: string, position: number, options?: EditChannelPositionOptions): Promise<void>;
@@ -1690,7 +1710,8 @@ declare namespace Eris {
     getGuildVanity(guildID: string): Promise<GuildVanity>;
     getGuildWebhooks(guildID: string): Promise<Webhook[]>;
     getGuildWelcomeScreen(guildID: string): Promise<WelcomeScreen>;
-    getGuildWidget(guildID: string): Promise<Widget>;
+    getGuildWidget(guildID: string): Promise<WidgetData>;
+    getGuildWidgetSettings(guildID: string): Promise<Widget>;
     getInvite(inviteID: string, withCounts?: false): Promise<Invite<"withoutCount">>;
     getInvite(inviteID: string, withCounts: true): Promise<Invite<"withCount">>;
     getMessage(channelID: string, messageID: string): Promise<Message>;
@@ -2040,7 +2061,8 @@ declare namespace Eris {
     getVoiceRegions(): Promise<VoiceRegion[]>;
     getWebhooks(): Promise<Webhook[]>;
     getWelcomeScreen(): Promise<WelcomeScreen>;
-    getWidget(): Promise<Widget>;
+    getWidget(): Promise<WidgetData>;
+    getWidgetSettings(): Promise<Widget>;
     kickMember(userID: string, reason?: string): Promise<void>;
     leave(): Promise<void>;
     leaveVoiceChannel(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -767,7 +767,7 @@ declare namespace Eris {
     presence_count: number;
   }
   interface WidgetMember {
-    avatar: null;
+    avatar: string | null;
     avatar_url: string;
     discriminator: string;
     id: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -683,28 +683,7 @@ declare namespace Eris {
     entries: GuildAuditLogEntry[];
     integrations: GuildIntegration[];
     users: User[];
-    webhooks: Webhook[];
-  }
-  interface WidgetChannel {
-    id: string;
-    name: string;
-    position: number;
-  }
-  interface WidgetMember {
-    id: string;
-    username: string;
-    discriminator: string;
-    avatar: null;
-    status: string;
-    avatar_url: string;
-  }
-  interface WidgetData {
-    id: string;
-    name: string;
-    instant_invite: string;
-    channels: WidgetChannel[];
-    members: WidgetMember[];
-    presence_count: number;
+    webhooks: Webhook[]
   }
   interface GuildOptions {
     afkChannelID?: string;
@@ -776,6 +755,27 @@ declare namespace Eris {
   interface Widget {
     channel_id?: string;
     enabled: boolean;
+  }
+  interface WidgetChannel {
+    id: string;
+    name: string;
+    position: number;
+  }
+  interface WidgetData {
+    channels: WidgetChannel[];
+    id: string;
+    instant_invite: string;
+    members: WidgetMember[];
+    name: string;
+    presence_count: number;
+  }
+  interface WidgetMember {
+    avatar: null;
+    avatar_url: string;
+    discriminator: string;
+    id: string;
+    status: string;
+    username: string;
   }
 
   // Invite

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1758,7 +1758,7 @@ class Client extends EventEmitter {
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<GuildIntegration[]>}
     */
-    getGuildIntegrations(guildID, options = {}) {
+    getGuildIntegrations(guildID) {
         const guild = this.guilds.get(guildID);
         return this.requestHandler.request("GET", Endpoints.GUILD_INTEGRATIONS(guildID), true).then((integrations) => integrations.map((integration) => new GuildIntegration(integration, guild)));
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -639,7 +639,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {Number | Permission} [options.permissions] The role permissions
+    * @arg {Number | String | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -641,14 +641,14 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {Number} [options.permissions] The role permissions number
+    * @arg {Number | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */
     createRole(guildID, options, reason) {
         return this.requestHandler.request("POST", Endpoints.GUILD_ROLES(guildID), true, {
             name: options.name,
-            permissions: options.permissions instanceof Permission ? options.permissions.allow : options.permissions,
+            permissions: options.permissions instanceof Permission ? String(options.permissions.allow) : String(options.permissions),
             color: options.color,
             hoist: options.hoist,
             mentionable: options.mentionable,
@@ -953,11 +953,12 @@ class Client extends EventEmitter {
     * @arg {String} overwriteID The ID of the overwritten user or role (everyone role ID = guild ID)
     * @arg {BigInt} allow The permissions number for allowed permissions
     * @arg {BigInt} deny The permissions number for denied permissions
-    * @arg {String} type The object type of the overwrite, either "member" or "role"
+    * @arg {Number} type The object type of the overwrite, either 1 for "member" or 0 for "role"
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise}
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type, reason) {
+        type = Number(type);
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
             allow: allow.toString(),
             deny: deny.toString(),
@@ -1267,7 +1268,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {BigInt | Number} [options.permissions] The role permissions number
+    * @arg {BigInt | Number | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */
@@ -1276,6 +1277,7 @@ class Client extends EventEmitter {
             options.permissions = options.permissions.toString();
         }
         options.reason = reason;
+        options.permissions = options.permissions instanceof Permission ? String(options.permissions.allow) : String(options.permissions);
         return this.requestHandler.request("PATCH", Endpoints.GUILD_ROLE(guildID, roleID), true, options).then((role) => new Role(role, this.guilds.get(guildID)));
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1118,7 +1118,7 @@ class Client extends EventEmitter {
     * @arg {String} [options.nick] Set the member's server nickname, "" to remove
     * @arg {Array<String>} [options.roles] The array of role IDs the member should have
     * @arg {String} [reason] The reason to be displayed in audit logs
-    * @returns {Promise}
+    * @returns {Promise<Member>}
     */
     editGuildMember(guildID, memberID, options, reason) {
         return this.requestHandler.request("PATCH", Endpoints.GUILD_MEMBER(guildID, memberID), true, {
@@ -1128,7 +1128,7 @@ class Client extends EventEmitter {
             deaf: options.deaf,
             channel_id: options.channelID,
             reason: reason
-        });
+        }).then(member => new Member(member, this.guilds.get(guildID), this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -77,7 +77,7 @@ class Client extends EventEmitter {
     /**
     * Create a Client
     * @arg {String} token The auth token to use. Bot tokens should be prefixed with `Bot` (e.g. `Bot MTExIHlvdSAgdHJpZWQgMTEx.O5rKAA.dQw4w9WgXcQ_wpV-gGA4PSk_bm8`). Prefix-less bot tokens are [DEPRECATED]
-    * @arg {Object} [options] Eris options (all options are optional)
+    * @arg {Object} options Eris client options
     * @arg {Object} [options.agent] [DEPRECATED] A HTTPS Agent used to proxy requests. This option has been moved under `options.rest`
     * @arg {Object} [options.allowedMentions] A list of mentions to allow by default in createMessage/editMessage
     * @arg {Boolean} [options.allowedMentions.everyone] Whether or not to allow @everyone/@here.
@@ -93,7 +93,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String>} [options.intents] A list of intents, or raw bitmask value describing the intents to subscribe to. "presence" intent must be enabled on your application's page to be used.
+    * @arg {Number | Array<String>} options.intents A list of intents, or raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1748,15 +1748,11 @@ class Client extends EventEmitter {
     /**
     * Get a list of integrations for a guild
     * @arg {String} guildID The ID of the guild
-    * @arg {Object} [options] Options for getting integrations
-    * @arg {Object} [options.includeApplications=false] Whether or not to include bot and OAuth2 webhook integrations
     * @returns {Promise<GuildIntegration[]>}
     */
     getGuildIntegrations(guildID, options = {}) {
         const guild = this.guilds.get(guildID);
-        return this.requestHandler.request("GET", Endpoints.GUILD_INTEGRATIONS(guildID), true, {
-            include_applications: options.includeApplications || false
-        }).then((integrations) => integrations.map((integration) => new GuildIntegration(integration, guild)));
+        return this.requestHandler.request("GET", Endpoints.GUILD_INTEGRATIONS(guildID), true).then((integrations) => integrations.map((integration) => new GuildIntegration(integration, guild)));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1128,7 +1128,7 @@ class Client extends EventEmitter {
             deaf: options.deaf,
             channel_id: options.channelID,
             reason: reason
-        }).then(member => new Member(member, this.guilds.get(guildID), this));
+        }).then((member) => new Member(member, this.guilds.get(guildID), this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -956,7 +956,9 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type, reason) {
-        type = Number(type);
+        if(isNaN(type)) { // backward compatbility
+            type = type === "member" ? 1 : 0;
+        }
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
             allow: allow.toString(),
             deny: deny.toString(),

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1823,7 +1823,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get a guild's widget object.
+    * Get a guild's widget object
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<Object>} A guild widget object
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -958,7 +958,7 @@ class Client extends EventEmitter {
     * @returns {Promise}
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type, reason) {
-        if(isNaN(type)) { // backward compatbility
+        if(typeof type === "string") { // backward compatibility
             type = type === "member" ? 1 : 0;
         }
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -77,7 +77,7 @@ class Client extends EventEmitter {
     /**
     * Create a Client
     * @arg {String} token The auth token to use. Bot tokens should be prefixed with `Bot` (e.g. `Bot MTExIHlvdSAgdHJpZWQgMTEx.O5rKAA.dQw4w9WgXcQ_wpV-gGA4PSk_bm8`). Prefix-less bot tokens are [DEPRECATED]
-    * @arg {Object} options Eris client options
+    * @arg {Object} options Eris client options (only `intents` is required)
     * @arg {Object} [options.agent] [DEPRECATED] A HTTPS Agent used to proxy requests. This option has been moved under `options.rest`
     * @arg {Object} [options.allowedMentions] A list of mentions to allow by default in createMessage/editMessage
     * @arg {Boolean} [options.allowedMentions.everyone] Whether or not to allow @everyone/@here.

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -93,7 +93,6 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Boolean} [options.guildSubscriptions=true] If false, disables some guild subscription events, including typing and presence events. This will reduce processing load, but will also result in inconsistent member caching
     * @arg {Number | Array<String>} [options.intents] A list of intents, or raw bitmask value describing the intents to subscribe to. "presence" intent must be enabled on your application's page to be used.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
@@ -136,7 +135,6 @@ class Client extends EventEmitter {
             firstShardID: 0,
             getAllUsers: false,
             guildCreateTimeout: 2000,
-            guildSubscriptions: true,
             largeThreshold: 250,
             maxReconnectAttempts: Infinity,
             maxResumeAttempts: 10,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1823,12 +1823,21 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Get a guild's widget object
+    * Get a guild's widget object.
     * @arg {String} guildID The ID of the guild
     * @returns {Promise<Object>} A guild widget object
     */
     getGuildWidget(guildID) {
         return this.requestHandler.request("GET", Endpoints.GUILD_WIDGET(guildID), true);
+    }
+
+    /**
+    * Get a guild's widget settings object. Requires MANAGE_GUILD permission
+    * @arg {String} guildID The ID of the guild
+    * @returns {Promise<Object>} A guild widget setting object
+    */
+    getGuildWidgetSettings(guildID) {
+        return this.requestHandler.request("GET", Endpoints.GUILD_WIDGET_SETTINGS(guildID), true);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -211,7 +211,9 @@ class Client extends EventEmitter {
         this.relationships = new Collection(Relationship);
         this.users = new Collection(User);
         this.presence = {
-            game: null,
+            activities: null,
+            afk: false,
+            since: null,
             status: "offline"
         };
         this.userGuildSettings = [];
@@ -1402,25 +1404,31 @@ class Client extends EventEmitter {
     /**
     * Update the bot's status on all guilds
     * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
-    * @arg {Object} [game] Sets the bot's active game, null to clear
-    * @arg {String} game.name Sets the name of the bot's active game
-    * @arg {Number} [game.type] The type of game. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
+    * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
+    * @arg {String} activities[].name The name of the activity
+    * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
+    * @arg {Number} [activities[].url] The URL of the activity
     * @arg {String} [game.url] Sets the url of the shard's active game
     */
-    editStatus(status, game) {
-        if(game === undefined && typeof status === "object") {
-            game = status;
+    editStatus(status, activities) {
+        if(activities === undefined && typeof status === "object") {
+            activities = status;
             status = undefined;
         }
         if(status) {
             this.presence.status = status;
         }
-        if(game !== undefined) {
-            this.presence.game = game;
+        if(activities === null) {
+            activities = [];
+        } else if(activities && !Array.isArray(activities)) {
+            activities = [activities];
+        }
+        if(activities !== undefined) {
+            this.presence.activities = activities;
         }
 
         this.shards.forEach((shard) => {
-            shard.editStatus(status, game);
+            shard.editStatus(status, activities);
         });
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1744,15 +1744,6 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [DEPRECATED] Get a guild's embed object
-    * @arg {String} guildID The ID of the guild
-    * @returns {Promise<Object>} A guild embed object
-    */
-    getGuildEmbed(guildID) {
-        return this.requestHandler.request("GET", Endpoints.GUILD_EMBED(guildID), true);
-    }
-
-    /**
     * Get a list of integrations for a guild
     * @arg {String} guildID The ID of the guild
     * @arg {Object} [options] Options for getting integrations

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -30,8 +30,8 @@ module.exports.GatewayOPCodes = {
     SYNC_CALL:          13
 };
 
-module.exports.GATEWAY_VERSION = 6;
-module.exports.REST_VERSION = 7;
+module.exports.GATEWAY_VERSION = 8;
+module.exports.REST_VERSION = 8;
 
 const Permissions = {
     createInstantInvite:  1n,

--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -16,7 +16,7 @@ class CommandClient extends Client {
     /**
     * Create a CommandClient
     * @arg {String} token Bot token
-    * @arg {Object} [options] Eris options (same as Client)
+    * @arg {Object} options Eris options (same as Client)
     * @arg {Object} [commandOptions] Command options
     * @arg {Function} [argsSplitter] The function used to split args. The function is given a string with the contents of the command message (without the prefix) and should return an array of strings. By default, args are split by consecutive whitespace
     * @arg {Boolean} [commandOptions.defaultHelpCommand=true] Whether to register the default help command or not

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -326,7 +326,6 @@ class Shard extends EventEmitter {
             v: GATEWAY_VERSION,
             compress: !!this.client.options.compress,
             large_threshold: this.client.options.largeThreshold,
-            guild_subscriptions: !!this.client.options.guildSubscriptions,
             intents: this.client.options.intents,
             properties: {
                 "os": process.platform,

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1475,19 +1475,9 @@ class Shard extends EventEmitter {
                     /**
                     * Fired when a channel is created
                     * @event Client#channelCreate
-                    * @prop {TextChannel | VoiceChannel | CategoryChannel | StoreChannel | NewsChannel | GuildChannel | PrivateChannel} channel The channel
+                    * @prop {TextChannel | VoiceChannel | CategoryChannel | StoreChannel | NewsChannel | GuildChannel} channel The channel
                     */
                     this.emit("channelCreate", channel);
-                } else if(channel instanceof PrivateChannel) {
-                    if(channel instanceof GroupChannel) {
-                        this.client.groupChannels.add(channel, this.client);
-                    } else {
-                        this.client.privateChannels.add(channel, this.client);
-                        this.client.privateChannelMap[packet.d.recipients[0].id] = packet.d.id;
-                    }
-                    if(this.id === 0) {
-                        this.emit("channelCreate", channel);
-                    }
                 } else {
                     this.emit("warn", new Error("Unhandled CHANNEL_CREATE type: " + JSON.stringify(packet, null, 2)));
                     break;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -195,7 +195,7 @@ class Shard extends EventEmitter {
     }
 
     /**
-    * Update the bot's AFK status. Setting this to true will enable push notifications for userbots.
+    * Update the bot's AFK status.
     * @arg {Boolean} afk Whether the bot user is AFK or not
     */
     editAFK(afk) {
@@ -207,33 +207,32 @@ class Shard extends EventEmitter {
     /**
     * Updates the bot's status on all guilds the shard is in
     * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
-    * @arg {Object} [game] Sets the bot's active game, null to clear
-    * @arg {String} game.name Sets the name of the bot's active game
-    * @arg {Number} [game.type] The type of game. 0 is default, 1 is streaming (Twitch only)
-    * @arg {String} [game.url] Sets the url of the shard's active game
+    * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
+    * @arg {String} activities[].name The name of the activity
+    * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
+    * @arg {Number} [activities[].url] The URL of the activity
     */
-    editStatus(status, game) {
-        if(game === undefined && typeof status === "object") {
-            game = status;
+    editStatus(status, activities) {
+        if(activities === undefined && typeof status === "object") {
+            activities = status;
             status = undefined;
         }
         if(status) {
             this.presence.status = status;
         }
-        if(game !== undefined) {
-            if(game !== null && !game.hasOwnProperty("type")) {
-                game.type = game.url ? 1 : 0; // No other types _yet_
+        if(activities === null) {
+            activities = [];
+        } else if(activities && !Array.isArray(activities)) {
+            activities = [activities];
+        }
+        if(activities !== undefined) {
+            if(activities.length > 0 && !activities[0].hasOwnProperty("type")) {
+                activities[0].type = activities[0].url ? 1 : 0;
             }
-            this.presence.game = game;
+            this.presence.activities = activities;
         }
 
         this.sendStatusUpdate();
-
-        this.client.guilds.forEach((guild) => {
-            if(guild.shard.id === this.id) {
-                guild.members.get(this.client.user.id).update(this.presence);
-            }
-        });
     }
 
     emit(event, ...args) {
@@ -556,8 +555,8 @@ class Shard extends EventEmitter {
 
     sendStatusUpdate() {
         this.sendWS(GatewayOPCodes.STATUS_UPDATE, {
+            activities: this.presence.activities,
             afk: !!this.presence.afk, // For push notifications
-            game: this.presence.game,
             since: this.presence.status === "idle" ? Date.now() : 0,
             status: this.presence.status
         });
@@ -632,7 +631,7 @@ class Shard extends EventEmitter {
                         break;
                     }
                     const oldPresence = {
-                        game: relationship.game,
+                        activities: relationship.activities,
                         status: relationship.status
                     };
                     /**

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -646,10 +646,6 @@ class Shard extends EventEmitter {
                     * @prop {String} oldPresence.clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
                     * @prop {String} oldPresence.clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
                     * @prop {String} oldPresence.clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
-                    * @prop {Object?} oldPresence.game The old game the other user was playing
-                    * @prop {String} oldPresence.game.name The name of the active game
-                    * @prop {Number} oldPresence.game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
-                    * @prop {String} oldPresence.game.url The url of the active game
                     * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
                     */
                     this.emit("presenceUpdate", this.client.relationships.update(packet.d), oldPresence);
@@ -666,7 +662,6 @@ class Shard extends EventEmitter {
                     oldPresence = {
                         activities: member.activities,
                         clientStatus: member.clientStatus,
-                        game: member.game,
                         status: member.status
                     };
                 }

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -38,7 +38,6 @@ module.exports.GUILD_BANS =                                            (guildID)
 module.exports.GUILD_CHANNELS =                                        (guildID) => `/guilds/${guildID}/channels`;
 module.exports.GUILD_DISCOVERY =                                       (guildID) => `/guilds/${guildID}/discovery-metadata`;
 module.exports.GUILD_DISCOVERY_CATEGORY =                  (guildID, categoryID) => `/guilds/${guildID}/discovery-categories/${categoryID}`;
-module.exports.GUILD_EMBED =                                           (guildID) => `/guilds/${guildID}/embed`;
 module.exports.GUILD_EMOJI =                                  (guildID, emojiID) => `/guilds/${guildID}/emojis/${emojiID}`;
 module.exports.GUILD_EMOJIS =                                          (guildID) => `/guilds/${guildID}/emojis`;
 module.exports.GUILD_INTEGRATION =                             (guildID, inteID) => `/guilds/${guildID}/integrations/${inteID}`;

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -64,7 +64,7 @@ module.exports.GUILD_WELCOME_SCREEN =                                  (guildID)
 module.exports.GUILD_WIDGET =                                          (guildID) => `/guilds/${guildID}/widget`;
 module.exports.GUILD_VOICE_STATE =                               (guildID, user) => `/guilds/${guildID}/voice-states/${user}`;
 module.exports.GUILDS =                                                             "/guilds";
-module.exports.INVITE =                                               (inviteID) => `/invite/${inviteID}`;
+module.exports.INVITE =                                               (inviteID) => `/invites/${inviteID}`;
 module.exports.OAUTH2_APPLICATION =                                      (appID) => `/oauth2/applications/${appID}`;
 module.exports.USER =                                                   (userID) => `/users/${userID}`;
 module.exports.USER_BILLING =                                           (userID) => `/users/${userID}/billing`;

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -61,7 +61,8 @@ module.exports.GUILD_TEMPLATE_GUILD =                            (guildID, code)
 module.exports.GUILD_VOICE_REGIONS =                                   (guildID) => `/guilds/${guildID}/regions`;
 module.exports.GUILD_WEBHOOKS =                                        (guildID) => `/guilds/${guildID}/webhooks`;
 module.exports.GUILD_WELCOME_SCREEN =                                  (guildID) => `/guilds/${guildID}/welcome-screen`;
-module.exports.GUILD_WIDGET =                                          (guildID) => `/guilds/${guildID}/widget`;
+module.exports.GUILD_WIDGET =                                          (guildID) => `/guilds/${guildID}/widget.json`;
+module.exports.GUILD_WIDGET_SETTINGS =                                 (guildID) => `/guilds/${guildID}/widget`;
 module.exports.GUILD_VOICE_STATE =                               (guildID, user) => `/guilds/${guildID}/voice-states/${user}`;
 module.exports.GUILDS =                                                             "/guilds";
 module.exports.INVITE =                                               (inviteID) => `/invites/${inviteID}`;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -80,8 +80,7 @@ class RequestHandler {
             const actualCall = (cb) => {
                 const headers = {
                     "User-Agent": this.userAgent,
-                    "Accept-Encoding": "gzip,deflate",
-                    "X-RateLimit-Precision": "millisecond"
+                    "Accept-Encoding": "gzip,deflate"
                 };
                 let data;
                 let finalURL = url;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -730,12 +730,10 @@ class Guild extends Base {
 
     /**
     * Get a list of integrations for the guild
-    * @arg {Object} [options] Options for getting integrations
-    * @arg {Object} [options.includeApplications=false] Whether or not to include bot and OAuth2 webhook integrations
     * @returns {Promise<GuildIntegration[]>}
     */
-    getIntegrations(options) {
-        return this._client.getGuildIntegrations.call(this._client, this.id, options);
+    getIntegrations() {
+        return this._client.getGuildIntegrations.call(this._client, this.id);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -860,9 +860,9 @@ class Guild extends Base {
     }
 
     /**
-     * Get a guild's widget settings object
-     * @returns {Promise<Object>} A guild widget settings object
-     */
+    * Get a guild's widget settings object
+    * @returns {Promise<Object>} A guild widget settings object
+    */
     getWidgetSettings() {
         return this._client.getGuildWidgetSettings.call(this._client, this.id);
     }

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -374,7 +374,7 @@ class Guild extends Base {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {Number} [options.permissions] The role permissions number
+    * @arg {Number | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */
@@ -585,7 +585,7 @@ class Guild extends Base {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {BigInt | Number} [options.permissions] The role permissions number
+    * @arg {BigInt | Number | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */
@@ -726,14 +726,6 @@ class Guild extends Base {
      */
     getDiscovery() {
         return this._client.getGuildDiscovery.call(this._client, this.id);
-    }
-
-    /**
-    * [DEPRECATED] Get a guild's embed object
-    * @returns {Promise<Object>} A guild embed object
-    */
-    getEmbed() {
-        return this._client.getGuildEmbed.call(this._client, this.id);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -374,7 +374,7 @@ class Guild extends Base {
     * @arg {Boolean} [options.hoist] Whether to hoist the role in the user list or not
     * @arg {Boolean} [options.mentionable] Whether the role is mentionable or not
     * @arg {String} [options.name] The name of the role
-    * @arg {Number | Permission} [options.permissions] The role permissions
+    * @arg {Number | String | Permission} [options.permissions] The role permissions
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Role>}
     */

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -562,7 +562,7 @@ class Guild extends Base {
     * @arg {String} [options.nick] Set the member's guild nickname, "" to remove
     * @arg {Array<String>} [options.roles] The array of role IDs the member should have
     * @arg {String} [reason] The reason to be displayed in audit logs
-    * @returns {Promise}
+    * @returns {Promise<Member>}
     */
     editMember(memberID, options, reason) {
         return this._client.editGuildMember.call(this._client, this.id, memberID, options, reason);

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -860,6 +860,14 @@ class Guild extends Base {
     }
 
     /**
+     * Get a guild's widget settings object
+     * @returns {Promise<Object>} A guild widget settings object
+     */
+    getWidgetSettings() {
+        return this._client.getGuildWidgetSettings.call(this._client, this.id);
+    }
+
+    /**
     * Kick a member from the guild
     * @arg {String} userID The ID of the member
     * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -76,11 +76,11 @@ class GuildAuditLogEntry extends Base {
                 this.membersRemoved = +data.options.members_removed;
             }
             if(data.options.type) {
-                if(data.options.type === "member") {
+                if(data.options.type === "1") {
                     this.member = guild.members.get(data.options.id) || {
                         id: data.options.id
                     };
-                } else if(data.options.type === "role") {
+                } else if(data.options.type === "0") {
                     this.role = guild.roles.get(data.options.id) || {
                         id: data.options.id,
                         name: data.options.role_name

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -93,7 +93,7 @@ class GuildChannel extends Channel {
     * @arg {String} overwriteID The ID of the overwritten user or role
     * @arg {BigInt | Number} allow The permissions number for allowed permissions
     * @arg {BigInt | Number} deny The permissions number for denied permissions
-    * @arg {String} type The object type of the overwrite, either "member" or "role"
+    * @arg {Number} type The object type of the overwrite, either 1 for "member" or 0 for "role"
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<PermissionOverwrite>}
     */

--- a/lib/structures/GuildIntegration.js
+++ b/lib/structures/GuildIntegration.js
@@ -7,19 +7,19 @@ const Base = require("./Base");
 * @prop {Object} account Info on the integration account
 * @prop {String} account.id The ID of the integration account
 * @prop {String} account.name The name of the integration account
-* @prop {Object} application The bot/OAuth2 application for Discord integrations. See [the Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object)
+* @prop {Object?} application The bot/OAuth2 application for Discord integrations. See [the Discord docs](https://discord.com/developers/docs/resources/guild#integration-application-object)
 * @prop {Number} createdAt Timestamp of the guild integration's creation
 * @prop {Boolean} enabled Whether the integration is enabled or not
-* @prop {Boolean} enableEmoticons Whether integration emoticons are enabled or not
-* @prop {Number} expireBehavior behavior of expired subscriptions
-* @prop {Number} expireGracePeriod grace period for expired subscriptions
+* @prop {Boolean?} enableEmoticons Whether integration emoticons are enabled or not
+* @prop {Number?} expireBehavior behavior of expired subscriptions
+* @prop {Number?} expireGracePeriod grace period for expired subscriptions
 * @prop {String} id The ID of the integration
 * @prop {String} name The name of the integration
-* @prop {Boolean} revoked Whether or not the application was revoked
-* @prop {String} roleID The ID of the role connected to the integration
-* @prop {Number} subscriberCount number of subscribers
-* @prop {Number} syncedAt Unix timestamp of last integration sync
-* @prop {Boolean} syncing Whether the integration is syncing or not
+* @prop {Boolean?} revoked Whether or not the application was revoked
+* @prop {String?} roleID The ID of the role connected to the integration
+* @prop {Number?} subscriberCount number of subscribers
+* @prop {Number?} syncedAt Unix timestamp of last integration sync
+* @prop {Boolean?} syncing Whether the integration is syncing or not
 * @prop {String} type The type of the integration
 * @prop {User?} user The user connected to the integration
 */
@@ -29,7 +29,9 @@ class GuildIntegration extends Base {
         this.guild = guild;
         this.name = data.name;
         this.type = data.type;
-        this.roleID = data.role_id;
+        if(data.role_id !== undefined) {
+            this.roleID = data.role_id;
+        }
         if(data.user) {
             this.user = guild.shard.client.users.add(data.user, guild.shard.client);
         }
@@ -39,13 +41,27 @@ class GuildIntegration extends Base {
 
     update(data) {
         this.enabled = data.enabled;
-        this.syncing = data.syncing;
-        this.expireBehavior = data.expire_behavior;
-        this.expireGracePeriod = data.expire_grace_period;
-        this.enableEmoticons = data.enable_emoticons;
-        this.subscriberCount = data.subscriber_count;
-        this.syncedAt = data.synced_at;
-        this.revoked = data.revoked;
+        if(data.syncing !== undefined) {
+            this.syncing = data.syncing;
+        }
+        if(data.expire_behavior !== undefined) {
+            this.expireBehavior = data.expire_behavior;
+        }
+        if(data.expire_behavior !== undefined) {
+            this.expireGracePeriod = data.expire_grace_period;
+        }
+        if(data.enable_emoticons) {
+            this.enableEmoticons = data.enable_emoticons;
+        }
+        if(data.subscriber_count !== undefined) {
+            this.subscriberCount = data.subscriber_count;
+        }
+        if(data.synced_at !== undefined) {
+            this.syncedAt = data.synced_at;
+        }
+        if(data.revoked !== undefined) {
+            this.revoked = data.revoked;
+        }
         if(data.application !== undefined) {
             this.application = data.application;
         }

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -160,7 +160,7 @@ class Member extends Base {
     }
 
     get game() {
-        return this.activities ? this.activities[0] : null;
+        return this.activities && this.activities.length > 0 ? this.activities[0] : null;
     }
 
     /**
@@ -228,7 +228,7 @@ class Member extends Base {
 
     toJSON(props = []) {
         return super.toJSON([
-            "game",
+            "activities",
             "joinedAt",
             "nick",
             "pending",

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -58,7 +58,6 @@ class Member extends Base {
             this.user = null;
         }
 
-        this.game = null;
         this.nick = null;
         this.roles = [];
         this.update(data);
@@ -67,9 +66,6 @@ class Member extends Base {
     update(data) {
         if(data.status !== undefined) {
             this.status = data.status;
-        }
-        if(data.game !== undefined) {
-            this.game = data.game;
         }
         if(data.joined_at !== undefined) {
             this.joinedAt = Date.parse(data.joined_at);
@@ -161,6 +157,10 @@ class Member extends Base {
                 id: this.id
             });
         }
+    }
+
+    get game() {
+        return this.activities ? this.activities[0] : null;
     }
 
     /**

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -6,7 +6,7 @@ const Permission = require("./Permission");
 * Represents a permission overwrite
 * @extends Permission
 * @prop {String} id The ID of the overwrite
-* @prop {String} type The type of the overwrite, either "member" or "role"
+* @prop {Number} type The type of the overwrite, either 1 for "member" or 0 for "role"
 */
 class PermissionOverwrite extends Permission {
     constructor(data) {

--- a/lib/structures/PermissionOverwrite.js
+++ b/lib/structures/PermissionOverwrite.js
@@ -10,7 +10,7 @@ const Permission = require("./Permission");
 */
 class PermissionOverwrite extends Permission {
     constructor(data) {
-        super(data.allow_new || data.allow, data.deny_new || data.deny);
+        super(data.allow, data.deny);
         this.id = data.id;
         this.type = data.type;
     }

--- a/lib/structures/Relationship.js
+++ b/lib/structures/Relationship.js
@@ -18,7 +18,7 @@ class Relationship extends Base {
         this.user = client.users.add(data.user, client);
         this.type = 0;
         this.status = "offline";
-        this.game = null;
+        this.activities = null;
         this.update(data);
     }
 
@@ -29,14 +29,14 @@ class Relationship extends Base {
         if(data.status !== undefined) {
             this.status = data.status;
         }
-        if(data.game !== undefined) {
-            this.game = data.game;
+        if(data.activities !== undefined) {
+            this.activities = data.activities;
         }
     }
 
     toJSON(props = []) {
         return super.toJSON([
-            "game",
+            "activities",
             "status",
             "type",
             "user",

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -49,7 +49,7 @@ class Role extends Base {
             this.position = data.position;
         }
         if(data.permissions !== undefined) {
-            this.permissions = new Permission(data.permissions_new || data.permissions);
+            this.permissions = new Permission(data.permissions);
         }
         if(data.tags !== undefined) {
             this.tags = data.tags;


### PR DESCRIPTION
Ref: discord/discord-api-docs#2097


- X-Ratelimit-Precision was removed because no longer necessary (all ratelimits are ms by default)
- `guildSubscription` is removed because obsolete since intents.
- Removed deprecated endpoint and methods (GUILD_EMBED)
- use correct invites endpoint
- Permissions will still be numbers internally and are parsed as string when create/edit role.
- Game was removed, replaced by activities[0] for backward compatbility
- DM channel are no longer sent in CHANNEL_CREATE
- `editGuildMember` / `editMember` now returns the Member (discord/discord-api-docs#2505)

BREAKING CHANGES:
- `getGuildEmbed` replaced with `getGuildWidget`
- `PermissionsOverwrite.type` is now a number instead of a String: 
  - editChannelPermission is backward compatible
- member.game was removed, but a getter was ket for backward compatibility

~~This unfortunately invalidate #1016 ?~~

Review and testing is appreciated.