### PR TITLE
Remove extra whitespace

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -88,4 +88,3 @@ rules:
         custom-inspect-method:
         - name: "[util.inspect.custom]"
           type: method
-


### PR DESCRIPTION
Unless this was intentionally placed, this removes the extra whitespace in the ESLint config file.