### PR TITLE
Improve v8 ratelimit handling

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -268,9 +268,6 @@ class RequestHandler {
                         this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
 
                         const retryAfter = parseInt(resp.headers["x-ratelimit-reset-after"] || resp.headers["retry-after"]) * 1000;
-                        if(retryAfter >= 1000 * 1000) {
-                            this._client.emit("warn", `Excessive Retry-After interval detected (Retry-After: ${resp.headers["retry-after"]} * 1000, Via: ${resp.headers["via"]})`);
-                        }
                         if(retryAfter >= 0) {
                             if(resp.headers["x-ratelimit-global"]) {
                                 this.globalBlock = true;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -267,14 +267,9 @@ class RequestHandler {
 
                         this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
 
-                        let retryAfter = parseInt(resp.headers["retry-after"]);
-                        // Discord breaks RFC here, using milliseconds instead of seconds (╯°□°）╯︵ ┻━┻
-                        // This is the unofficial Discord dev-recommended way of detecting that
-                        if(retryAfter && (typeof resp.headers["via"] !== "string" || !resp.headers["via"].includes("1.1 google"))) {
-                            retryAfter *= 1000;
-                            if(retryAfter >= 1000 * 1000) {
-                                this._client.emit("warn", `Excessive Retry-After interval detected (Retry-After: ${resp.headers["retry-after"]} * 1000, Via: ${resp.headers["via"]})`);
-                            }
+                        const retryAfter = parseInt(resp.headers["x-ratelimit-reset-after"] || resp.headers["retry-after"]) * 1000;
+                        if(retryAfter >= 1000 * 1000) {
+                            this._client.emit("warn", `Excessive Retry-After interval detected (Retry-After: ${resp.headers["retry-after"]} * 1000, Via: ${resp.headers["via"]})`);
                         }
                         if(retryAfter >= 0) {
                             if(resp.headers["x-ratelimit-global"]) {


### PR DESCRIPTION
Retry-After is now in seconds without ms precision instead of being in ms (v6/7 behaviour) in order to conform with RFC-6585§4, and X-RateLimit-Reset-After is now always in ms precision, so this header should be used instead.
X-RateLimit-Reset-After is not shown on global ratelimits so fallback has been provided though I do want to somehow get the ms precision from the json payload somehow