### PR TITLE
Fix getMessages before & after option not being passed when trying to fetch 100 messages at once

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1947,7 +1947,7 @@ class Client extends EventEmitter {
                 this.emit("debug", `Getting ${limit} more messages during getMessages for ${channelID}: ${_before} ${_after}`, -1);
                 return get((_before || !_after) && messages[messages.length - 1].id, _after && messages[0].id);
             };
-            return get(before, after);
+            return get(options.before, options.after);
         }
         const messages = await this.requestHandler.request("GET", Endpoints.CHANNEL_MESSAGES(channelID), true, options);
         return messages.map((message) => {


### PR DESCRIPTION
If you tried using these options while fetching more than 100 messages at a time, Eris uses the deprecated before & after param. If you only passed the newer options, it'd still fetch messages that you thought would be excluded.