### PR TITLE
Better handling of rate limits

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -401,9 +401,7 @@ class RequestHandler {
         if(method === "DELETE" && route.endsWith("/messages/:id")) { // Delete Messsage endpoint has its own ratelimit
             const messageID = url.replace(/\/channels\/\d+\/messages\//, "");
             const diff = Date.now() - this.latencyRef.offset - (Math.floor(messageID / 4194304) + 1420070400000);
-            if(diff < 10000) {
-                method += "_NEW";
-            } else if(diff >= 1209600000) {
+            if(diff >= 1209600000) {
                 method += "_OLD";
             }
 

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -399,6 +399,14 @@ class RequestHandler {
             return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
         }).replace(/\/reactions\/[^/]+/g, "/reactions/:id").replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
         if(method === "DELETE" && route.endsWith("/messages/:id")) { // Delete Messsage endpoint has its own ratelimit
+            const messageID = url.replace(/\/channels\/\d+\/messages\//, "");
+            const diff = Date.now() - this.latencyRef.offset - (Math.floor(messageID / 4194304) + 1420070400000);
+            if(diff < 10000) {
+                method += "_NEW";
+            } else if(diff >= 1209600000) {
+                method += "_OLD";
+            }
+
             route = method + route;
         }
         return route;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -409,6 +409,9 @@ class RequestHandler {
 
             route = method + route;
         }
+        if((method === "PUT" || method === "DELETE") && route.includes("/reactions/")) {
+            route = route.replace(/\/reactions\/.+/, "/reactions");
+        }
         return route;
     }
 


### PR DESCRIPTION
~~- Deleting messages younger than 10 seconds have no rate limit~~ apparently it existed before? discord/discord-api-docs#1092
- Deleting messages younger than 2 weeks have a rate limit of 3 per 1 second
- Deleting all other messages have a rate limit of 30 per 120 seconds
- PUT/DELETE reaction endpoints share the same rate limit bucket, fixes #1138