### PR TITLE
Convert BigInts in request bodies to strings

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -959,10 +959,10 @@ class Client extends EventEmitter {
     */
     editChannelPermission(channelID, overwriteID, allow, deny, type, reason) {
         return this.requestHandler.request("PUT", Endpoints.CHANNEL_PERMISSION(channelID, overwriteID), true, {
-            allow: allow.toString(),
-            deny: deny.toString(),
-            type: type,
-            reason: reason
+            allow,
+            deny,
+            type,
+            reason
         });
     }
 
@@ -1272,9 +1272,6 @@ class Client extends EventEmitter {
     * @returns {Promise<Role>}
     */
     editRole(guildID, roleID, options, reason) {
-        if(typeof options.permissions === "bigint") {
-            options.permissions = options.permissions.toString();
-        }
         options.reason = reason;
         return this.requestHandler.request("PATCH", Endpoints.GUILD_ROLE(guildID, roleID), true, options).then((role) => new Role(role, this.guilds.get(guildID)));
     }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -149,7 +149,8 @@ class RequestHandler {
                             });
                             finalURL += "?" + qs.substring(1);
                         } else {
-                            data = JSON.stringify(body);
+                            // Replacer function serializes bigints to strings, the format Discord uses
+                            data = JSON.stringify(body, (k, v) => typeof v === "bigint" ? v.toString() : v);
                             headers["Content-Type"] = "application/json";
                         }
                     }


### PR DESCRIPTION
Fixes #1196. Modifies the request handler to serialize `BigInt`s to strings when stringifying request bodies, and removes explicit `BigInt` to string conversions elsewhere down the chain. `Base#toJSON` still manually converts `BigInt` values to strings, since all its output values need to be serializable to JSON without custom replacers.