### PR TITLE
Require ClientOptions in Eris constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@ import { URL } from "url";
 import { Socket as DgramSocket } from "dgram";
 import * as WebSocket from "ws";
 
-declare function Eris(token: string, options?: Eris.ClientOptions): Eris.Client;
+declare function Eris(token: string, options: Eris.ClientOptions): Eris.Client;
 
 declare namespace Eris {
   export const Constants: Constants;


### PR DESCRIPTION
Class `Client` constructor makes `ClientOptions` a required parameter, since `intents` is no longer optional.

> Eris client options (only `intents` is required) 

However, the top level `Eris` function allows the user to mistakenly bypass this requirement of specifying `ClientOptions` with the `intent` property while calling the `Client` constructor.

This change should make it as so `ClientOptions` is required while calling `Eris` just as intended.