### PR TITLE
Remove `[key: string]: number` from certain TS typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -908,7 +908,6 @@ declare namespace Eris {
       INTEGRATION_CREATE: 80;
       INTEGRATION_UPDATE: 81;
       INTEGRATION_DELETE: 82;
-      [key: string]: number;
     };
     ChannelTypes: {
       GUILD_TEXT: 0;
@@ -918,7 +917,6 @@ declare namespace Eris {
       GUILD_CATEGORY: 4;
       GUILD_NEWS: 5;
       GUILD_STORE: 6;
-      [key: string]: number;
     };
     GATEWAY_VERSION: 6;
     GatewayOPCodes: {
@@ -936,13 +934,11 @@ declare namespace Eris {
       HEARTBEAT_ACK: 11;
       SYNC_GUILD: 12;
       SYNC_CALL: 13;
-      [key: string]: number;
     };
     ImageFormats: ["jpg", "jpeg", "png", "webp", "gif"];
     ImageSizeBoundaries: {
       MAXIMUM: 4096;
       MINIMUM: 16;
-      [key: string]: number;
     };
     Intents: {
       guilds: 1;
@@ -960,14 +956,12 @@ declare namespace Eris {
       directMessages: 4096;
       directMessageReactions: 8192;
       directMessageTyping: 16384;
-      [key: string]: number;
     };
     MessageActivityTypes: {
       JOIN: 1;
       SPECTATE: 2;
       LISTEN: 3;
       JOIN_REQUEST: 5;
-      [key: string]: number;
     };
     MessageFlags: {
       CROSSPOSTED: 0;
@@ -975,7 +969,6 @@ declare namespace Eris {
       SUPPRESS_EMBEDS: 4;
       SOURCE_MESSAGE_DELETED: 8;
       URGENT: 16;
-      [key: string]: number;
     };
     MessageTypes: {
       DEFAULT: 0;
@@ -996,7 +989,6 @@ declare namespace Eris {
       GUILD_DISCOVERY_REQUALIFIED: 15;
       GUILD_DISCOVERY_GRACE_PERIOD_INITIAL_WARNING: 16;
       GUILD_DISCOVERY_GRACE_PERIOD_FINAL_WARNING: 17;
-      [key: string]: number;
     };
     Permissions: {
       createInstantInvite: 1;
@@ -1034,7 +1026,6 @@ declare namespace Eris {
       allGuild: 2080899263;
       allText: 805829714;
       allVoice: 871367441;
-      [key: string]: number;
     };
     REST_VERSION: 7;
     SystemJoinMessages: [
@@ -1067,7 +1058,6 @@ declare namespace Eris {
       BUG_HUNTER_LEVEL_2: 16384;
       VERIFIED_BOT: 65536;
       VERIFIED_BOT_DEVELOPER: 131072;
-      [key: string]: number;
     };
     VoiceOPCodes: {
       IDENTIFY: 0;
@@ -1081,7 +1071,6 @@ declare namespace Eris {
       HELLO: 8;
       RESUMED: 9;
       DISCONNECT: 13;
-      [key: string]: number;
     };
   }
 


### PR DESCRIPTION
Unless there is something I'm not seeing here, these typings are not needed and could do more harm than good. 
Using `[key: string]: number` allows properties with any key, which in this case is incorrect as all known properties are explicitly listed, and there are no unknown properties to account for.
As such, these lines should be removed to prevent any unexpected behaviour.