### PR TITLE
Added stickers to messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -732,6 +732,16 @@ declare namespace Eris {
     guildID?: string;
     messageID?: string;
   }
+  interface Sticker {
+    id: string;
+    pack_id: string;
+    name: string;
+    description: string;
+    tags?: string;
+    asset: string;
+    preview_asset: string;
+    format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]]
+  }
 
   // Presence
   interface Activity extends ActivityPartial<ActivityType> {
@@ -1051,6 +1061,11 @@ declare namespace Eris {
       allVoice: 871367441;
     };
     REST_VERSION: 7;
+    StickerFormats: {
+      PNG: 1,
+      APNG: 2,
+      LOTTIE: 3
+    }
     SystemJoinMessages: [
       "%user% joined the party.",
       "%user% is here.",
@@ -2049,6 +2064,7 @@ declare namespace Eris {
     reactions: { [s: string]: { count: number; me: boolean } };
     referencedMessage?: Message | null;
     roleMentions: string[];
+    stickers?: Sticker[];
     timestamp: number;
     tts: boolean;
     type: number;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -36,6 +36,7 @@ const User = require("./User");
 * @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
 * @prop {Message?} referencedMessage The message that was replied to. If undefined, message data was not received. If null, the message was deleted.
 * @prop {Array<String>} roleMentions Array of mentioned roles' ids
+* @prop {Array<Object>?} stickers The stickers sent with the message (bots currently can only receive messages with stickers, not send)
 * @prop {Number} timestamp Timestamp of message creation
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Number} type The type of the message
@@ -242,7 +243,9 @@ class Message extends Base {
         if(data.application !== undefined) {
             this.application = data.application;
         }
-
+        if(data.stickers !== undefined) {
+            this.stickers = data.stickers;
+        }
         if(data.reactions) {
             data.reactions.forEach((reaction) => {
                 this.reactions[reaction.emoji.id ? `${reaction.emoji.name}:${reaction.emoji.id}` : reaction.emoji.name] = {


### PR DESCRIPTION
Add `stickers` property to `Message` and a `Sticker` interface.

[Discord documentation - Message](https://discord.com/developers/docs/resources/channel#message-object-message-structure)
[Discord documentation - Sticker](https://discord.com/developers/docs/resources/channel#message-object-message-sticker-structure)