### PR TITLE
Support per-guild avatars

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -455,10 +455,11 @@ declare namespace Eris {
     videoQualityMode: VideoQualityMode;
   }
   interface OldMember {
-    roles: string[];
+    avatar: string | null;
     nick: string | null;
-    premiumSince: number;
     pending?: boolean;
+    premiumSince: number;
+    roles: string[];
   }
   interface OldMessage {
     attachments: Attachment[];
@@ -789,7 +790,7 @@ declare namespace Eris {
     channelID?: string | null;
     deaf?: boolean;
     mute?: boolean;
-    nick?: string;
+    nick?: string | null;
     roles?: string[];
   }
   interface MemberPartial {
@@ -1634,6 +1635,7 @@ declare namespace Eris {
     editGuildWelcomeScreen(guildID: string, options: WelcomeScreenOptions): Promise<WelcomeScreen>;
     editGuildWidget(guildID: string, options: Widget): Promise<Widget>;
     editMessage(channelID: string, messageID: string, content: MessageContent): Promise<Message>;
+    /** @deprecated */
     editNickname(guildID: string, nick: string, reason?: string): Promise<void>;
     editRole(guildID: string, roleID: string, options: RoleOptions, reason?: string): Promise<Role>; // TODO not all options are available?
     editRolePosition(guildID: string, roleID: string, position: number): Promise<void>;
@@ -2007,6 +2009,7 @@ declare namespace Eris {
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     editIntegration(integrationID: string, options: IntegrationOptions): Promise<void>;
     editMember(memberID: string, options: MemberOptions, reason?: string): Promise<void>;
+    /** @deprecated */
     editNickname(nick: string): Promise<void>;
     editRole(roleID: string, options: RoleOptions): Promise<Role>;
     editTemplate(code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1111,7 +1111,7 @@ class Client extends EventEmitter {
     /**
     * Edit a guild member
     * @arg {String} guildID The ID of the guild
-    * @arg {String} memberID The ID of the member
+    * @arg {String} memberID The ID of the member (use "@me" to edit the current bot user)
     * @arg {Object} options The properties to edit
     * @arg {String} [options.channelID] The ID of the voice channel to move the member to (must be in voice)
     * @arg {Boolean} [options.deaf] Server deafen the member
@@ -1245,7 +1245,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edit the bot's nickname in a guild
+    * [DEPRECATED] Edit the bot's nickname in a guild
     * @arg {String} guildID The ID of the guild
     * @arg {String} nick The nickname
     * @arg {String} [reason] The reason to be displayed in audit logs
@@ -2720,7 +2720,7 @@ class Client extends EventEmitter {
 
     _formatImage(url, format, size) {
         if(!format || !Constants.ImageFormats.includes(format.toLowerCase())) {
-            format = url.includes("/a_") ? "gif": this.options.defaultImageFormat;
+            format = url.includes("/a_") ? "gif" : this.options.defaultImageFormat;
         }
         if(!size || size < Constants.ImageSizeBoundaries.MINIMUM || size > Constants.ImageSizeBoundaries.MAXIMUM || (size & (size - 1))) {
             size = this.options.defaultImageSize;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1111,7 +1111,7 @@ class Client extends EventEmitter {
     /**
     * Edit a guild member
     * @arg {String} guildID The ID of the guild
-    * @arg {String} memberID The ID of the member (use "@me" to edit the current bot user)
+    * @arg {String} memberID The ID of the member (you can use "@me" if you are only editing the bot user's nickname)
     * @arg {Object} options The properties to edit
     * @arg {String} [options.channelID] The ID of the voice channel to move the member to (must be in voice)
     * @arg {Boolean} [options.deaf] Server deafen the member

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1129,6 +1129,7 @@ class Shard extends EventEmitter {
                 let oldMember = null;
                 if(member) {
                     oldMember = {
+                        avatar: member.avatar,
                         roles: member.roles,
                         nick: member.nick,
                         premiumSince: member.premiumSince,
@@ -1137,11 +1138,12 @@ class Shard extends EventEmitter {
                 }
                 member = guild.members.update(packet.d, guild);
                 /**
-                * Fired when a member's roles or nickname are updated or they start boosting a server
+                * Fired when a member's guild avatar, roles or nickname are updated or they start boosting a server
                 * @event Client#guildMemberUpdate
                 * @prop {Guild} guild The guild
                 * @prop {Member} member The updated member
-                * @prop {Object?} oldMember The old member data
+                * @prop {Object?} oldMember The old member data, or null if the member wasn't cached
+                * @prop {String?} oldMember.avatar The hash of the member's guild avatar, or null if no guild avatar
                 * @prop {Array<String>} oldMember.roles An array of role IDs this member is a part of
                 * @prop {String?} oldMember.nick The server nickname of the member
                 * @prop {Number} oldMember.premiumSince Timestamp of when the member boosted the guild

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -98,6 +98,7 @@ module.exports.APPLICATION_ICON =                          (applicationID, icon)
 module.exports.CHANNEL_ICON =                                 (chanID, chanIcon) => `/channel-icons/${chanID}/${chanIcon}`;
 module.exports.CUSTOM_EMOJI =                                          (emojiID) => `/emojis/${emojiID}`;
 module.exports.DEFAULT_USER_AVATAR =                         (userDiscriminator) => `/embed/avatars/${userDiscriminator}`;
+module.exports.GUILD_AVATAR =                     (guildID, userID, guildAvatar) => `/guilds/${guildID}/${userID}/avatars/${guildAvatar}`;
 module.exports.GUILD_BANNER =                             (guildID, guildBanner) => `/banners/${guildID}/${guildBanner}`;
 module.exports.GUILD_DISCOVERY_SPLASH =          (guildID, guildDiscoverySplash) => `/discovery-splashes/${guildID}/${guildDiscoverySplash}`;
 module.exports.GUILD_ICON =                                 (guildID, guildIcon) => `/icons/${guildID}/${guildIcon}`;

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -98,7 +98,7 @@ module.exports.APPLICATION_ICON =                          (applicationID, icon)
 module.exports.CHANNEL_ICON =                                 (chanID, chanIcon) => `/channel-icons/${chanID}/${chanIcon}`;
 module.exports.CUSTOM_EMOJI =                                          (emojiID) => `/emojis/${emojiID}`;
 module.exports.DEFAULT_USER_AVATAR =                         (userDiscriminator) => `/embed/avatars/${userDiscriminator}`;
-module.exports.GUILD_AVATAR =                     (guildID, userID, guildAvatar) => `/guilds/${guildID}/${userID}/avatars/${guildAvatar}`;
+module.exports.GUILD_AVATAR =                     (guildID, userID, guildAvatar) => `/guilds/${guildID}/users/${userID}/avatars/${guildAvatar}`;
 module.exports.GUILD_BANNER =                             (guildID, guildBanner) => `/banners/${guildID}/${guildBanner}`;
 module.exports.GUILD_DISCOVERY_SPLASH =          (guildID, guildDiscoverySplash) => `/discovery-splashes/${guildID}/${guildDiscoverySplash}`;
 module.exports.GUILD_ICON =                                 (guildID, guildIcon) => `/icons/${guildID}/${guildIcon}`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -554,7 +554,7 @@ class Guild extends Base {
 
     /**
     * Edit a guild member
-    * @arg {String} memberID The ID of the member
+    * @arg {String} memberID The ID of the member (use "@me" to edit the current bot user)
     * @arg {Object} options The properties to edit
     * @arg {String} [options.channelID] The ID of the voice channel to move the member to (must be in voice)
     * @arg {Boolean} [options.deaf] Server deafen the member
@@ -569,7 +569,7 @@ class Guild extends Base {
     }
 
     /**
-    * Edit the bot's nickname in the guild
+    * [DEPRECATED] Edit the bot's nickname in the guild
     * @arg {String} nick The nickname
     * @returns {Promise}
     */

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -1,13 +1,14 @@
 "use strict";
 
 const Base = require("./Base");
+const Endpoints = require("../rest/Endpoints");
 const User = require("./User");
 const VoiceState = require("./VoiceState");
 
 /**
 * Represents a server member
 * @prop {Array<Object>?} activities The member's current activities
-* @prop {String?} avatar The hash of the user's avatar, or null if no avatar
+* @prop {String?} avatar The hash of the member's guild avatar, or null if no guild avatar
 * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
 * @prop {Boolean} bot Whether the user is an OAuth bot or not
 * @prop {Object?} clientStatus The member's per-client status
@@ -102,14 +103,13 @@ class Member extends Base {
         if(data.pending !== undefined) {
             this.pending = data.pending;
         }
-    }
-
-    get avatar() {
-        return this.user.avatar;
+        if(data.avatar !== undefined) {
+            this.avatar = data.avatar;
+        }
     }
 
     get avatarURL() {
-        return this.user.avatarURL;
+        return this.avatar ? this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar)) : this.user.avatarURL;
     }
 
     get bot() {


### PR DESCRIPTION
Adds support for guild specific avatars 

## Notes:
- Possibly breaking change: Member#avatar will now return the avatar hash of the guild member or null if there isn't one, instead of getting the relevant hash from the User class. 
- This feature is still in private beta, only some users will be able to see and use it.