### PR TITLE
Support sending multiple embeds

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -54,7 +54,9 @@ declare namespace Eris {
   type AdvancedMessageContent = {
     allowedMentions?: AllowedMentions;
     content?: string;
+    /** @deprecated */
     embed?: EmbedOptions;
+    embeds?: EmbedOptions[];
     flags?: number;
     messageReference?: MessageReferenceReply;
     /** @deprecated */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -604,6 +604,8 @@ class Client extends EventEmitter {
                 content.content = "" + content.content;
             } else if(content.content === undefined && !content.embed && !content.embeds && !file) {
                 return Promise.reject(new Error("No content, file, or embeds"));
+            } else if(content.embed && content.embeds) {
+                content.embeds.push(content.embed);
             } else if(content.embed) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
                 content.embeds = [content.embed];
@@ -1241,6 +1243,8 @@ class Client extends EventEmitter {
                 content.content = "" + content.content;
             } else if(content.content === undefined && !content.embed && !content.embeds && content.flags === undefined) {
                 return Promise.reject(new Error("No content, embeds or flags"));
+            } else if(content.embed && content.embeds) {
+                content.embeds.push(content.embed);
             } else if(content.embed) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
                 content.embeds = [content.embed];

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -581,6 +581,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [content.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to.
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
@@ -601,8 +602,10 @@ class Client extends EventEmitter {
                 };
             } else if(content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
-            } else if(content.content === undefined && !content.embed && !file) {
-                return Promise.reject(new Error("No content, file, or embed"));
+            } else if(content.content === undefined && !content.embed && !content.embeds && !file) {
+                return Promise.reject(new Error("No content, file, or embeds"));
+            } else if(content.embed) {
+                this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
             }
             content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             if(content.messageReference) {
@@ -628,7 +631,7 @@ class Client extends EventEmitter {
                 content.message_reference = {message_id: content.messageReferenceID};
             }
         } else if(!file) {
-            return Promise.reject(new Error("No content, file, or embed"));
+            return Promise.reject(new Error("No content, file, or embeds"));
         }
         return this.requestHandler.request("POST", Endpoints.CHANNEL_MESSAGES(channelID), true, content, file).then((message) => new Message(message, this));
     }
@@ -1223,6 +1226,7 @@ class Client extends EventEmitter {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */
@@ -1234,10 +1238,12 @@ class Client extends EventEmitter {
                 };
             } else if(content.content !== undefined && typeof content.content !== "string") {
                 content.content = "" + content.content;
-            } else if(content.content === undefined && !content.embed && content.flags === undefined) {
-                return Promise.reject(new Error("No content, embed or flags"));
+            } else if(content.content === undefined && !content.embed && !content.embeds && content.flags === undefined) {
+                return Promise.reject(new Error("No content, embeds or flags"));
+            } else if(content.embed) {
+                this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
             }
-            if(content.content !== undefined || content.embed || content.allowedMentions) {
+            if(content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             }
         }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -580,7 +580,7 @@ class Client extends EventEmitter {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [content.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to.
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -1225,7 +1225,7 @@ class Client extends EventEmitter {
     * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -604,9 +604,7 @@ class Client extends EventEmitter {
                 content.content = "" + content.content;
             } else if(content.content === undefined && !content.embed && !content.embeds && !file) {
                 return Promise.reject(new Error("No content, file, or embeds"));
-            } else if(content.embed && content.embeds) {
-                content.embeds.push(content.embed);
-            } else if(content.embed) {
+            } else if(content.embed && !content.embeds) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
                 content.embeds = [content.embed];
             }
@@ -1243,9 +1241,7 @@ class Client extends EventEmitter {
                 content.content = "" + content.content;
             } else if(content.content === undefined && !content.embed && !content.embeds && content.flags === undefined) {
                 return Promise.reject(new Error("No content, embeds or flags"));
-            } else if(content.embed && content.embeds) {
-                content.embeds.push(content.embed);
-            } else if(content.embed) {
+            } else if(content.embed && !content.embeds) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
                 content.embeds = [content.embed];
             }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -580,7 +580,7 @@ class Client extends EventEmitter {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [content.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to.
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -1226,7 +1226,7 @@ class Client extends EventEmitter {
     * @arg {Boolean | Array<String>} [content.allowedMentions.roles] Whether or not to allow all role mentions, or an array of specific role mentions to allow.
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -606,6 +606,7 @@ class Client extends EventEmitter {
                 return Promise.reject(new Error("No content, file, or embeds"));
             } else if(content.embed) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
+                content.embeds = [content.embed];
             }
             content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);
             if(content.messageReference) {
@@ -1242,6 +1243,7 @@ class Client extends EventEmitter {
                 return Promise.reject(new Error("No content, embeds or flags"));
             } else if(content.embed) {
                 this.emit("warn", "[DEPRECATED] content.embed is deprecated. Use content.embeds instead");
+                content.embeds = [content.embed];
             }
             if(content.content !== undefined || content.embeds || content.allowedMentions) {
                 content.allowed_mentions = this._formatAllowedMentions(content.allowedMentions);

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -47,7 +47,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -85,7 +85,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -47,7 +47,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -85,7 +85,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -48,6 +48,7 @@ class PrivateChannel extends Channel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
@@ -85,6 +86,7 @@ class PrivateChannel extends Channel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -68,7 +68,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -128,7 +128,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure. Use `embeds` instead
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -68,7 +68,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
@@ -128,7 +128,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean | Array<String>} [content.allowedMentions.users] Whether or not to allow all user mentions, or an array of specific user mentions to allow.
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
-    * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Object} [content.embed] [DEPRECATED] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -69,6 +69,7 @@ class TextChannel extends GuildChannel {
     * @arg {Boolean} [options.allowedMentions.repliedUser] Whether or not to mention the author of the message being replied to
     * @arg {String} content.content A content string
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Object} [content.messageReference] The message reference, used when replying to messages
     * @arg {String} [content.messageReference.channelID] The channel ID of the referenced message
     * @arg {Boolean} [content.messageReference.failIfNotExists=true] Whether to throw an error if the message reference doesn't exist. If false, and the referenced message doesn't exist, the message is created without a referenced message
@@ -128,6 +129,7 @@ class TextChannel extends GuildChannel {
     * @arg {String} content.content A content string
     * @arg {Boolean} [content.disableEveryone] Whether to filter @everyone/@here or not (overrides default)
     * @arg {Object} [content.embed] An embed object. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
+    * @arg {Array<Object>} [content.embeds] An array of embed objects. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#embed-object) for object structure
     * @arg {Number} [content.flags] A number representing the flags to apply to the message. See [the official Discord API documentation entry](https://discord.com/developers/docs/resources/channel#message-object-message-flags) for flags reference
     * @returns {Promise<Message>}
     */


### PR DESCRIPTION
https://discord.com/developers/docs/resources/channel#create-message-jsonform-params
https://discord.com/developers/docs/resources/channel#edit-message-jsonform-params

Discord has deprecated embed when creating/editing messages and has changed to embeds. It's better to switch from the regular embed to embeds before Discord might remove them in the future API version 👍🏻 