### PR TITLE
Add `interaction` prop to Messages

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -51,6 +51,7 @@ declare namespace Eris {
   type ImageFormat = "jpg" | "jpeg" | "png" | "gif" | "webp";
   type MessageContent = string | AdvancedMessageContent;
   type PossiblyUncachedMessage = Message | { channel: TextableChannel | { id: string; guild?: { id: string } }; guildID?: string; id: string };
+  type InteractionType = 1 | 2;
 
   // Permission
   type PermissionType = "role" | "member";
@@ -796,6 +797,13 @@ declare namespace Eris {
     asset: string;
     preview_asset?: string;
     format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
+  }
+  interface MessageInteraction {
+    id: string;
+    type: InteractionType;
+    name: string;
+    user: User;
+    member?: Member;
   }
 
   // Presence
@@ -2124,6 +2132,7 @@ declare namespace Eris {
     referencedMessage?: Message | null;
     roleMentions: string[];
     stickers?: Sticker[];
+    interaction?: MessageInteraction;
     timestamp: number;
     tts: boolean;
     type: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2132,7 +2132,7 @@ declare namespace Eris {
     referencedMessage?: Message | null;
     roleMentions: string[];
     stickers?: Sticker[];
-    interaction?: MessageInteraction;
+    interaction: MessageInteraction | null;
     timestamp: number;
     tts: boolean;
     type: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -803,7 +803,7 @@ declare namespace Eris {
     type: InteractionType;
     name: string;
     user: User;
-    member?: Member;
+    member: Member | null;
   }
 
   // Presence

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -95,7 +95,11 @@ class Message extends Base {
             this.referencedMessage = data.referenced_message;
         }
         if(data.interaction) {
-            this.interaction = data.interaction;
+            this.interaction = {
+                id: data.interaction.id,
+                type: data.interaction.type,
+                name: data.interaction.name
+            };
             if(data.interaction.user.discriminator !== "0000") {
                 this.interaction.user = client.users.update(data.interaction.user, client);
             } else {
@@ -103,7 +107,7 @@ class Message extends Base {
             }
             if(data.interaction.member) {
                 data.interaction.member.id = data.interaction.user.id;
-                data.interaction.member = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
+                this.interaction.member = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
             } else if(this.channel.guild && this.channel.guild.members.has(data.interaction.user.id)) {
                 this.interaction.member = this.channel.guild.members.get(data.interaction.user.id);
             } else {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -33,7 +33,7 @@ const User = require("./User");
 * @prop {String?} messageReference.guildID The id of the guild this message was crossposted from
 * @prop {Object?} interaction An object containing the interaction for the original message if it has been created by an interaction
 * @prop {String} interaction.id The id of the interaction the message was created from
-* @prop {String} interaction.type The type of interaction the message was created from
+* @prop {Number} interaction.type The type of interaction the message was created from
 * @prop {User} interaction.user The user who invoked the interaction the message was created from
 * @prop {Member?} interaction.member The member who invoked the interaction the message was created from
 * @prop {Boolean} pinned Whether the message is pinned or not

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -31,6 +31,11 @@ const User = require("./User");
 * @prop {String?} messageReference.messageID The id of the original message this message was crossposted from
 * @prop {String} messageReference.channelID The id of the channel this message was crossposted from
 * @prop {String?} messageReference.guildID The id of the guild this message was crossposted from
+* @prop {Object?} interaction An object containing the interaction for the original message if it has been created by an interaction
+* @prop {String} interaction.id The id of the interaction the message was created from
+* @prop {String} interaction.type The type of interaction the message was created from
+* @prop {User} interaction.user The user who invoked the interaction the message was created from
+* @prop {Member?} interaction.member The member who invoked the interaction the message was created from
 * @prop {Boolean} pinned Whether the message is pinned or not
 * @prop {String?} prefix The prefix used in the Message, if any (CommandClient only)
 * @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
@@ -88,6 +93,24 @@ class Message extends Base {
             }
         } else {
             this.referencedMessage = data.referenced_message;
+        }
+        if(data.interaction) {
+            this.interaction = data.interaction;
+            if(data.interaction.user.discriminator !== "0000") {
+                this.interaction.user = client.users.update(data.interaction.user, client);
+            } else {
+                this.interaction.user = new User(data.interaction.user, client);
+            }
+            if(data.interaction.member) {
+                data.interaction.member.id = data.interaction.user.id;
+                data.interaction.member = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
+            } else if(this.channel.guild && this.channel.guild.members.has(data.interaction.user.id)) {
+                this.interaction.member = this.channel.guild.members.get(data.interaction.user.id);
+            } else {
+                this.interaction.member = null;
+            }
+        } else {
+            this.interaction = null;
         }
         if(this.channel.guild) {
             if(data.member) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -31,11 +31,11 @@ const User = require("./User");
 * @prop {String?} messageReference.messageID The id of the original message this message was crossposted from
 * @prop {String} messageReference.channelID The id of the channel this message was crossposted from
 * @prop {String?} messageReference.guildID The id of the guild this message was crossposted from
-* @prop {Object?} interaction An object containing the interaction for the original message if it has been created by an interaction
-* @prop {String} interaction.id The id of the interaction the message was created from
-* @prop {Number} interaction.type The type of interaction the message was created from
-* @prop {User} interaction.user The user who invoked the interaction the message was created from
-* @prop {Member?} interaction.member The member who invoked the interaction the message was created from
+* @prop {Object?} interaction An object containing info about the interaction the message is responding to, if applicable
+* @prop {String} interaction.id The id of the interaction
+* @prop {Number} interaction.type The type of interaction
+* @prop {User} interaction.user The user who invoked the interaction
+* @prop {Member?} interaction.member The member who invoked the interaction
 * @prop {Boolean} pinned Whether the message is pinned or not
 * @prop {String?} prefix The prefix used in the Message, if any (CommandClient only)
 * @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -95,24 +95,27 @@ class Message extends Base {
             this.referencedMessage = data.referenced_message;
         }
         if(data.interaction) {
-            this.interaction = {
-                id: data.interaction.id,
-                type: data.interaction.type,
-                name: data.interaction.name
-            };
+            let interactionUser, interactionMember;
             if(data.interaction.user.discriminator !== "0000") {
-                this.interaction.user = client.users.update(data.interaction.user, client);
+                interactionUser = client.users.update(data.interaction.user, client);
             } else {
-                this.interaction.user = new User(data.interaction.user, client);
+                interactionUser = new User(data.interaction.user, client);
             }
             if(data.interaction.member) {
                 data.interaction.member.id = data.interaction.user.id;
-                this.interaction.member = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
+                interactionMember = this.channel.guild.members.update(data.interaction.member, this.channel.guild);
             } else if(this.channel.guild && this.channel.guild.members.has(data.interaction.user.id)) {
-                this.interaction.member = this.channel.guild.members.get(data.interaction.user.id);
+                interactionMember = this.channel.guild.members.get(data.interaction.user.id);
             } else {
-                this.interaction.member = null;
+                interactionMember = null;
             }
+            this.interaction = {
+                id: data.interaction.id,
+                type: data.interaction.type,
+                name: data.interaction.name,
+                user: interactionUser,
+                member: interactionMember
+            };
         } else {
             this.interaction = null;
         }


### PR DESCRIPTION
Towards the end of the [Message object structure](https://discord.com/developers/docs/resources/channel#message-object-message-structure) there is an `interaction` prop for messages that are created for interactions. There is also an undocumented `member` property inside of a [MessageInteraction](https://discord.com/developers/docs/interactions/slash-commands#messageinteraction) that only shows up when the message is created in gateway.