### PR TITLE
Implemented role tags

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2181,11 +2181,13 @@ declare namespace Eris {
   }
 
   export class Role extends Base {
+    botID?: string;
     color: number;
     createdAt: number;
     guild: Guild;
     hoist: boolean;
     id: string;
+    integrationID?: string;
     json: Partial<Record<Exclude<keyof Constants["Permissions"], "all" | "allGuild" | "allText" | "allVoice">, boolean>>;
     managed: boolean;
     mention: string;
@@ -2193,6 +2195,7 @@ declare namespace Eris {
     name: string;
     permissions: Permission;
     position: number;
+    premiumSubscriber: boolean;
     constructor(data: BaseData, guild: Guild);
     delete(reason?: string): Promise<void>;
     edit(options: RoleOptions, reason?: string): Promise<Role>;

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -110,13 +110,16 @@ class Role extends Base {
 
     toJSON(props = []) {
         return super.toJSON([
+            "botID",
             "color",
             "hoist",
+            "integrationID ",
             "managed",
             "mentionable",
             "name",
             "permissions",
             "position",
+            "premiumSubscriber ",
             ...props
         ]);
     }

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -5,10 +5,12 @@ const Permission = require("./Permission");
 
 /**
 * Represents a role
+* @prop {String?} botID The id of the bot this role belongs to
 * @prop {Number} color The hex color of the role in base 10
 * @prop {Number} createdAt Timestamp of the role's creation
 * @prop {Boolean} hoist Whether users with this role are hoisted in the user list or not
 * @prop {String} id The ID of the role
+* @prop {String?} integrationID The id of the integration this role belongs to
 * @prop {Object} json Generates a JSON representation of the role permissions
 * @prop {Guild} guild The guild that owns the role
 * @prop {Boolean} managed Whether a guild integration manages this role or not
@@ -17,6 +19,7 @@ const Permission = require("./Permission");
 * @prop {String} name The name of the role
 * @prop {Permission} permissions The permissions representation of the role
 * @prop {Number} position The position of the role
+* @prop {Boolean} premiumSubscriber Whether this is the guild's premium subscriber role
 */
 class Role extends Base {
     constructor(data, guild) {
@@ -46,6 +49,21 @@ class Role extends Base {
         }
         if(data.permissions !== undefined) {
             this.permissions = new Permission(data.permissions_new || data.permissions);
+        }
+        if(data.tags !== undefined) {
+            if(data.tags.bot_id !== undefined) {
+                this.botID = data.tags.bot_id;
+            }
+            if(data.tags.integration_id !== undefined) {
+                this.integrationID = data.tags.integration_id;
+            }
+            if(data.tags.premium_subscriber !== undefined) {
+                this.premiumSubscriber = true;
+            } else {
+                this.premiumSubscriber = false;
+            }
+        } else {
+            this.premiumSubscriber = false;
         }
     }
 

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -113,7 +113,7 @@ class Role extends Base {
             "botID",
             "color",
             "hoist",
-            "integrationID ",
+            "integrationID",
             "managed",
             "mentionable",
             "name",

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -119,7 +119,7 @@ class Role extends Base {
             "name",
             "permissions",
             "position",
-            "premiumSubscriber ",
+            "premiumSubscriber",
             ...props
         ]);
     }


### PR DESCRIPTION
Implemented [role tags](https://discord.com/developers/docs/topics/permissions#role-object-role-tags-structure) into the Role class as attributes `botID`, `integrationID` and `premiumSubscriber`.
- Converted the premiumSubscriber to a boolean which makes more sense than keeping it as null type