### PR TITLE
typings: Fix OAuthTeamInfo#members

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -941,7 +941,7 @@ declare namespace Eris {
   interface OAuthTeamInfo {
     icon: string | null;
     id: string;
-    members: OAuthTeamMember;
+    members: OAuthTeamMember[];
     owner_user_id: string;
   }
   interface OAuthTeamMember {


### PR DESCRIPTION
Dev teams have arrays of members, not just a single member.