### PR TITLE
Added flags property to OldMessage

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -394,6 +394,7 @@ declare namespace Eris {
     content: string;
     editedTimestamp?: number;
     embeds: Embed[];
+    flags: Number;
     mentionedBy?: unknown;
     mentions: string[];
     pinned: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -394,7 +394,7 @@ declare namespace Eris {
     content: string;
     editedTimestamp?: number;
     embeds: Embed[];
-    flags: Number;
+    flags: number;
     mentionedBy?: unknown;
     mentions: string[];
     pinned: boolean;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -844,6 +844,7 @@ class Shard extends EventEmitter {
                         content: message.content,
                         editedTimestamp: message.editedTimestamp,
                         embeds: message.embeds,
+                        flags: message.flags,
                         mentionedBy: message.mentionedBy,
                         mentions: message.mentions,
                         pinned: message.pinned,
@@ -865,6 +866,7 @@ class Shard extends EventEmitter {
                 * @prop {String} oldMessage.content Message content
                 * @prop {Number} oldMessage.editedTimestamp Timestamp of latest message edit
                 * @prop {Array<Object>} oldMessage.embeds Array of embeds
+                * @prop {Number} oldMessage.flags Old message flags (see constants)
                 * @prop {Object} oldMessage.mentionedBy Object of if different things mention the bot user
                 * @prop {Array<String>} oldMessage.mentions Array of mentioned users' ids
                 * @prop {Boolean} oldMessage.pinned Whether the message was pinned or not


### PR DESCRIPTION
flags can change according to [Discord documentation](https://discord.com/developers/docs/resources/channel#edit-message) but are not included on OldMessage so I added them.