### PR TITLE
Fix decode error when using sodium-native

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -516,8 +516,8 @@ class VoiceConnection extends EventEmitter {
             msg.copy(nonce, 0, 0, 12);
             let data;
             if(!NaCl) {
-                data = Buffer.allocUnsafe(msg.length - 12 - Sodium.crypto_secretbox_MACBYTES);
-                Sodium.crypto_secretbox_open_easy(data, msg.subarray(12), this.nonce, this.secret);
+                data = Buffer.alloc(msg.length - 12 - Sodium.crypto_secretbox_MACBYTES);
+                Sodium.crypto_secretbox_open_easy(data, msg.subarray(12), nonce, this.secret);
             } else {
                 if(!(data = NaCl.secretbox.open(msg.subarray(12), nonce, this.secret))) {
                     /**


### PR DESCRIPTION
This PR fixes the decode error when recording voice with the optional lib sodium-native installed
![image](https://user-images.githubusercontent.com/66310990/113327209-91d0b280-9312-11eb-8742-89dd3c226385.png)
