### PR TITLE
Fix voice server update endpoint handling

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -115,6 +115,7 @@ class VoiceConnection extends EventEmitter {
         this.sequence = 0;
         this.timestamp = 0;
         this.ssrcUserMap = {};
+        this.connectionTimeout = null;
 
         this.nonce = Buffer.alloc(24);
 
@@ -147,27 +148,26 @@ class VoiceConnection extends EventEmitter {
     }
 
     connect(data) {
-        if(this.connecting) {
-            return;
-        }
         this.connecting = true;
         if(this.ws && this.ws.readyState !== WebSocket.CLOSED) {
             this.disconnect(undefined, true);
             return setTimeout(() => this.connect(data), 500);
         }
-        if(!data.endpoint || !data.token || !data.session_id || !data.user_id) {
+        clearTimeout(this.connectionTimeout);
+        this.connectionTimeout = setTimeout(() => {
+            if(this.connecting) {
+                this.disconnect(new Error("Voice connection timeout"));
+            }
+            this.connectionTimeout = null;
+        }, this.shard.client ? this.shard.client.options.connectionTimeout : 30000);
+        if(!data.endpoint) return; // Endpoint null, wait next update.
+        if(!data.token || !data.session_id || !data.user_id) {
             this.disconnect(new Error("Malformed voice server update: " + JSON.stringify(data)));
             return;
         }
         this.channelID = data.channel_id;
         this.endpoint = data.endpoint.split(":")[0];
         this.ws = new WebSocket("wss://" + this.endpoint);
-        let connectionTimeout = setTimeout(() => {
-            if(this.connecting) {
-                this.disconnect(new Error("Voice connection timeout"));
-            }
-            connectionTimeout = null;
-        }, this.shard.client ? this.shard.client.options.connectionTimeout : 30000);
         /**
         * Fired when stuff happens and gives more info
         * @event VoiceConnection#debug
@@ -180,9 +180,9 @@ class VoiceConnection extends EventEmitter {
             * @event VoiceConnection#connect
             */
             this.emit("connect");
-            if(connectionTimeout) {
-                clearTimeout(connectionTimeout);
-                connectionTimeout = null;
+            if(this.connectionTimeout) {
+                clearTimeout(this.connectionTimeout);
+                this.connectionTimeout = null;
             }
             this.sendWS(VoiceOPCodes.IDENTIFY, {
                 server_id: this.id === "call" ? data.channel_id : this.id,


### PR DESCRIPTION
Discord sometime send null endpoint on waiting assign voice server then send real endpoint later.

![](https://cdn.discordapp.com/attachments/831501554795151363/831503089407885322/unknown.png)