### PR TITLE
Ability to manage stickers, guildStickersUpdate and Guild#stickers

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1800,7 +1800,7 @@ declare namespace Eris {
     getRESTGuilds(limit?: number, before?: string, after?: string): Promise<Guild[]>;
     getRESTGuildSticker(guildID: string, stickerID: string): Promise<Sticker>;
     getRESTGuildStickers(guildID: string): Promise<Sticker[]>;
-    getRESTSticker(): Promise<Sticker>;
+    getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTUser(userID: string): Promise<User>;
     getSelf(): Promise<ExtendedUser>;
     getSelfBilling(): Promise<{
@@ -2126,7 +2126,7 @@ declare namespace Eris {
     /** @deprecated */
     getRESTMembers(limit?: number, after?: string): Promise<Member[]>;
     getRESTRoles(): Promise<Role[]>;
-    getRESTSticker(): Promise<Sticker>;
+    getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTStickers(): Promise<Sticker[]>;
     getTemplates(): Promise<GuildTemplate[]>;
     getVanity(): Promise<GuildVanity>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -172,7 +172,7 @@ declare namespace Eris {
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
     /** @deprecated */
     addMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;
-    createMessage(content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message>;
+    createMessage(content: MessageContent, file?: FileContent | FileContent[]): Promise<Message>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message>;
     getMessage(messageID: string): Promise<Message>;
@@ -613,7 +613,7 @@ declare namespace Eris {
   interface RawRESTRequest {
     auth: boolean;
     body?: unknown;
-    file?: MessageFile;
+    file?: FileContent;
     method: string;
     resp: IncomingMessage;
     route: string;
@@ -864,8 +864,7 @@ declare namespace Eris {
     width?: number;
   }
   interface CreateStickerOptions extends Required<Pick<EditStickerOptions, "name" | "tags">> {
-    description?: string;
-    file: Omit<MessageFile, "name">;
+    file: FileContent;
   }
   interface EditStickerOptions {
     description?: string;
@@ -889,7 +888,7 @@ declare namespace Eris {
     id: string;
     name: string;
   }
-  interface MessageFile {
+  interface FileContent {
     file: Buffer | string;
     name: string;
   }
@@ -1076,7 +1075,7 @@ declare namespace Eris {
     avatarURL?: string;
     content?: string;
     embeds?: EmbedOptions[];
-    file?: MessageFile | MessageFile[];
+    file?: FileContent | FileContent[];
     tts?: boolean;
     username?: string;
     wait?: boolean;
@@ -1659,7 +1658,7 @@ declare namespace Eris {
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createGuildTemplate(guildID: string, name: string, description?: string | null): Promise<GuildTemplate>;
-    createMessage(channelID: string, content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message>;
+    createMessage(channelID: string, content: MessageContent, file?: FileContent | FileContent[]): Promise<Message>;
     createRole(guildID: string, options?: RoleOptions | Role, reason?: string): Promise<Role>;
     crosspostMessage(channelID: string, messageID: string): Promise<Message>;
     deleteChannel(channelID: string, reason?: string): Promise<void>;
@@ -2373,7 +2372,7 @@ declare namespace Eris {
     rateLimitPerUser: 0;
     type: 5;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", NewsChannel>>;
-    createMessage(content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<NewsChannel>>;
+    createMessage(content: MessageContent, file?: FileContent | FileContent[]): Promise<Message<NewsChannel>>;
     crosspostMessage(messageID: string): Promise<Message<NewsChannel>>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<NewsChannel>>;
     follow(webhookChannelID: string): Promise<ChannelFollow>;
@@ -2425,7 +2424,7 @@ declare namespace Eris {
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
     /** @deprecated */
     addMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;
-    createMessage(content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<PrivateChannel>>;
+    createMessage(content: MessageContent, file?: FileContent | FileContent[]): Promise<Message<PrivateChannel>>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     editMessage(messageID: string, content: MessageContent): Promise<Message<PrivateChannel>>;
     getMessage(messageID: string): Promise<Message<PrivateChannel>>;
@@ -2469,7 +2468,7 @@ declare namespace Eris {
     /** @deprecated */
     constructor(client: Client, forceQueueing?: boolean);
     globalUnblock(): void;
-    request(method: RequestMethod, url: string, auth?: boolean, body?: { [s: string]: unknown }, file?: MessageFile, _route?: string, short?: boolean): Promise<unknown>;
+    request(method: RequestMethod, url: string, auth?: boolean, body?: { [s: string]: unknown }, file?: FileContent, _route?: string, short?: boolean): Promise<unknown>;
     routefy(url: string, method: RequestMethod): string;
     toString(): string;
     toJSON(props?: string[]): JSONCache;
@@ -2620,7 +2619,7 @@ declare namespace Eris {
     /** @deprecated */
     addMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;
     createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", TextChannel>>;
-    createMessage(content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message<TextChannel>>;
+    createMessage(content: MessageContent, file?: FileContent | FileContent[]): Promise<Message<TextChannel>>;
     createWebhook(options: { name: string; avatar?: string | null}, reason?: string): Promise<Webhook>;
     deleteMessage(messageID: string, reason?: string): Promise<void>;
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2153,7 +2153,7 @@ declare namespace Eris {
     message?: Message<GuildTextableChannel>;
     reason: string | null;
     role?: Role | { id: string; name: string };
-    target?: Guild | AnyGuildChannel | Member | Role | Invite | Emoji | Message<GuildTextableChannel> | null;
+    target?: Guild | AnyGuildChannel | Member | Role | Invite | Emoji | Sticker | Message<GuildTextableChannel> | null;
     targetID: string;
     user: User;
     constructor(data: BaseData, guild: Guild);

--- a/index.d.ts
+++ b/index.d.ts
@@ -1298,8 +1298,8 @@ declare namespace Eris {
     };
     REST_VERSION: 8;
     StickerTypes: {
-      STANDARD: 1,
-      GUILD: 2
+      STANDARD: 1;
+      GUILD: 2;
     };
     StickerFormats: {
       PNG: 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1159,9 +1159,9 @@ declare namespace Eris {
       INTEGRATION_UPDATE: 81;
       INTEGRATION_DELETE: 82;
 
-      STICKER_CREATE: 90,
-      STICKER_UPDATE: 91,
-      STICKER_DELETE: 92
+      STICKER_CREATE: 90;
+      STICKER_UPDATE: 91;
+      STICKER_DELETE: 92;
     };
     ChannelTypes: {
       GUILD_TEXT: 0;

--- a/index.d.ts
+++ b/index.d.ts
@@ -863,6 +863,15 @@ declare namespace Eris {
     url: string;
     width?: number;
   }
+  interface CreateStickerOptions extends Required<Pick<EditStickerOptions, "name" | "tags">> {
+    description?: string;
+    file: Omit<MessageFile, "name">;
+  }
+  interface EditStickerOptions {
+    description?: string;
+    name?: string;
+    tags?: string
+  }
   interface GetMessageReactionOptions {
     after?: string;
     /** @deprecated */
@@ -1648,7 +1657,7 @@ declare namespace Eris {
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
-    createGuildSticker(guildID: string, options: { description?: string, file: Omit<MessageFile, "name">, name: string, tags: string }, reason?: string): Promise<Sticker>;
+    createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createGuildTemplate(guildID: string, name: string, description?: string | null): Promise<GuildTemplate>;
     createMessage(channelID: string, content: MessageContent, file?: MessageFile | MessageFile[]): Promise<Message>;
     createRole(guildID: string, options?: RoleOptions | Role, reason?: string): Promise<Role>;
@@ -1697,7 +1706,7 @@ declare namespace Eris {
     ): Promise<Emoji>;
     editGuildIntegration(guildID: string, integrationID: string, options: IntegrationOptions): Promise<void>;
     editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
-    editGuildSticker(guildID: string, stickerID: string, options?: { description?: string, name?: string, tags?: string }, reason?: string): Promise<Sticker>;
+    editGuildSticker(guildID: string, stickerID: string, options?: EditStickerOptions, reason?: string): Promise<Sticker>;
     editGuildTemplate(guildID: string, code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;
     editGuildVanity(guildID: string, code: string | null): Promise<GuildVanity>;
     editGuildVoiceState(guildID: string, options: VoiceStateOptions, userID?: string): Promise<void>;
@@ -2071,7 +2080,7 @@ declare namespace Eris {
     createChannel(name: string, type?: number, reason?: string, options?: CreateChannelOptions | string): Promise<unknown>;
     createEmoji(options: { image: string; name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     createRole(options: RoleOptions | Role, reason?: string): Promise<Role>;
-    createSticker(options: { description?: string, file: Omit<MessageFile, "name">, name: string, tags: string }, reason?: string): Promise<Sticker>;
+    createSticker(options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createTemplate(name: string, description?: string | null): Promise<GuildTemplate>;
     delete(): Promise<void>;
     deleteDiscoverySubcategory(categoryID: string, reason?: string): Promise<void>;
@@ -2091,7 +2100,7 @@ declare namespace Eris {
     editMember(memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
     editNickname(nick: string): Promise<void>;
     editRole(roleID: string, options: RoleOptions): Promise<Role>;
-    editSticker(stickerID: string, options?: { description?: string, name?: string, tags?: string }, reason?: string): Promise<Sticker>;
+    editSticker(stickerID: string, options?: EditStickerOptions, reason?: string): Promise<Sticker>;
     editTemplate(code: string, options: GuildTemplateOptions): Promise<GuildTemplate>;
     editVanity(code: string | null): Promise<GuildVanity>;
     editVoiceState(options: VoiceStateOptions, userID?: string): Promise<void>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2022,7 +2022,7 @@ class Client extends EventEmitter {
 
     /**
      * Get the list of sticker packs available to Nitro subscribers
-     * @returns {Promise<Array<Object>>} An array of sticker pack objects
+     * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
      */
     getNitroStickerPacks() {
         return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -749,6 +749,19 @@ class Client extends EventEmitter {
     }
 
     /**
+    * Delete a guild sticker
+    * @arg {String} guildID The ID of the guild
+    * @arg {String} stickerID The ID of the sticker
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise}
+    */
+    deleteGuildSticker(guildID, stickerID, reason) {
+        return this.requestHandler.request("DELETE", Endpoints.GUILD_STICKER(guildID, stickerID), true, {
+            reason
+        });
+    }
+
+    /**
     * Delete a guild template
     * @arg {String} guildID The ID of the guild
     * @arg {String} code The template code
@@ -1140,6 +1153,21 @@ class Client extends EventEmitter {
             channel_id: options.channelID,
             reason: reason
         }).then((member) => new Member(member, this.guilds.get(guildID), this));
+    }
+
+    /**
+    * Edit a guild sticker
+    * @arg {String} stickerID The ID of the sticker
+    * @arg {Object} options The properties to edit
+    * @arg {String} [options.description] The description of the sticker
+    * @arg {String} [options.name] The name of the sticker
+    * @arg {String} [options.tags] The Discord name of a unicode emoji representing the sticker's expression
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise<Object>} A sticker object
+    */
+    editGuildSticker(guildID, stickerID, options, reason) {
+        options.reason = reason;
+        return this.requestHandler.request("PATCH", Endpoints.GUILD_STICKER(guildID, stickerID), true, options);
     }
 
     /**
@@ -1977,6 +2005,14 @@ class Client extends EventEmitter {
     }
 
     /**
+     * Get the list of sticker packs available to Nitro subscribers
+     * @returns {Promise<Array<Object>>} An array of sticker pack objects
+     */
+    getNitroStickerPacks() {
+        return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);
+    }
+
+    /**
     * Get data on an OAuth2 application
     * @arg {String} [appID="@me"] The client ID of the application to get data for (user accounts only). "@me" refers to the logged in user's own application
     * @returns {Promise<Object>} The bot's application data. Refer to [the official Discord API documentation entry](https://discord.com/developers/docs/topics/oauth2#get-current-application-information) for object structure
@@ -2151,6 +2187,43 @@ class Client extends EventEmitter {
             options.before = before;
         }
         return this.requestHandler.request("GET", Endpoints.USER_GUILDS("@me"), true, options).then((guilds) => guilds.map((guild) => new Guild(guild, this)));
+    }
+
+    /**
+    * Get a guild sticker via the REST API. REST mode is required to use this endpoint.
+    * @arg {String} guildID The ID of the guild
+    * @arg {String} stickerID The ID of the sticker
+    * @returns {Promise<Object>} A sticker object
+    */
+    getRESTGuildSticker(guildID, stickerID) {
+        if(!this.options.restMode) {
+            return Promise.reject(new Error("Eris REST mode is not enabled"));
+        }
+        return this.requestHandler.request("GET", Endpoints.GUILD_STICKER(guildID, stickerID), true);
+    }
+
+    /**
+    * Get a guild's stickers via the REST API. REST mode is required to use this endpoint.
+    * @arg {String} guildID The ID of the guild
+    * @returns {Promise<Array<Object>>} An array of guild sticker objects
+    */
+    getRESTGuildStickers(guildID) {
+        if(!this.options.restMode) {
+            return Promise.reject(new Error("Eris REST mode is not enabled"));
+        }
+        return this.requestHandler.request("GET", Endpoints.GUILD_STICKERS(guildID), true);
+    }
+
+    /**
+    * Get a sticker via the REST API. REST mode is required to use this endpoint.
+    * @arg {String} stickerID The ID of the sticker
+    * @returns {Promise<Object>} A sticker object
+     */
+    getRESTSticker(stickerID) {
+        if(!this.options.restMode) {
+            return Promise.reject(new Error("Eris REST mode is not enabled"));
+        }
+        return this.requestHandler.request("GET", Endpoints.STICKER(stickerID), true);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -567,9 +567,12 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} A sticker object
     */
     createGuildSticker(guildID, options, reason) {
-        options.description = options.description || "";
-        options.reason = reason;
-        return this.requestHandler.request("POST", Endpoints.GUILD_STICKERS(guildID), true, options, options.file);
+        return this.requestHandler.request("POST", Endpoints.GUILD_STICKERS(guildID), true, {
+            description: options.description || "",
+            name: options.name,
+            tags: options.tags,
+            reason: reason
+        }, options.file);
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -556,6 +556,22 @@ class Client extends EventEmitter {
     }
 
     /**
+    * Create a guild sticker
+    * @arg {Object} options The properties to edit
+    * @arg {String} options.description The description of the sticker
+    * @arg {Object} options.file A file object
+    * @arg {Buffer} options.file.file A buffer containing file data
+    * @arg {String} options.name The name of the sticker
+    * @arg {String} options.tags The Discord name of a unicode emoji representing the sticker's expression
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise<Object>} A sticker object
+    */
+    createGuildSticker(guildID, options, reason) {
+        options.reason = reason;
+        return this.requestHandler.request("POST", Endpoints.GUILD_STICKERS(guildID), true, options, options.file);
+    }
+
+    /**
     * Create a template for a guild
     * @arg {String} guildID The ID of the guild
     * @arg {String} name The name of the template

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -557,8 +557,8 @@ class Client extends EventEmitter {
 
     /**
     * Create a guild sticker
-    * @arg {Object} options The properties to edit
-    * @arg {String} options.description The description of the sticker
+    * @arg {Object} options Sticker options
+    * @arg {String} [options.description] The description of the sticker
     * @arg {Object} options.file A file object
     * @arg {Buffer} options.file.file A buffer containing file data
     * @arg {String} options.name The name of the sticker
@@ -567,6 +567,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Object>} A sticker object
     */
     createGuildSticker(guildID, options, reason) {
+        options.description = options.description || "";
         options.reason = reason;
         return this.requestHandler.request("POST", Endpoints.GUILD_STICKERS(guildID), true, options, options.file);
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -561,6 +561,7 @@ class Client extends EventEmitter {
     * @arg {String} [options.description] The description of the sticker
     * @arg {Object} options.file A file object
     * @arg {Buffer} options.file.file A buffer containing file data
+    * @arg {String} options.file.name What to name the file
     * @arg {String} options.name The name of the sticker
     * @arg {String} options.tags The Discord name of a unicode emoji representing the sticker's expression
     * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -184,7 +184,11 @@ module.exports.AuditLogActions = {
 
     INTEGRATION_CREATE:       80,
     INTEGRATION_UPDATE:       81,
-    INTEGRATION_DELETE:       82
+    INTEGRATION_DELETE:       82,
+
+    STICKER_CREATE:           90,
+    STICKER_UPDATE:           91,
+    STICKER_DELETE:           92
 };
 
 module.exports.MessageActivityTypes = {

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -260,7 +260,6 @@ module.exports.UserFlags = {
     DISCORD_CERTIFIED_MODERATOR:  1 << 18
 };
 
-
 module.exports.Intents = {
     guilds:                 1 << 0,
     guildMembers:           1 << 1,
@@ -277,4 +276,15 @@ module.exports.Intents = {
     directMessages:         1 << 12,
     directMessageReactions: 1 << 13,
     directMessageTyping:    1 << 14
+};
+
+module.exports.StickerTypes = {
+    STANDARD: 1,
+    GUILD:    2
+};
+
+module.exports.StickerFormats = {
+    PNG:    1,
+    APNG:   2,
+    LOTTIE: 3
 };

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2012,6 +2012,25 @@ class Shard extends EventEmitter {
                 this.emit("guildEmojisUpdate", guild || {id: packet.d.guild_id}, emojis, oldEmojis);
                 break;
             }
+            case "GUILD_STICKERS_UPDATE": {
+                const guild = this.client.guilds.get(packet.d.guild_ID);
+                let oldStickers = null;
+                let stickers = packet.d.stickers;
+                if(guild) {
+                    oldStickers = guild.stickers;
+                    guild.update(packet.d);
+                    stickers = guild.stickers;
+                }
+                /**
+                * Fired when a guild's stickers are updated
+                * @event Client#guildStickersUpdate
+                * @prop {Guild} guild The guild. If the guild is uncached, this is an object with an ID key. No other property is guaranteed
+                * @prop {Array} stickers The updated stickers of the guild
+                * @prop {Array?} oldStickers The old stickers of the guild. If the guild is uncached, this will be null
+                */
+                this.emit("guildStickersUpdate", guild || {id: packet.d.guild_id}, stickers, oldStickers);
+                break;
+            }
             case "CHANNEL_PINS_UPDATE": {
                 const channel = this.client.getChannel(packet.d.channel_id);
                 if(!channel) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1247,6 +1247,7 @@ class Shard extends EventEmitter {
                     region: guild.region,
                     rulesChannelID: guild.rulesChannelID,
                     splash: guild.splash,
+                    stickers: guild.stickers,
                     systemChannelFlags: guild.systemChannelFlags,
                     systemChannelID: guild.systemChannelID,
                     vanityURL: guild.vanityURL,
@@ -1281,6 +1282,7 @@ class Shard extends EventEmitter {
                 * @prop {String} oldGuild.region The region of the guild
                 * @prop {String?} oldGuild.rulesChannelID The channel where "COMMUNITY" guilds display rules and/or guidelines
                 * @prop {String?} oldGuild.splash The hash of the guild splash image, or null if no splash (VIP only)
+                * @prop {Array<Object>?} stickers An array of guild sticker objects
                 * @prop {Number} oldGuild.systemChannelFlags the flags for the system channel
                 * @prop {String?} oldGuild.systemChannelID The ID of the default channel for system messages (built-in join messages and boost messages)
                 * @prop {String?} oldGuild.vanityURL The vanity URL of the guild (VIP only)

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2013,7 +2013,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_STICKERS_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.guild_ID);
+                const guild = this.client.guilds.get(packet.d.guild_id);
                 let oldStickers = null;
                 let stickers = packet.d.stickers;
                 if(guild) {

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -70,7 +70,7 @@ module.exports.GUILDS =                                                         
 module.exports.INVITE =                                               (inviteID) => `/invites/${inviteID}`;
 module.exports.OAUTH2_APPLICATION =                                      (appID) => `/oauth2/applications/${appID}`;
 module.exports.STICKER =                                             (stickerID) => `/stickers/${stickerID}`;
-module.exports.STICKER_PACKS =                                                      "sticker-packs";
+module.exports.STICKER_PACKS =                                                      "/sticker-packs";
 module.exports.USER =                                                   (userID) => `/users/${userID}`;
 module.exports.USER_BILLING =                                           (userID) => `/users/${userID}/billing`;
 module.exports.USER_BILLING_PAYMENTS =                                  (userID) => `/users/${userID}/billing/payments`;

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -55,6 +55,8 @@ module.exports.GUILD_PREVIEW =                                         (guildID)
 module.exports.GUILD_PRUNE =                                           (guildID) => `/guilds/${guildID}/prune`;
 module.exports.GUILD_ROLE =                                    (guildID, roleID) => `/guilds/${guildID}/roles/${roleID}`;
 module.exports.GUILD_ROLES =                                           (guildID) => `/guilds/${guildID}/roles`;
+module.exports.GUILD_STICKER =                              (guildID, stickerID) => `/guilds/${guildID}/stickers/${stickerID}`;
+module.exports.GUILD_STICKERS =                                        (guildID) => `/guilds/${guildID}/stickers`;
 module.exports.GUILD_TEMPLATE =                                           (code) => `/guilds/templates/${code}`;
 module.exports.GUILD_TEMPLATES =                                       (guildID) => `/guilds/${guildID}/templates`;
 module.exports.GUILD_TEMPLATE_GUILD =                            (guildID, code) => `/guilds/${guildID}/templates/${code}`;
@@ -67,6 +69,8 @@ module.exports.GUILD_VOICE_STATE =                               (guildID, user)
 module.exports.GUILDS =                                                             "/guilds";
 module.exports.INVITE =                                               (inviteID) => `/invites/${inviteID}`;
 module.exports.OAUTH2_APPLICATION =                                      (appID) => `/oauth2/applications/${appID}`;
+module.exports.STICKER =                                             (stickerID) => `/stickers/${stickerID}`;
+module.exports.STICKER_PACKS =                                                      "sticker-packs";
 module.exports.USER =                                                   (userID) => `/users/${userID}`;
 module.exports.USER_BILLING =                                           (userID) => `/users/${userID}/billing`;
 module.exports.USER_BILLING_PAYMENTS =                                  (userID) => `/users/${userID}/billing/payments`;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -126,7 +126,13 @@ class RequestHandler {
                             headers["Content-Type"] = "multipart/form-data; boundary=" + data.boundary;
                             data.attach("file", file.file, file.name);
                             if(body) {
-                                data.attach("payload_json", body);
+                                if(method === "POST" && url.endsWith("/stickers")) {
+                                    for(const key in body) {
+                                        data.attach(key, body[key]);
+                                    }
+                                } else {
+                                    data.attach("payload_json", body);
+                                }
                             }
                             data = data.finish();
                         } else {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -448,6 +448,16 @@ class Guild extends Base {
     }
 
     /**
+    * Delete a guild sticker
+    * @arg {String} stickerID The ID of the sticker
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise}
+    */
+    deleteSticker(stickerID, reason) {
+        return this._client.deleteGuildSticker.call(this._client, this.id, stickerID, reason);
+    }
+
+    /**
     * Delete a guild template
     * @arg {String} code The template code
     * @returns {Promise<GuildTemplate>}
@@ -599,6 +609,20 @@ class Guild extends Base {
     */
     editRole(roleID, options, reason) {
         return this._client.editRole.call(this._client, this.id, roleID, options, reason);
+    }
+
+    /**
+    * Edit a guild sticker
+    * @arg {String} stickerID The ID of the sticker
+    * @arg {Object} options The properties to edit
+    * @arg {String} [options.description] The description of the sticker
+    * @arg {String} [options.name] The name of the sticker
+    * @arg {String} [options.tags] The Discord name of a unicode emoji representing the sticker's expression
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise<Object>} A sticker object
+    */
+    editSticker(stickerID, options, reason) {
+        return this._client.editGuildSticker.call(this._client, this.id, stickerID, options, reason);
     }
 
     /**
@@ -815,6 +839,23 @@ class Guild extends Base {
     */
     getRESTRoles() {
         return this._client.getRESTGuildRoles.call(this._client, this.id);
+    }
+
+    /**
+    * Get a guild sticker via the REST API. REST mode is required to use this endpoint.
+    * @arg {String} stickerID The ID of the sticker
+    * @returns {Promise<Object>} A sticker object
+    */
+    getRESTSticker(stickerID) {
+        return this._client.getRESTGuildSticker.call(this._client, this.id, stickerID);
+    }
+
+    /**
+    * Get a guild's stickers via the REST API. REST mode is required to use this endpoint.
+    * @returns {Promise<Array<Object>>} An array of guild sticker objects
+    */
+    getRESTStickers() {
+        return this._client.getRESTGuildStickers.call(this._client, this.id);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -396,6 +396,7 @@ class Guild extends Base {
     * @arg {String} [options.description] The description of the sticker
     * @arg {Object} options.file A file object
     * @arg {Buffer} options.file.file A buffer containing file data
+    * @arg {String} options.file.name What to name the file
     * @arg {String} options.name The name of the sticker
     * @arg {String} options.tags The Discord name of a unicode emoji representing the sticker's expression
     * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -391,6 +391,21 @@ class Guild extends Base {
     }
 
     /**
+    * Create a guild sticker
+    * @arg {Object} options The properties to edit
+    * @arg {String} options.description The description of the sticker
+    * @arg {Object} options.file A file object
+    * @arg {Buffer} options.file.file A buffer containing file data
+    * @arg {String} options.name The name of the sticker
+    * @arg {String} options.tags The Discord name of a unicode emoji representing the sticker's expression
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise<Object>} A sticker object
+    */
+    createSticker(options, reason) {
+        return this._client.createGuildSticker.call(this._client, this.id, options, reason);
+    }
+
+    /**
     * Create a template for this guild
     * @arg {String} name The name of the template
     * @arg {String} [description] The description for the template

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -392,8 +392,8 @@ class Guild extends Base {
 
     /**
     * Create a guild sticker
-    * @arg {Object} options The properties to edit
-    * @arg {String} options.description The description of the sticker
+    * @arg {Object} options Sticker options
+    * @arg {String} [options.description] The description of the sticker
     * @arg {Object} options.file A file object
     * @arg {Buffer} options.file.file A buffer containing file data
     * @arg {String} options.name The name of the sticker

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -60,6 +60,7 @@ const {Permissions} = require("../Constants");
 * @prop {Shard} shard The Shard that owns the guild
 * @prop {String?} splash The hash of the guild splash image, or null if no splash (VIP only)
 * @prop {String?} splashURL The URL of the guild's splash image
+* @prop {Array<Object>?} stickers An array of guild sticker objects
 * @prop {Number} systemChannelFlags The flags for the system channel
 * @prop {String?} systemChannelID The ID of the default channel for system messages (built-in join messages and boost messages)
 * @prop {Boolean} unavailable Whether the guild is unavailable or not
@@ -215,6 +216,9 @@ class Guild extends Base {
         }
         if(data.emojis !== undefined) {
             this.emojis = data.emojis;
+        }
+        if(data.stickers !== undefined) {
+            this.stickers = data.stickers;
         }
         if(data.afk_channel_id !== undefined) {
             this.afkChannelID = data.afk_channel_id;
@@ -1029,6 +1033,7 @@ class Guild extends Base {
             "roles",
             "rulesChannelID",
             "splash",
+            "stickers",
             "systemChannelFlags",
             "systemChannelID",
             "unavailable",

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -121,6 +121,8 @@ class GuildAuditLogEntry extends Base {
             return this.guild && this.guild.shard.client.users.get(this.targetID);
         } else if(this.actionType < 90) { // Integrations
             return null;
+        } else if(this.actionType < 100) { // Sticker
+            return this.guild && this.guild.stickers.find((sticker) => sticker.id === this.targetID);
         } else {
             throw new Error("Unrecognized action type: " + this.actionType);
         }

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -30,7 +30,8 @@ const {AuditLogActions} = require("../Constants");
 * If the action targets a role, this could be a Role object
 * If the action targets an invite, this is an Invite object
 * If the action targets a webhook, this is null
-* If the action targets a emoji, this could be an emoji Object
+* If the action targets a emoji, this could be an emoji object
+* If the action targets a sticker, this could be a sticker object
 * If the action targets a message, this is a User object
 * @prop {String} targetID The ID of the action target
 * @prop {User} user The user that performed the action

--- a/lib/util/MultipartData.js
+++ b/lib/util/MultipartData.js
@@ -11,10 +11,38 @@ class MultipartData {
             return;
         }
         let str = "\r\n--" + this.boundary + "\r\nContent-Disposition: form-data; name=\"" + fieldName + "\"";
+        let contentType;
         if(filename) {
             str += "; filename=\"" + filename + "\"";
+            const extension = filename.match(/\.(png|apng|gif|jpg|jpeg|webp|svg|json)$/i);
+            if(extension) {
+                let ext = extension[1].toLowerCase();
+                switch(ext) {
+                    case "png":
+                    case "apng":
+                    case "gif":
+                    case "jpg":
+                    case "jpeg":
+                    case "webp":
+                    case "svg": {
+                        if(ext === "svg") {
+                            ext = "svg+xml";
+                        }
+                        contentType = "image/";
+                        break;
+                    }
+                    case "json": {
+                        contentType = "application/";
+                        break;
+                    }
+                }
+                contentType += ext;
+            }
         }
-        if(ArrayBuffer.isView(data)) {
+
+        if(contentType) {
+            str += `\r\nContent-Type: ${contentType}`;
+        } else if(ArrayBuffer.isView(data)) {
             str +="\r\nContent-Type: application/octet-stream";
             if(!(data instanceof Uint8Array)) {
                 data = new Uint8Array(data.buffer, data.byteOffset, data.byteLength);


### PR DESCRIPTION
This PR will add a ton of sticker-related functions and properties. Please nitpick as many inconsistencies/issues you can spot :)

# Additions

 - Guild#stickers property (32b4025)
 - Sticker endpoints (32b4025)
 - Ability to create/edit/delete stickers (049299e, 6436774)
 - New `guildStickersUpdate` event (6fdbeae)
 - Audit log action types for `STICKER_CREATE`, `STICKER_UPDATE` and `STICKER_DELETE` (735a142)
 - Guild#getRESTStickers, Guild#getRESTSticker, Client#getRESTGuildStickers, Client#getRESTGuildSticker, Client#getNitroStickerPacks, Client#getRESTSticker (049299e)

# Changes

- RequestHandler supports creating a sticker via using the `file` param (2db7ffc)