### PR TITLE
feat: Hide client property 

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -60,7 +60,7 @@ const {Permissions} = require("../Constants");
 class Guild extends Base {
     constructor(data, client) {
         super(data.id);
-        this._client = client;
+        Object.defineProperty(this, "_client", { value: client });
         this.shard = client.shards.get(client.guildShardMap[this.id]);
         this.unavailable = !!data.unavailable;
         this.joinedAt = Date.parse(data.joined_at);

--- a/lib/structures/GuildPreview.js
+++ b/lib/structures/GuildPreview.js
@@ -22,7 +22,7 @@ const Endpoints = require("../rest/Endpoints.js");
 class GuildPreview extends Base {
     constructor(data, client) {
         super(data.id);
-        this._client = client;
+        Object.defineProperty(this, "_client", { value: client });
 
         this.name = data.name;
         this.icon = data.icon;

--- a/lib/structures/Invite.js
+++ b/lib/structures/Invite.js
@@ -24,7 +24,7 @@ const Guild = require("./Guild");
 class Invite extends Base {
     constructor(data, client) {
         super();
-        this._client = client;
+        Object.defineProperty(this, "_client", { value: client });
         this.code = data.code;
         if(data.guild && client.guilds.has(data.guild.id)) {
             this.channel = client.guilds.get(data.guild.id).channels.update(data.channel);

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -46,7 +46,7 @@ const User = require("./User");
 class Message extends Base {
     constructor(data, client) {
         super(data.id);
-        this._client = client;
+        Object.defineProperty(this, "_client", { value: client });
         this.type = data.type || 0;
         this.timestamp = Date.parse(data.timestamp);
         this.channel = client.getChannel(data.channel_id) || {

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -25,7 +25,7 @@ class User extends Base {
         if(!client) {
             this._missingClientError = new Error("Missing client in constructor"); // Preserve constructor callstack
         }
-        this._client = client;
+        Object.defineProperty(this, "_client", { value: client });
         this.bot = !!data.bot;
         this.system = !!data.system;
         this.update(data);


### PR DESCRIPTION
As projects get bigger or you're ~debugging~ logging it might be hard to have to scroll over as the client is logged multiple times.
This should only affect logging it will not show the client but it will still be a  property of the class.
allowing for easy navigation during logging.

### Exampal of large data
```js
Message {
...data,
Client: {}
channel: {
 data...
 Client: {}
 }
author: {
 data...
 Client: {}
 }
guild: {
 data...
 Client: {}
 }
}
```