### PR TITLE
Added attachment image properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -708,6 +708,8 @@ declare namespace Eris {
     proxy_url: string;
     size: number;
     url: string;
+    height?: number;
+    width?: number;
   }
   interface MessageActivity {
     party_id?: string;


### PR DESCRIPTION
Added `height` and `width` properties to the `Attachment` interface.
[Discord documentation reference](https://discord.com/developers/docs/resources/channel#attachment-object-attachment-structure)