### PR TITLE
Add decodeReasons to RequestHandlerOptions typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -239,6 +239,7 @@ declare namespace Eris {
   interface RequestHandlerOptions {
     agent?: HTTPSAgent;
     baseURL?: string;
+    decodeReasons?: boolean;
     disableLatencyCompensation?: boolean;
     domain?: string;
     latencyThreshold?: number;


### PR DESCRIPTION
I'm not sure if the plan is to remove this deprecated option in 0.16 or to keep it for a while longer, but it's still in the docs, so this PR adds it to typings for now.