### PR TITLE
Bump ws from 7.2.1 to 7.4.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,11 +42,11 @@
   },
   "homepage": "https://abal.moe/Eris/",
   "dependencies": {
-    "ws": "^7.2.1"
+    "ws": "^7.4.6"
   },
   "devDependencies": {
     "@types/node": "^14.14.35",
-    "@types/ws": "^7.4.2",
+    "@types/ws": "^7.4.4",
     "@typescript-eslint/eslint-plugin": "^4.19.0",
     "@typescript-eslint/parser": "^4.19.0",
     "eslint": "^7.22.0",


### PR DESCRIPTION
This is a security vuln PR - we shouldn't have any code changes but here's a list of [commits](https://github.com/websockets/ws/compare/7.2.1...7.4.6) from ws@7.2.1