### PR TITLE
Allow passing a plain object to permissionsOf

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -797,7 +797,7 @@ declare namespace Eris {
     user: User;
   }
   interface MemberRoles extends BaseData {
-    roles: string;
+    roles: string[];
   }
   interface PartialUser {
     avatar: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -796,6 +796,9 @@ declare namespace Eris {
     id: string;
     user: User;
   }
+  interface MemberRoles extends BaseData {
+    roles: string;
+  }
   interface PartialUser {
     avatar: string | null;
     discriminator: string;
@@ -2044,7 +2047,7 @@ declare namespace Eris {
     kickMember(userID: string, reason?: string): Promise<void>;
     leave(): Promise<void>;
     leaveVoiceChannel(): void;
-    permissionsOf(memberID: string | Member): Permission;
+    permissionsOf(memberID: string | Member | MemberRoles): Permission;
     pruneMembers(options?: PruneMemberOptions): Promise<number>;
     removeMemberRole(memberID: string, roleID: string, reason?: string): Promise<void>;
     searchMembers(query: string, limit?: number): Promise<Member[]>;
@@ -2094,7 +2097,7 @@ declare namespace Eris {
     ): Promise<PermissionOverwrite>;
     editPosition(position: number, options?: EditChannelPositionOptions): Promise<void>;
     getInvites(): Promise<Invite[]>;
-    permissionsOf(memberID: string | Member): Permission;
+    permissionsOf(memberID: string | Member | MemberRoles): Permission;
   }
 
   export class GuildIntegration extends Base {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -898,7 +898,7 @@ class Guild extends Base {
     * @returns {Permission}
     */
     permissionsOf(memberID) {
-        const member = typeof memberID === "string" ? this.guild.members.get(memberID) : memberID;
+        const member = typeof memberID === "string" ? this.members.get(memberID) : memberID;
         if(member.id === this.ownerID) {
             return new Permission(Permissions.all);
         } else {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -894,11 +894,11 @@ class Guild extends Base {
 
     /**
     * Get the guild permissions of a member
-    * @arg {String | Member} memberID The ID of the member or a Member instance
+    * @arg {String | Member | Object} memberID The ID of the member or a Member object
     * @returns {Permission}
     */
     permissionsOf(memberID) {
-        const member = memberID instanceof Member ? memberID : this.members.get(memberID);
+        const member = typeof memberID === "string" ? this.guild.members.get(memberID) : memberID;
         if(member.id === this.ownerID) {
             return new Permission(Permissions.all);
         } else {

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -2,7 +2,6 @@
 
 const Channel = require("./Channel");
 const Collection = require("../util/Collection");
-const Member = require("./Member");
 const Permission = require("./Permission");
 const {Permissions} = require("../Constants");
 const PermissionOverwrite = require("./PermissionOverwrite");
@@ -115,11 +114,11 @@ class GuildChannel extends Channel {
 
     /**
     * Get the channel-specific permissions of a member
-    * @arg {String | Member} memberID The ID of the member or a Member instance
+    * @arg {String | Member | Object} memberID The ID of the member or a Member object
     * @returns {Permission}
     */
     permissionsOf(memberID) {
-        const member = memberID instanceof Member ? memberID : this.guild.members.get(memberID);
+        const member = typeof memberID === "string" ? this.guild.members.get(memberID) : memberID;
         let permission = this.guild.permissionsOf(member).allow;
         if(permission & Permissions.administrator) {
             return new Permission(Permissions.all);


### PR DESCRIPTION
Added in case we're dealing with plain objects, avoids throwing an error relating to member being uncached if we pass an object.