### PR TITLE
Corrected some typings.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2358,14 +2358,13 @@ declare namespace Eris {
     editNote(note: string): Promise<void>;
     getDMChannel(): Promise<PrivateChannel>;
     getProfile(): Promise<UserProfile>;
-
     removeRelationship(): Promise<void>;
   }
 
   export class VoiceChannel extends GuildChannel implements Invitable {
-    bitrate?: number;
+    bitrate: number;
     type: 2;
-    userLimit?: number;
+    userLimit: number;
     voiceMembers: Collection<Member>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
     getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
@@ -2417,7 +2416,7 @@ declare namespace Eris {
   }
 
   export class VoiceState extends Base {
-    channelID?: string;
+    channelID: string | null;
     createdAt: number;
     deaf: boolean;
     id: string;
@@ -2425,9 +2424,8 @@ declare namespace Eris {
     selfDeaf: boolean;
     selfMute: boolean;
     selfStream: boolean;
-    sessionID?: string;
+    sessionID: string | null;
     suppress: boolean;
-
     constructor(data: BaseData);
   }
 }


### PR DESCRIPTION
VoiceState `channelID` and `sessionID` were both marked as `channelID?: string;` which is equivalent to `channelID: string | undefined;` when they should be marked as `channelID: string | null;`.

VoiceChannel `bitrate` and `userLimit` where both marked as possibly undefined when neither should be.