### PR TITLE
Removes the "undefined" behaviour in debug event

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -257,7 +257,7 @@ class RequestHandler {
                         }
 
                         if(resp.statusCode !== 429) {
-                            this._client.emit("debug", `${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                            this._client.emit("debug", `${body && body.content ? body.content + " " : ""}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
                         if(resp.statusCode >= 300) {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -257,12 +257,14 @@ class RequestHandler {
                         }
 
                         if(resp.statusCode !== 429) {
-                            this._client.emit("debug", `${body && body.content ? `${body.content} ` : ""}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                            const content = typeof body === "object" && body.content ? `${body.content} ` : "";
+                            this._client.emit("debug", `${content}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
                         if(resp.statusCode >= 300) {
                             if(resp.statusCode === 429) {
-                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${body && body.content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                                const content = typeof body === "object" && body.content ? `${body.content} ` : "";
+                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                                 if(retryAfter) {
                                     setTimeout(() => {
                                         cb();

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -257,7 +257,7 @@ class RequestHandler {
                         }
 
                         if(resp.statusCode !== 429) {
-                            this._client.emit("debug", `${body && body.content ? body.content + " " : ""}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
+                            this._client.emit("debug", `${body && body.content ? `${body.content} ` : ""}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
                         if(resp.statusCode >= 300) {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -257,13 +257,13 @@ class RequestHandler {
                         }
 
                         if(resp.statusCode !== 429) {
-                            const content = typeof body === "object" && body.content ? `${body.content} ` : "";
+                            const content = typeof body === "object" ? `${body.content} ` : "";
                             this._client.emit("debug", `${content}${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                         }
 
                         if(resp.statusCode >= 300) {
                             if(resp.statusCode === 429) {
-                                const content = typeof body === "object" && body.content ? `${body.content} ` : "";
+                                const content = typeof body === "object" ? `${body.content} ` : "";
                                 this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
                                 if(retryAfter) {
                                     setTimeout(() => {


### PR DESCRIPTION
This PR removes the `undefined` behaviour when using the `debug` event in **RequestHandler**, it can be in-consice when debugging.

## Before
![before](https://cdn.floofy.dev/images/external/pr/before.png)

## After
(with any sort of body)
![after (with body)](https://cdn.floofy.dev/images/external/pr/after.png)

(without any sort of body)
![after (without body)](https://cdn.floofy.dev/images/external/pr/after_body.png)