### PR TITLE
Edited default help command

### DIFF
--- a/lib/command/CommandClient.js
+++ b/lib/command/CommandClient.js
@@ -17,6 +17,7 @@ class CommandClient extends Client {
     * @arg {String} token bot token
     * @arg {Object} [options] Eris options (same as Client)
     * @arg {Object} [commandOptions] Command options
+    * @arg {Function} [argsSplitter] The function used to split args. The function is given a string with the contents of the command message (without the prefix) and should return an array of strings. By default, args are split by consecutive whitespace
     * @arg {Boolean} [commandOptions.defaultHelpCommand=true] Whether to register the default help command or not
     * @arg {String} [commandOptions.description="An Eris-based Discord bot"] The description to show in the default help command
     * @arg {Boolean} [commandOptions.ignoreBots=true] Whether to ignore bot accounts or not
@@ -29,6 +30,7 @@ class CommandClient extends Client {
     constructor(token, options, commandOptions) {
         super(token, options);
         this.commandOptions = Object.assign({
+            argsSplitter: (str) => str.split(/\s+/g),
             defaultHelpCommand: true,
             description: "An Eris-based Discord bot",
             ignoreBots: true,
@@ -100,15 +102,22 @@ class CommandClient extends Client {
                             }
                         }
                     }
+                    return result
                 } else {
                     result += `${this.commandOptions.name} - ${this.commandOptions.description}\n`;
                     if(this.commandOptions.owner) {
                         result += `by ${this.commandOptions.owner}\n`;
                     }
                     result += "\n**Commands:**\n";
+                    var mod = 0;
                     for(const label in this.commands) {
                         if(this.commands.hasOwnProperty(label) && this.commands[label] && this.commands[label].permissionCheck(msg) && !this.commands[label].hidden) {
+                            var lastres = result
                             result += `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
+                            if (lastres.length <= 2000 && result.length > 2000){
+                                msg.channel.createMessage(lastres)
+                                result = `  **${msg.prefix}${label}** - ${this.commands[label].description}\n`;
+                            }
                         }
                     }
                     result += `\nType ${msg.prefix}help <command> for more info on a command.`;
@@ -141,7 +150,7 @@ class CommandClient extends Client {
 
         msg.command = false;
         if((!this.commandOptions.ignoreSelf || msg.author.id !== this.user.id) && (!this.commandOptions.ignoreBots || !msg.author.bot) && (msg.prefix = this.checkPrefix(msg))) {
-            const args = msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).trim().split(/\s+/g);
+            const args = this.commandOptions.argsSplitter(msg.content.replace(/<@!/g, "<@").substring(msg.prefix.length).trim());
             const label = args.shift();
             const command = this.resolveCommand(label);
             if(command !== undefined) {
@@ -175,7 +184,7 @@ class CommandClient extends Client {
                     if(msg.command.errorMessage) {
                         try {
                             if(typeof msg.command.errorMessage === "function") {
-                                const reply = msg.command.errorMessage();
+                                const reply = msg.command.errorMessage(msg, err);
                                 if(reply !== undefined) {
                                     newMsg = await this.createMessage(msg.channel.id, reply);
                                 }
@@ -321,7 +330,7 @@ class CommandClient extends Client {
     * @arg {Boolean} [options.deleteCommand=false] Whether to delete the user command message or not
     * @arg {String} [options.description="No description"] A short description of the command to show in the default help command
     * @arg {Boolean} [options.dmOnly=false] Whether to prevent the command from being used in guilds or not
-    * @arg {Function | String} [options.errorMessage] A string or a function that returns a string to show if the execution of the command handler somehow fails.
+    * @arg {Function | String} [options.errorMessage] A string or a function that returns a string to show if the execution of the command handler somehow fails. The function is passed the command message and the error as parameters.
     * @arg {String} [options.fullDescription="No full description"] A detailed description of the command to show in the default help command
     * @arg {Boolean} [options.guildOnly=false] Whether to prevent the command from being used in Direct Messages or not
     * @arg {Boolean} [options.hidden=false] Whether or not the command should be hidden from the default help command list


### PR DESCRIPTION
The previous default help command would automatically error out once the help text is longer than 2000 characters. Basically I split the help command message up if it was too long.