### PR TITLE
Update permission flag names to match Discord & update guildEmojisAndStickers intent name

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1265,6 +1265,8 @@ declare namespace Eris {
       manageRoles: 268435456n;
       manageWebhooks: 536870912n;
       manageEmojisAndStickers: 1073741824n;
+      /** @deprecated */
+      manageEmojis: 1073741824n;
       useSlashCommands: 2147483648n;
       voiceRequestToSpeak: 4294967296n;
       useExternalStickers: 137438953472n;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1264,7 +1264,7 @@ declare namespace Eris {
       manageNicknames: 134217728n;
       manageRoles: 268435456n;
       manageWebhooks: 536870912n;
-      manageEmojis: 1073741824n;
+      manageEmojisAndStickers: 1073741824n;
       useSlashCommands: 2147483648n;
       voiceRequestToSpeak: 4294967296n;
       useExternalStickers: 137438953472n;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1267,10 +1267,11 @@ declare namespace Eris {
       manageEmojis: 1073741824n;
       useSlashCommands: 2147483648n;
       voiceRequestToSpeak: 4294967296n;
+      useExternalStickers: 137438953472n;
       allGuild: 2080899262n;
-      allText: 2953313361n;
+      allText: 140392266833n;
       allVoice: 4629464849n;
-      all: 8589934591n;
+      all: 146028888063n;
     };
     REST_VERSION: 8;
     StickerFormats: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1269,6 +1269,8 @@ declare namespace Eris {
       manageEmojisAndStickers: 1073741824n;
       /** @deprecated */
       manageEmojis: 1073741824n;
+      useApplicationCommands: 2147483648n;
+      /** @deprecated */
       useSlashCommands: 2147483648n;
       voiceRequestToSpeak: 4294967296n;
       useExternalStickers: 137438953472n;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1175,6 +1175,8 @@ declare namespace Eris {
       guilds: 1;
       guildMembers: 2;
       guildBans: 4;
+      guildEmojisAndStickers: 8;
+      /** @deprecated */
       guildEmojis: 8;
       guildIntegrations: 16;
       guildWebhooks: 32;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -34,40 +34,40 @@ module.exports.GATEWAY_VERSION = 8;
 module.exports.REST_VERSION = 8;
 
 const Permissions = {
-    createInstantInvite:  1n,
-    kickMembers:          1n << 1n,
-    banMembers:           1n << 2n,
-    administrator:        1n << 3n,
-    manageChannels:       1n << 4n,
-    manageGuild:          1n << 5n,
-    addReactions:         1n << 6n,
-    viewAuditLog:         1n << 7n, viewAuditLogs: 1n << 7n, // [DEPRECATED]
-    voicePrioritySpeaker: 1n << 8n,
-    voiceStream:          1n << 9n, stream: 1n << 9n, // [DEPRECATED]
-    viewChannel:          1n << 10n, readMessages: 1n << 10n, // [DEPRECATED]
-    sendMessages:         1n << 11n,
-    sendTTSMessages:      1n << 12n,
-    manageMessages:       1n << 13n,
-    embedLinks:           1n << 14n,
-    attachFiles:          1n << 15n,
-    readMessageHistory:   1n << 16n,
-    mentionEveryone:      1n << 17n,
-    useExternalEmojis:    1n << 18n, externalEmojis: 1n << 18n, // [DEPRECATED]
-    viewGuildInsights:    1n << 19n,
-    voiceConnect:         1n << 20n,
-    voiceSpeak:           1n << 21n,
-    voiceMuteMembers:     1n << 22n,
-    voiceDeafenMembers:   1n << 23n,
-    voiceMoveMembers:     1n << 24n,
-    voiceUseVAD:          1n << 25n,
-    changeNickname:       1n << 26n,
-    manageNicknames:      1n << 27n,
-    manageRoles:          1n << 28n,
-    manageWebhooks:       1n << 29n,
-    manageEmojis:         1n << 30n,
-    useSlashCommands:     1n << 31n,
-    voiceRequestToSpeak:  1n << 32n,
-    useExternalStickers:  1n << 37n
+    createInstantInvite:     1n,
+    kickMembers:             1n << 1n,
+    banMembers:              1n << 2n,
+    administrator:           1n << 3n,
+    manageChannels:          1n << 4n,
+    manageGuild:             1n << 5n,
+    addReactions:            1n << 6n,
+    viewAuditLog:            1n << 7n, viewAuditLogs: 1n << 7n, // [DEPRECATED]
+    voicePrioritySpeaker:    1n << 8n,
+    voiceStream:             1n << 9n, stream: 1n << 9n, // [DEPRECATED]
+    viewChannel:             1n << 10n, readMessages: 1n << 10n, // [DEPRECATED]
+    sendMessages:            1n << 11n,
+    sendTTSMessages:         1n << 12n,
+    manageMessages:          1n << 13n,
+    embedLinks:              1n << 14n,
+    attachFiles:             1n << 15n,
+    readMessageHistory:      1n << 16n,
+    mentionEveryone:         1n << 17n,
+    useExternalEmojis:       1n << 18n, externalEmojis: 1n << 18n, // [DEPRECATED]
+    viewGuildInsights:       1n << 19n,
+    voiceConnect:            1n << 20n,
+    voiceSpeak:              1n << 21n,
+    voiceMuteMembers:        1n << 22n,
+    voiceDeafenMembers:      1n << 23n,
+    voiceMoveMembers:        1n << 24n,
+    voiceUseVAD:             1n << 25n,
+    changeNickname:          1n << 26n,
+    manageNicknames:         1n << 27n,
+    manageRoles:             1n << 28n,
+    manageWebhooks:          1n << 29n,
+    manageEmojisAndStickers: 1n << 30n, manageEmojis: 1n << 30n, // [DEPRECATED]
+    useSlashCommands:        1n << 31n,
+    voiceRequestToSpeak:     1n << 32n,
+    useExternalStickers:     1n << 37n
 };
 Permissions.allGuild = Permissions.kickMembers
     | Permissions.banMembers
@@ -80,7 +80,7 @@ Permissions.allGuild = Permissions.kickMembers
     | Permissions.manageNicknames
     | Permissions.manageRoles
     | Permissions.manageWebhooks
-    | Permissions.manageEmojis;
+    | Permissions.manageEmojisAndStickers;
 Permissions.allText = Permissions.createInstantInvite
     | Permissions.manageChannels
     | Permissions.addReactions

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -66,7 +66,8 @@ const Permissions = {
     manageWebhooks:       1n << 29n,
     manageEmojis:         1n << 30n,
     useSlashCommands:     1n << 31n,
-    voiceRequestToSpeak:  1n << 32n
+    voiceRequestToSpeak:  1n << 32n,
+    useExternalStickers:  1n << 37n
 };
 Permissions.allGuild = Permissions.kickMembers
     | Permissions.banMembers

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -95,7 +95,8 @@ Permissions.allText = Permissions.createInstantInvite
     | Permissions.useExternalEmojis
     | Permissions.manageRoles
     | Permissions.manageWebhooks
-    | Permissions.useSlashCommands;
+    | Permissions.useSlashCommands
+    | Permissions.useExternalStickers;
 Permissions.allVoice = Permissions.createInstantInvite
     | Permissions.manageChannels
     | Permissions.voicePrioritySpeaker

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -65,7 +65,7 @@ const Permissions = {
     manageRoles:             1n << 28n,
     manageWebhooks:          1n << 29n,
     manageEmojisAndStickers: 1n << 30n, manageEmojis: 1n << 30n, // [DEPRECATED]
-    useSlashCommands:        1n << 31n,
+    useApplicationCommands:  1n << 31n, useSlashCommands: 1n << 31n, // [DEPRECATED]
     voiceRequestToSpeak:     1n << 32n,
     useExternalStickers:     1n << 37n
 };
@@ -95,7 +95,7 @@ Permissions.allText = Permissions.createInstantInvite
     | Permissions.useExternalEmojis
     | Permissions.manageRoles
     | Permissions.manageWebhooks
-    | Permissions.useSlashCommands
+    | Permissions.useApplicationCommands
     | Permissions.useExternalStickers;
 Permissions.allVoice = Permissions.createInstantInvite
     | Permissions.manageChannels

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -243,7 +243,7 @@ module.exports.ChannelTypes = {
 module.exports.UserFlags = {
     NONE:                         0,
     DISCORD_EMPLOYEE:             1 << 0,
-    PARTNERED_SERVER_OWNER:       1 << 1, DISCORD_PARTNER : 1 << 1, // [DEPRECATED]
+    PARTNERED_SERVER_OWNER:       1 << 1, DISCORD_PARTNER: 1 << 1, // [DEPRECATED]
     HYPESQUAD_EVENTS:             1 << 2,
     BUG_HUNTER_LEVEL_1:           1 << 3,
     HOUSE_BRAVERY:                1 << 6,
@@ -263,7 +263,7 @@ module.exports.Intents = {
     guilds:                 1 << 0,
     guildMembers:           1 << 1,
     guildBans:              1 << 2,
-    guildEmojis:            1 << 3,
+    guildEmojisAndStickers: 1 << 3, guildEmojis: 1 << 3, // [DEPRECATED]
     guildIntegrations:      1 << 4,
     guildWebhooks:          1 << 5,
     guildInvites:           1 << 6,


### PR DESCRIPTION
This PR changes different permission flag names, as well as an intent flag name. These changes were made to be consistent with the Discord documentation. Furthermore, the `useExternalStickers` permission has been added.

 - Added `useExternalStickers` permission (7987295)
 - Changed `manageEmojis` permission to `manageEmojisAndStickers` (230efcf)
 - Changed `useSlashCommands` permission to `useApplicationCommands` (a329011)
 - Changed `guildEmojis` intent to `guildEmojisAndStickers` (636fc2d)