### PR TITLE
Add competing status in types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,7 @@ declare namespace Eris {
 
   // Presence/Relationship
   type ActivityType = BotActivityType | 4;
-  type BotActivityType = 0 | 1 | 2 | 3;
+  type BotActivityType = 0 | 1 | 2 | 3 | 5;
   type FriendSuggestionReasons = { name: string; platform_type: string; type: number }[];
   type Status = "online" | "idle" | "dnd" | "offline";
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1281,7 +1281,7 @@ class Client extends EventEmitter {
     * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
     * @arg {Object} [game] Sets the bot's active game, null to clear
     * @arg {String} game.name Sets the name of the bot's active game
-    * @arg {Number} [game.type] The type of game. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching
+    * @arg {Number} [game.type] The type of game. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
     * @arg {String} [game.url] Sets the url of the shard's active game
     */
     editStatus(status, game) {


### PR DESCRIPTION
This adds type 5 in `BotActivityType` which is the status prefixed with "Competing in".
Both #1071 and #1072 had these changes, but they were closed for some reason by the author.