### PR TITLE
Added user attribute to oldMember

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -447,7 +447,7 @@ declare namespace Eris {
     (event: "guildMemberRemove", listener: (guild: Guild, member: Member | MemberPartial) => void): T;
     (
       event: "guildMemberUpdate",
-      listener: (guild: Guild, member: Member, oldMember: { nick?: string; premiumSince: number; roles: string[] } | null) => void
+      listener: (guild: Guild, member: Member, oldMember: { nick?: string; premiumSince: number; roles: string[]; user: PartialUser | null } | null) => void
     ): T;
     (event: "guildRoleCreate" | "guildRoleDelete", listener: (guild: Guild, role: Role) => void): T;
     (event: "guildRoleUpdate", listener: (guild: Guild, role: Role, oldRole: OldRole) => void): T;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1084,30 +1084,28 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_MEMBER_UPDATE": {
+                let user = this.client.users.get(packet.d.user.id);
+                let oldUser = null;
+                if(user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar || user.discriminator !== packet.d.user.discriminator)) {
+                    oldUser = {
+                        username: user.username,
+                        discriminator: user.discriminator,
+                        avatar: user.avatar
+                    };
+                }
                 // Check for member update if guildPresences intent isn't set, to prevent emitting twice
-                if(!(this.client.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
-                    let user = this.client.users.get(packet.d.user.id);
-                    let oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.avatar !== packet.d.user.avatar || user.discriminator !== packet.d.user.discriminator)) {
-                        oldUser = {
-                            username: user.username,
-                            discriminator: user.discriminator,
-                            avatar: user.avatar
-                        };
-                    }
-                    if(!user || oldUser) {
-                        user = this.client.users.update(packet.d.user, this.client);
-                        /**
-                        * Fired when a user's username, avatar, or discriminator changes
-                        * @event Client#userUpdate
-                        * @prop {User} user The updated user
-                        * @prop {Object?} oldUser The old user data
-                        * @prop {String} oldUser.username The username of the user
-                        * @prop {String} oldUser.discriminator The discriminator of the user
-                        * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
-                        */
-                        this.emit("userUpdate", user, oldUser);
-                    }
+                if(!(this.client.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined && (!user || oldUser)) {
+                    user = this.client.users.update(packet.d.user, this.client);
+                    /**
+                    * Fired when a user's username, avatar, or discriminator changes
+                    * @event Client#userUpdate
+                    * @prop {User} user The updated user
+                    * @prop {Object?} oldUser The old user data
+                    * @prop {String} oldUser.username The username of the user
+                    * @prop {String} oldUser.discriminator The discriminator of the user
+                    * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
+                    */
+                    this.emit("userUpdate", user, oldUser);
                 }
                 const guild = this.client.guilds.get(packet.d.guild_id);
                 if(!guild) {
@@ -1120,7 +1118,8 @@ class Shard extends EventEmitter {
                     oldMember = {
                         roles: member.roles,
                         nick: member.nick,
-                        premiumSince: member.premiumSince
+                        premiumSince: member.premiumSince,
+                        user: oldUser
                     };
                 }
                 member = guild.members.update(packet.d, guild);
@@ -1133,6 +1132,10 @@ class Shard extends EventEmitter {
                 * @prop {Array<String>} oldMember.roles An array of role IDs this member is a part of
                 * @prop {String?} oldMember.nick The server nickname of the member
                 * @prop {Number} oldMember.premiumSince Timestamp of when the member boosted the guild
+                * @prop {Object?} oldMember.user The old user data
+                * @prop {String} oldMember.user.username The username of the user
+                * @prop {String} oldMember.user.discriminator The discriminator of the user
+                * @prop {String?} oldMember.user.avatar The hash of the user's avatar, or null if no avatar
                 */
                 this.emit("guildMemberUpdate", guild, member, oldMember);
                 break;


### PR DESCRIPTION
Added a `user` attribute to OldMember of type PartialUser since the event `guildMemberUpdate` is triggered when user attributes are updated as well, meaning that sometimes there is no difference between `member` and `oldMember`