### PR TITLE
New activity type - updated typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,7 @@ declare namespace Eris {
 
   // Presence/Relationship
   type ActivityType = BotActivityType | 4;
-  type BotActivityType = 0 | 1 | 2 | 3;
+  type BotActivityType = 0 | 1 | 2 | 3 | 5;
   type FriendSuggestionReasons = { name: string; platform_type: string; type: number }[];
   type Status = "online" | "idle" | "dnd" | "offline";
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1018,7 +1018,9 @@ class Client extends EventEmitter {
             } else if(content.content === undefined && !content.embed && content.flags === undefined) {
                 return Promise.reject(new Error("No content, embed or flags"));
             }
-            content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+            if(content.content !== undefined || content.embed || content.allowedMentions) {
+                content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
+            }
         }
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, content).then((message) => new Message(message, this));
     }


### PR DESCRIPTION
Currencly Discord allows 5 different status types (4 for bots): streaming, playing, watching, listening, custom status - only for users and competing (fifth). I did test this in JS and worked without problems the status came "Competing in <my status>" so it's typings problem and I did fix it now (atleast I assume). (this is small change, but important one whose want to use this brand new feature)