### PR TITLE
Fix doc for webhooksUpdate event

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1627,8 +1627,8 @@ class Shard extends EventEmitter {
                 * Fired when a channel's webhooks are updated
                 * @event Client#webhooksUpdate
                 * @prop {Object} data The update data
-                * @prop {String} channelID The ID of the channel that webhooks were updated in
-                * @prop {String} guildID The ID of the guild that webhooks were updated in
+                * @prop {String} data.channelID The ID of the channel that webhooks were updated in
+                * @prop {String} data.guildID The ID of the guild that webhooks were updated in
                 */
                 this.emit("webhooksUpdate", {
                     channelID: packet.d.channel_id,


### PR DESCRIPTION
The documentation for the `webhooksUpdate` event showed that there was data and two IDs rather than the two IDs being in the data object.