### PR TITLE
Enhancements for VoiceChannel join methods

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -954,6 +954,12 @@ declare namespace Eris {
   }
 
   // Voice
+  interface JoinVoiceChannelOptions {
+    opusOnly?: boolean;
+    selfDeaf?: boolean;
+    selfMute?: boolean;
+    shared?: boolean;
+  }
   interface VoiceConnectData {
     channel_id: string;
     endpoint: string;
@@ -1756,7 +1762,7 @@ declare namespace Eris {
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;
     getWebhook(webhookID: string, token?: string): Promise<Webhook>;
     getWebhookMessage(webhookID: string, token: string, messageID: string): Promise<Message<GuildTextableChannel>>;
-    joinVoiceChannel(channelID: string, options?: { opusOnly?: boolean; shared?: boolean; selfMute?: boolean; selfDeaf?: boolean }): Promise<VoiceConnection>;
+    joinVoiceChannel(channelID: string, options?: JoinVoiceChannelOptions): Promise<VoiceConnection>;
     kickGuildMember(guildID: string, userID: string, reason?: string): Promise<void>;
     leaveGuild(guildID: string): Promise<void>;
     leaveVoiceChannel(channelID: string): void;
@@ -2593,7 +2599,7 @@ declare namespace Eris {
     voiceMembers: Collection<Member>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
     getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
-    join(options: { opusOnly?: boolean; shared?: boolean; selfMute?: boolean; selfDeaf?: boolean }): Promise<VoiceConnection>;
+    join(options?: JoinVoiceChannelOptions): Promise<VoiceConnection>;
     leave(): void;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2593,7 +2593,7 @@ declare namespace Eris {
     voiceMembers: Collection<Member>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
     getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
-    join(options: { opusOnly?: boolean; shared?: boolean, selfMute?: boolean, selfDeaf?: boolean }): Promise<VoiceConnection>;
+    join(options: { opusOnly?: boolean; shared?: boolean; selfMute?: boolean; selfDeaf?: boolean }): Promise<VoiceConnection>;
     leave(): void;
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1756,7 +1756,7 @@ declare namespace Eris {
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;
     getWebhook(webhookID: string, token?: string): Promise<Webhook>;
     getWebhookMessage(webhookID: string, token: string, messageID: string): Promise<Message<GuildTextableChannel>>;
-    joinVoiceChannel(channelID: string, options?: { opusOnly?: boolean; shared?: boolean, selfMute?: boolean, selfDeaf?: boolean }): Promise<VoiceConnection>;
+    joinVoiceChannel(channelID: string, options?: { opusOnly?: boolean; shared?: boolean; selfMute?: boolean; selfDeaf?: boolean }): Promise<VoiceConnection>;
     kickGuildMember(guildID: string, userID: string, reason?: string): Promise<void>;
     leaveGuild(guildID: string): Promise<void>;
     leaveVoiceChannel(channelID: string): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1756,7 +1756,7 @@ declare namespace Eris {
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;
     getWebhook(webhookID: string, token?: string): Promise<Webhook>;
     getWebhookMessage(webhookID: string, token: string, messageID: string): Promise<Message<GuildTextableChannel>>;
-    joinVoiceChannel(channelID: string, options?: { opusOnly?: boolean; shared?: boolean }): Promise<VoiceConnection>;
+    joinVoiceChannel(channelID: string, options?: { opusOnly?: boolean; shared?: boolean, selfMute?: boolean, selfDeaf?: boolean }): Promise<VoiceConnection>;
     kickGuildMember(guildID: string, userID: string, reason?: string): Promise<void>;
     leaveGuild(guildID: string): Promise<void>;
     leaveVoiceChannel(channelID: string): void;
@@ -2593,7 +2593,7 @@ declare namespace Eris {
     voiceMembers: Collection<Member>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
     getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
-    join(options: { opusOnly?: boolean; shared?: boolean }): Promise<VoiceConnection>;
+    join(options: { opusOnly?: boolean; shared?: boolean, selfMute?: boolean, selfDeaf?: boolean }): Promise<VoiceConnection>;
     leave(): void;
   }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2247,6 +2247,8 @@ class Client extends EventEmitter {
     * @arg {Object} [options] VoiceConnection constructor options
     * @arg {Object} [options.opusOnly] Skip opus encoder initialization. You should not enable this unless you know what you are doing
     * @arg {Object} [options.shared] Whether the VoiceConnection will be part of a SharedStream or not
+    * @arg {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
+    * @arg {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not
     * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
     */
     joinVoiceChannel(channelID, options = {}) {
@@ -2260,8 +2262,8 @@ class Client extends EventEmitter {
         this.shards.get(this.guildShardMap[this.channelGuildMap[channelID]] || 0).sendWS(Constants.GatewayOPCodes.VOICE_STATE_UPDATE, {
             guild_id: this.channelGuildMap[channelID] || null,
             channel_id: channelID || null,
-            self_mute: false,
-            self_deaf: false
+            self_mute: options.selfMute || false,
+            self_deaf: options.selfDeaf || false
         });
         if(options.opusOnly === undefined) {
             options.opusOnly = this.options.opusOnly;

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -65,6 +65,8 @@ class VoiceChannel extends GuildChannel {
     * @arg {Object} [options] VoiceConnection constructor options
     * @arg {Object} [options.opusOnly] Skip opus encoder initialization. You should not enable this unless you know what you are doing
     * @arg {Object} [options.shared] Whether the VoiceConnection will be part of a SharedStream or not
+    * @arg {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
+    * @arg {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not
     * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
     */
     join(options) {


### PR DESCRIPTION
Added options to choose if the bot connects to a voice channel being muted or deafened instead of always joining without being muted and deafened.
