### PR TITLE
Assign default rest options within Client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -182,7 +182,7 @@ declare namespace Eris {
     messageLimit?: number;
     opusOnly?: boolean;
     /** @deprecated */
-    rateLimiterOffset?: number;
+    ratelimiterOffset?: number;
     /** @deprecated */
     requestTimeout?: number;
     reconnectDelay?: ReconnectDelayFunction;
@@ -197,7 +197,7 @@ declare namespace Eris {
     disableLatencyCompensation?: boolean;
     domain?: string;
     latencyThreshold?: number;
-    rateLimiterOffset?: number;
+    ratelimiterOffset?: number;
     requestTimeout?: number;
   }
   interface CommandClientOptions {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -491,7 +491,7 @@ class Shard extends EventEmitter {
             timeout: setTimeout(() => {
                 res(this.requestMembersPromise[opts.nonce].members);
                 delete this.requestMembersPromise[opts.nonce];
-            }, (options && options.timeout) || (this.client.options.rest && this.client.options.rest.requestTimeout) || this.client.options.requestTimeout)
+            }, (options && options.timeout) || this.client.options.rest.requestTimeout || this.client.options.requestTimeout)
         });
     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -491,7 +491,7 @@ class Shard extends EventEmitter {
             timeout: setTimeout(() => {
                 res(this.requestMembersPromise[opts.nonce].members);
                 delete this.requestMembersPromise[opts.nonce];
-            }, (options && options.timeout) || this.client.options.requestTimeout)
+            }, (options && options.timeout) || (this.client.options.rest && this.client.options.rest.requestTimeout) || this.client.options.requestTimeout)
         });
     }
 

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -21,12 +21,13 @@ class RequestHandler {
                 forceQueueing: options
             };
         }
-        this.options = options = Object.assign({
+
+        this.options = client.options.rest = Object.assign({
             agent: client.options.agent || null,
             baseURL: Endpoints.BASE_URL,
             disableLatencyCompensation: false,
             domain: "discord.com",
-            latencyThreshold: 30000,
+            latencyThreshold: client.options.latencyThreshold || 30000,
             ratelimiterOffset: client.options.ratelimiterOffset || 0,
             requestTimeout: client.options.requestTimeout || 15000
         }, options);
@@ -37,7 +38,7 @@ class RequestHandler {
         this.ratelimits = {};
         this.latencyRef = {
             latency: 500,
-            offset: options.ratelimiterOffset,
+            offset: this.options.ratelimiterOffset,
             raw: new Array(10).fill(500),
             timeOffset: 0,
             timeOffsets: new Array(10).fill(0),


### PR DESCRIPTION
The default properties for the new `rest` options get defined in the Request Handler and doesn't change the actual `client.options` object. The [requestGuildMembers](https://github.com/abalabahaha/eris/blob/dev/index.d.ts#L2295) function still tries to use this object, so that won't work properly for the user unless they manually define a timeout (it doesn't return the Array of members found).

I left the default options in the RequestHandler file because I wasn't sure if they were there for a reason, I can move them to Client.js if you think that's necessary.