### PR TITLE
Use "const" over "var" in README

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -88,4 +88,3 @@ rules:
         custom-inspect-method:
         - name: "[util.inspect.custom]"
           type: method
-

--- a/README.md
+++ b/README.md
@@ -20,8 +20,12 @@ Ping Pong Example
 ```js
 const Eris = require("eris");
 
-const bot = new Eris("Bot TOKEN");
 // Replace TOKEN with your bot account's token
+const bot = new Eris("Bot TOKEN", {
+    intents: [
+        "guildMessages"
+    ];
+});
 
 bot.on("ready", () => { // When the bot is ready
     console.log("Ready!"); // Log "Ready!"

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Ping Pong Example
 ```js
 const Eris = require("eris");
 
-var bot = new Eris("Bot TOKEN");
+const bot = new Eris("Bot TOKEN");
 // Replace TOKEN with your bot account's token
 
 bot.on("ready", () => { // When the bot is ready

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ const Eris = require("eris");
 const bot = new Eris("Bot TOKEN", {
     intents: [
         "guildMessages"
-    ];
+    ]
 });
 
 bot.on("ready", () => { // When the bot is ready


### PR DESCRIPTION
This prefers the use of constants over the "var" keyword for the bot sample located in the ReadMe.