### PR TITLE
More accurate typings. (Message class and Emoji interface)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1934,10 +1934,10 @@ declare namespace Eris {
     editedTimestamp?: number;
     embeds: Embed[];
     flags: number;
-    guildID: T extends GuildChannel ? string : undefined;
+    guildID: T extends GuildTextable ? string : undefined;
     id: string;
     jumpLink: string;
-    member: T extends GuildChannel ? Member : null;
+    member: T extends GuildTextable ? Member : null;
     mentionEveryone: boolean;
     mentions: User[];
     messageReference: MessageReference | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1937,7 +1937,7 @@ declare namespace Eris {
     guildID: T extends GuildChannel ? string : undefined;
     id: string;
     jumpLink: string;
-    member: T extends GuildChannel ? Member : Member | null;
+    member: T extends GuildChannel ? Member : null;
     mentionEveryone: boolean;
     mentions: User[];
     messageReference: MessageReference | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1934,10 +1934,10 @@ declare namespace Eris {
     editedTimestamp?: number;
     embeds: Embed[];
     flags: number;
-    guildID?: string;
+    guildID: T extends GuildChannel ? string : undefined;
     id: string;
     jumpLink: string;
-    member: Member | null;
+    member: T extends GuildChannel ? Member : Member | null;
     mentionEveryone: boolean;
     mentions: User[];
     messageReference: MessageReference | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -315,11 +315,12 @@ declare namespace Eris {
   // Emoji
   interface Emoji extends EmojiBase {
     animated: boolean;
+    available: boolean;
     id: string;
     managed: boolean;
     require_colons: boolean;
     roles: string[];
-    user: PartialUser;
+    user?: PartialUser;
   }
   interface EmojiBase {
     icon?: string;


### PR DESCRIPTION
Before:
```ts
let message: Message;
let member = message.member; // This is Member | null.
let guildID = message.guildID; // This is string | undefined.
if (message.channel instanceof TextChannel) {
    message = message as Message<TextChannel>; // Have to do this, but it is safe to do so.
    member = member as Member; // member is still treated as Member | null without this.
    guildID = guildID as string; // guildID is still treated as string | undefined without this.
} else {
    member = member as null; // member is still treated as Member | null without this.
    guildID = guildID as undefined; // guildID is still treated as string | undefined without this.
}
```
After:
```ts
let message: Messaage;
const member = message.member; // This is Member | null.
const guildID = message.guildID; // This is string | undefined.
if (message.channel instanceof TextChannel) {
    message = message as Message<TextChannel>; // Still have to do this, but it is still safe to do so.
    // member is now treated as Member automatically.
    // guildID is now treated as string automatically.
} else {
    // member is now treated as null automatically.
    // guildID is now treated as undefined automatically.
}
```


On an unrelated note, `Message#addReaction(reaction: string, userID: string): Promise<void>;` and `Message#removeReaction(reaction: string, userID: string): Promise<void>;` (and all equivalent methods where usedID is one of the parameters) are both marked at deprecated for all messages. Reading the previous commits, unless I've missed something, it looks like these should only be deprecated for messages in private channels, rather than for every message.
Could someone let me know if this is the case, or if I have missed something somewhere.