### PR TITLE
Workaround voice disconnect at switch channel

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -115,6 +115,7 @@ class VoiceConnection extends EventEmitter {
         this.sequence = 0;
         this.timestamp = 0;
         this.ssrcUserMap = {};
+        this.disconnectTimeout;
 
         this.nonce = Buffer.alloc(24);
 
@@ -154,6 +155,10 @@ class VoiceConnection extends EventEmitter {
         if(this.ws && this.ws.readyState !== WebSocket.CLOSED) {
             this.disconnect(undefined, true);
             return setTimeout(() => this.connect(data), 500);
+        }
+        if(this.disconnectTimeout) {
+            clearTimeout(this.disconnectTimeout); // receive new geteway, cancel disconnect clean up.
+            this.disconnectTimeout = null;
         }
         if(!data.endpoint || !data.token || !data.session_id || !data.user_id) {
             this.disconnect(new Error("Malformed voice server update: " + JSON.stringify(data)));
@@ -356,11 +361,7 @@ class VoiceConnection extends EventEmitter {
         this.timestamp = 0;
         this.sequence = 0;
 
-        if(reconnecting) {
-            this.pause();
-        } else {
-            this.stopPlaying();
-        }
+        this.pause();
         if(this.heartbeatInterval) {
             clearInterval(this.heartbeatInterval);
             this.heartbeatInterval = null;
@@ -388,14 +389,22 @@ class VoiceConnection extends EventEmitter {
                 this.emit("error", error);
             }
         } else {
-            this.channelID = null;
-            this.updateVoiceState();
-            /**
-            * Fired when the voice connection disconnects
-            * @event VoiceConnection#disconnect
-            * @prop {Error?} error The error, if any
-            */
-            this.emit("disconnect", error);
+            // Wait 5s for VOICE_SERVER_UPDATE before clean up.
+            // We don't know disconnect is kicked or just switch server.
+            // Workaround https://github.com/discord/discord-api-docs/issues/2450
+            this.disconnectTimeout = setTimeout(() => {
+                if(!this.ws && !this.connecting) {
+                    this.stopPlaying();
+                    this.channelID = null;
+                    this.updateVoiceState();
+                    /**
+                    * Fired when the voice connection disconnects
+                    * @event VoiceConnection#disconnect
+                    * @prop {Error?} error The error, if any
+                    */
+                    this.emit("disconnect", error);
+                }
+            }, 5000);
         }
     }
 

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -404,7 +404,7 @@ class VoiceConnection extends EventEmitter {
                     */
                     this.emit("disconnect", error);
                 }
-            }, 5000);
+            }, this.shard.client ? this.shard.client.options.connectionTimeout : 30000);
         }
     }
 

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -115,7 +115,7 @@ class VoiceConnection extends EventEmitter {
         this.sequence = 0;
         this.timestamp = 0;
         this.ssrcUserMap = {};
-        this.disconnectTimeout;
+        this.disconnectTimeout = null;
 
         this.nonce = Buffer.alloc(24);
 


### PR DESCRIPTION
Discord using same close code on kick and change voice server (switch channel will change voice server).
We need wait `VOICE_SERVER_UPDATE` to know it is kick or change voice server.

This will fix 4014 and 4006 cause connection disconnect but will cause `disconnect` event delay 5s.

Workaround https://github.com/discord/discord-api-docs/issues/2450