### PR TITLE
 wrong typing on inline replies 

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -700,7 +700,7 @@ declare namespace Eris {
     everyone?: boolean;
     roles?: boolean | string[];
     users?: boolean | string[];
-    replied_user?: boolean;
+    repliedUser?: boolean;
   }
   interface Attachment {
     filename: string;


### PR DESCRIPTION
the replied user would not get notification by receiveing an inline reply even though `replied_user` was set as `true`.

i confirmed that the replied user now gets notification when `repliedUser` is `true`, and not when it is `false`, with switching the flag in my application.
also lint'd (no fix was needed).