### PR TITLE
Move to content.messageReference

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -48,7 +48,7 @@ declare namespace Eris {
     content?: string;
     embed?: EmbedOptions;
     flags?: number;
-    messageReference?: string | MessageReferenceReply;
+    messageReference?: MessageReferenceReply;
     /** @deprecated */
     messageReferenceID?: string;
     tts?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -48,6 +48,8 @@ declare namespace Eris {
     content?: string;
     embed?: EmbedOptions;
     flags?: number;
+    messageReference?: string | MessageReferenceReply;
+    /** @deprecated */
     messageReferenceID?: string;
     tts?: boolean;
   };
@@ -802,6 +804,10 @@ declare namespace Eris {
     channelID?: string;
     guildID?: string;
     messageID?: string;
+  }
+  interface MessageReferenceReply extends MessageReferenceBase {
+    messageID: string;
+    failIfNotExists?: boolean;
   }
   interface Sticker {
     asset: string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -581,12 +581,12 @@ class Client extends EventEmitter {
     * @arg {Boolean} [content.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to.
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
-    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
-    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
-    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
-    * @arg {String} content.messageReference.messageID The message ID of the referenced message
-    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
+    * @arg {Object} [content.messageReference] The message reference, used when replying to messages
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. Use `messageReference` instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object | Array<Object>} [file] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -606,15 +606,22 @@ class Client extends EventEmitter {
             }
             content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             if(content.messageReference) {
-                if(typeof content.messageReference === "string") {
-                    content.message_reference = {message_id: content.messageReference};
-                } else {
-                    content.message_reference = {
-                        message_id: content.messageReference.messageID,
-                        channel_id: content.messageReference.channelID,
-                        guild_id: content.messageReference.guildID,
-                        fail_if_not_exists: content.messageReference.failIfNotExists
-                    };
+                content.message_reference = content.messageReference;
+                if(content.messageReference.messageID !== undefined) {
+                    content.message_reference.message_id = content.messageReference.messageID;
+                    content.messageReference.messageID = undefined;
+                }
+                if(content.messageReference.channelID !== undefined) {
+                    content.message_reference.channel_id = content.messageReference.channelID;
+                    content.messageReference.channelID = undefined;
+                }
+                if(content.messageReference.guildID !== undefined) {
+                    content.message_reference.guild_id = content.messageReference.guildID;
+                    content.messageReference.guildID = undefined;
+                }
+                if(content.messageReference.failIfNotExists !== undefined) {
+                    content.message_reference.fail_if_not_exists = content.messageReference.failIfNotExists;
+                    content.messageReference.failIfNotExists = undefined;
                 }
             } else if(content.messageReferenceID) {
                 this.emit("warn", "[DEPRECATED] content.messageReferenceID is deprecated. Use content.messageReference instead");

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -581,7 +581,12 @@ class Client extends EventEmitter {
     * @arg {Boolean} [content.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to.
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String} [content.messageReferenceID] The ID of the message should be replied to. The reference message cannot be a system message.
+    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object | Array<Object>} [file] A file object (or an Array of them)
     * @arg {Buffer} file.file A buffer containing file data
@@ -600,7 +605,19 @@ class Client extends EventEmitter {
                 return Promise.reject(new Error("No content, file, or embed"));
             }
             content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
-            if(content.messageReferenceID) {
+            if(content.messageReference) {
+                if(typeof content.messageReference === "string") {
+                    content.message_reference = {message_id: content.messageReference};
+                } else {
+                    content.message_reference = {
+                        message_id: content.messageReference.messageID,
+                        channel_id: content.messageReference.channelID,
+                        guild_id: content.messageReference.guildID,
+                        fail_if_not_exists: content.messageReference.failIfNotExists
+                    };
+                }
+            } else if(content.messageReferenceID) {
+                this.emit("warn", "[DEPRECATED] content.messageReferenceID is deprecated. Use content.messageReference instead");
                 content.message_reference = {message_id: content.messageReferenceID};
             }
         } else if(!file) {

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -48,12 +48,12 @@ class PrivateChannel extends Channel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
-    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
-    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
-    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
-    * @arg {String} content.messageReference.messageID The message ID of the referenced message
-    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
+    * @arg {Object} [content.messageReference] The message reference, used when replying to messages
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. Use `messageReference` instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -48,7 +48,12 @@ class PrivateChannel extends Channel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String} [content.messageReferenceID] The ID of the message should be replied to. The reference message cannot be a system message.
+    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -69,7 +69,12 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String} [content.messageReferenceID] The ID of the message should be replied to. The reference message cannot be a system message.
+    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -69,12 +69,12 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
-    * @arg {String | Object} [content.messageReference] The message reference, used when replying to messages. The reference message cannot be a system message. If a string is passed, this should be the message ID only. If an object is passed:
-    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message - If you provide this property, it will be validated and should be the same channel ID as where the message is being created
-    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist instead of sending as a normal (non-reply) message
-    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message - If you provide this property, it will be validated and should be the same guild ID as where the message is being created
-    * @arg {String} content.messageReference.messageID The message ID of the referenced message
-    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. The reference message cannot be a system message. `messageReference` is prioritized and you should use this instead
+    * @arg {Object} [content.messageReference] The message reference, used when replying to messages
+    * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
+    * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
+    * @arg {String} [content.messageReference.guildID] The guild ID of the referenced message
+    * @arg {String} content.messageReference.messageID The message ID of the referenced message. This cannot reference a system message
+    * @arg {String} [content.messageReferenceID] [DEPRECATED] The ID of the message should be replied to. Use `messageReference` instead
     * @arg {Boolean} [content.tts] Set the message TTS flag
     * @arg {Object} [file] A file object
     * @arg {Buffer} file.file A buffer containing file data


### PR DESCRIPTION
This deprecates `content.messageReferenceID` in favour of `content.messageReference` which is more flexible, allowing an object as well as a string