### PR TITLE
fix replies in dm channels

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -83,7 +83,7 @@ class Message extends Base {
                 ? this._client.guilds.get(data.referenced_message.guild_id).channels.get(data.referenced_message.channel_id)
                 : this._client.privateChannels.get(data.referenced_message.channel_id);
             if(channel) {
-                this.referencedMessage = channel.messages.update(data.referenced_message);
+                this.referencedMessage = channel.messages.update(data.referenced_message, this._client);
             } else {
                 this.referencedMessage = new Message(data.referenced_message, this._client);
             }


### PR DESCRIPTION
the client was not being passed to `channel.messages.update` which caused crashes on `messageCreate` events in DM channels if the message was a reply
![image](https://user-images.githubusercontent.com/57028336/103351815-221f1180-4af0-11eb-8390-c3d11e428c64.png)
