### PR TITLE
Include never on Message#crosspost in Promise

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2048,7 +2048,7 @@ declare namespace Eris {
     addReaction(reaction: string): Promise<void>;
     /** @deprecated */
     addReaction(reaction: string, userID: string): Promise<void>;
-    crosspost(): T extends NewsChannel ? Promise<Message<NewsChannel>> : never;
+    crosspost(): Promise<T extends NewsChannel ? Message<NewsChannel> : never>;
     delete(reason?: string): Promise<void>;
     edit(content: MessageContent): Promise<Message<T>>;
     editWebhook(token: string, options: MessageWebhookContent): Promise<Message<T>>;


### PR DESCRIPTION
The never should be wrapped in the promise, since it still returns a promise when called on a non-news channel message.