### PR TITLE
Remove Sticker preview_asset typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -807,7 +807,6 @@ declare namespace Eris {
     id: string;
     name: string;
     pack_id: string;
-    preview_asset?: string;
     tags?: string;
   }
   interface MessageInteraction {


### PR DESCRIPTION
Apparently the prop was never sent even though it was marked as guaranteed nullable string (not optional) as mentioned in discord/discord-api-docs#2815 and was undocumented in discord/discord-api-docs@b9b8db2ed548dded2a50824a68ea638d735737c6