### PR TITLE
Remove checking of "nsfw" and "nsfw-" in channel name.

### DIFF
--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -41,7 +41,7 @@ class GuildChannel extends Channel {
         if(data.parent_id !== undefined) {
             this.parentID = data.parent_id;
         }
-        this.nsfw = (this.name.length === 4 ? this.name === "nsfw" : this.name.startsWith("nsfw-")) || data.nsfw;
+        this.nsfw = data.nsfw;
         if(data.permission_overwrites) {
             this.permissionOverwrites = new Collection(PermissionOverwrite);
             data.permission_overwrites.forEach((overwrite) => {


### PR DESCRIPTION
The rest api says that channels with the name "nsfw", and that start with "nsfw-" are not nsfw. This legacy behavior should be removed, as there is no reasonable way for bots to legitimately tell if a channel is nsfw if it has either of these naming conventions.

[example rest response](https://butts-are.cool/2020-12-20_1-1-59.596.png)

The channel is named "nsfw-testing", and is not nsfw. The api reports this correctly, while Eris says the channel is nsfw. This allows many bots nsfw command checks to be completely bypassed and ran in channels that are not actually marked nsfw.