### PR TITLE
Update sticker properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -875,20 +875,21 @@ declare namespace Eris {
     messageID: string;
     failIfNotExists?: boolean;
   }
-  interface StickerItems {
-    id: string;
-    name: string;
-    format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
-  }
   interface Sticker extends StickerItems {
+    /** @deprecated */
     asset: "";
     available?: boolean;
     description: string;
     guild_id?: string;
     pack_id?: string;
     sort_value?: number;
-    tags?: string;
-    user?: PartialUser;
+    tags: string;
+    user?: User;
+  }
+  interface StickerItems {
+    id: string;
+    name: string;
+    format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
   }
 
   // Presence
@@ -2259,9 +2260,9 @@ declare namespace Eris {
     reactions: { [s: string]: { count: number; me: boolean } };
     referencedMessage?: Message | null;
     roleMentions: string[];
-    sticker_items?: Sticker[];
     /** @deprecated */
-    stickers?: Sticker[];
+    stickers?: StickerItems[];
+    stickerItems?: StickerItems[];
     timestamp: number;
     tts: boolean;
     type: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -881,6 +881,7 @@ declare namespace Eris {
     format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
   }
   interface Sticker extends StickerItems {
+    asset: "";
     available?: boolean;
     description: string;
     guild_id?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -875,13 +875,15 @@ declare namespace Eris {
     messageID: string;
     failIfNotExists?: boolean;
   }
-  interface Sticker {
-    available?: boolean;
-    description?: string;
-    format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
-    guild_id?: string;
+  interface StickerItems {
     id: string;
     name: string;
+    format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
+  }
+  interface Sticker extends StickerItems {
+    available?: boolean;
+    description: string;
+    guild_id?: string;
     pack_id?: string;
     sort_value?: number;
     tags?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -876,13 +876,16 @@ declare namespace Eris {
     failIfNotExists?: boolean;
   }
   interface Sticker {
-    asset: string;
-    description: string;
+    available?: boolean;
+    description?: string;
     format_type: Constants["StickerFormats"][keyof Constants["StickerFormats"]];
+    guild_id?: string;
     id: string;
     name: string;
-    pack_id: string;
+    pack_id?: string;
+    sort_value?: number;
     tags?: string;
+    user?: PartialUser;
   }
 
   // Presence

--- a/index.d.ts
+++ b/index.d.ts
@@ -2261,7 +2261,7 @@ declare namespace Eris {
     referencedMessage?: Message | null;
     roleMentions: string[];
     /** @deprecated */
-    stickers?: StickerItems[];
+    stickers?: Sticker[];
     stickerItems?: StickerItems[];
     timestamp: number;
     tts: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2258,6 +2258,8 @@ declare namespace Eris {
     reactions: { [s: string]: { count: number; me: boolean } };
     referencedMessage?: Message | null;
     roleMentions: string[];
+    sticker_items?: Sticker[];
+    /** @deprecated */
     stickers?: Sticker[];
     timestamp: number;
     tts: boolean;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -292,6 +292,9 @@ class Message extends Base {
                 };
             });
         }
+        if(data.stickers !== undefined) {
+            this.stickers = data.stickers;
+        }
         if(data.sticker_items !== undefined) {
             this.stickerItems = data.sticker_items.map((sticker) => {
                 if(sticker.user) {
@@ -300,7 +303,6 @@ class Message extends Base {
 
                 return sticker;
             });
-            this.stickers = this.stickerItems;
         }
     }
 

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -516,6 +516,7 @@ class Message extends Base {
             "reactions",
             "referencedMesssage",
             "roleMentions",
+            "stickers",
             "stickerItems",
             "timestamp",
             "tts",

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -292,9 +292,11 @@ class Message extends Base {
                 };
             });
         }
+
         if(data.stickers !== undefined) {
             this.stickers = data.stickers;
         }
+
         if(data.sticker_items !== undefined) {
             this.stickerItems = data.sticker_items.map((sticker) => {
                 if(sticker.user) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -295,7 +295,7 @@ class Message extends Base {
         if(data.sticker_items !== undefined) {
             this.stickerItems = data.sticker_items.map((sticker) => {
                 if(sticker.user) {
-                    sticker.user = client.users.add(sticker.user, client);
+                    sticker.user = client.users.update(sticker.user, client);
                 }
 
                 return sticker;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -42,8 +42,8 @@ const User = require("./User");
 * @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
 * @prop {Message?} referencedMessage The message that was replied to. If undefined, message data was not received. If null, the message was deleted.
 * @prop {Array<String>} roleMentions Array of mentioned roles' ids
-* @prop {Array<Object>?} sticker_items The stickers sent with the message
 * @prop {Array<Object>?} stickers [DEPRECATED] The stickers sent with the message
+* @prop {Array<Object>?} stickerItems The stickers sent with the message
 * @prop {Number} timestamp Timestamp of message creation
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Number} type The type of the message
@@ -293,14 +293,14 @@ class Message extends Base {
             });
         }
         if(data.sticker_items !== undefined) {
-            this.sticker_items = data.sticker_items.map((sticker) => {
+            this.stickerItems = data.sticker_items.map((sticker) => {
                 if(sticker.user) {
                     sticker.user = client.users.add(sticker.user, client);
                 }
 
                 return sticker;
             });
-            this.stickers = this.sticker_items;
+            this.stickers = this.stickerItems;
         }
     }
 
@@ -514,7 +514,7 @@ class Message extends Base {
             "reactions",
             "referencedMesssage",
             "roleMentions",
-            "sticker_items",
+            "stickerItems",
             "timestamp",
             "tts",
             "type",

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -293,8 +293,14 @@ class Message extends Base {
             });
         }
         if(data.sticker_items !== undefined) {
-            this.sticker_items = data.sticker_items;
-            this.stickers = data.sticker_items;
+            this.sticker_items = data.sticker_items.map((sticker) => {
+                if(sticker.user) {
+                    sticker.user = client.users.add(sticker.user, client);
+                }
+
+                return sticker;
+            });
+            this.stickers = this.sticker_items;
         }
     }
 

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -291,8 +291,8 @@ class Message extends Base {
                 };
             });
         }
-        if(data.stickers !== undefined) {
-            this.stickers = data.stickers;
+        if(data.sticker_items !== undefined) {
+            this.stickers = data.sticker_items;
         }
     }
 

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -42,7 +42,8 @@ const User = require("./User");
 * @prop {Object} reactions An object containing the reactions on the message. Each key is a reaction emoji and each value is an object with properties `me` (Boolean) and `count` (Number) for that specific reaction emoji.
 * @prop {Message?} referencedMessage The message that was replied to. If undefined, message data was not received. If null, the message was deleted.
 * @prop {Array<String>} roleMentions Array of mentioned roles' ids
-* @prop {Array<Object>?} stickers The stickers sent with the message
+* @prop {Array<Object>?} sticker_items The stickers sent with the message
+* @prop {Array<Object>?} stickers [DEPRECATED] The stickers sent with the message
 * @prop {Number} timestamp Timestamp of message creation
 * @prop {Boolean} tts Whether to play the message using TTS or not
 * @prop {Number} type The type of the message
@@ -292,6 +293,7 @@ class Message extends Base {
             });
         }
         if(data.sticker_items !== undefined) {
+            this.sticker_items = data.sticker_items;
             this.stickers = data.sticker_items;
         }
     }
@@ -506,7 +508,7 @@ class Message extends Base {
             "reactions",
             "referencedMesssage",
             "roleMentions",
-            "stickers",
+            "sticker_items",
             "timestamp",
             "tts",
             "type",


### PR DESCRIPTION
These changes will deprecate the old `stickers` property and use `stickerItems` instead. Since Discord no longer sends `sticker`, `sticker_items` should be used instead.

The `User` property sent with the sticker (if any) is no longer partial and will update the user cache.