### PR TITLE
Remove deprecated markers on non-deprecated removeReaction

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1559,7 +1559,6 @@ declare namespace Eris {
     ): Promise<number>;
     removeGroupRecipient(groupID: string, userID: string): Promise<void>;
     removeGuildMemberRole(guildID: string, memberID: string, roleID: string, reason?: string): Promise<void>;
-    /** @deprecated */
     removeMessageReaction(channelID: string, messageID: string, reaction: string, userID: string): Promise<void>;
     removeMessageReaction(channelID: string, messageID: string, reaction: string): Promise<void>;
     removeMessageReactionEmoji(channelID: string, messageID: string, reaction: string): Promise<void>;
@@ -2319,7 +2318,6 @@ declare namespace Eris {
     getWebhooks(): Promise<Webhook[]>;
     pinMessage(messageID: string): Promise<void>;
     purge(limit: number, filter?: (message: Message<TextChannel>) => boolean, before?: string, after?: string, reason?: string): Promise<number>;
-    /** @deprecated */
     removeMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string): Promise<void>;
     removeMessageReactionEmoji(messageID: string, reaction: string): Promise<void>;


### PR DESCRIPTION
According to the documentation, using removeReaction with a user ID is not deprecated everywhere (thankfully!) but the typings reflect otherwise, since all available methods are marked as deprecated.

I looked through the typings and removed the deprecated annotations on methods that aren't documented as deprecated in the source code. I left the ones actually documented as deprecated with the annotation.