### PR TITLE
Deprecate (useSlashCommands), add (useApplicationCommands)  for permissions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1265,7 +1265,9 @@ declare namespace Eris {
       manageRoles: 268435456n;
       manageWebhooks: 536870912n;
       manageEmojis: 1073741824n;
+      /** @deprecated */
       useSlashCommands: 2147483648n;
+      useApplicationCommands: 2147483648n;
       voiceRequestToSpeak: 4294967296n;
       allGuild: 2080899262n;
       allText: 2953313361n;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -65,7 +65,7 @@ const Permissions = {
     manageRoles:          1n << 28n,
     manageWebhooks:       1n << 29n,
     manageEmojis:         1n << 30n,
-    useSlashCommands:     1n << 31n,
+    useApplicationCommands:     1n << 31n, useSlashCommands: 1n << 31n, // [DEPRECATED]
     voiceRequestToSpeak:  1n << 32n
 };
 Permissions.allGuild = Permissions.kickMembers
@@ -94,7 +94,7 @@ Permissions.allText = Permissions.createInstantInvite
     | Permissions.useExternalEmojis
     | Permissions.manageRoles
     | Permissions.manageWebhooks
-    | Permissions.useSlashCommands;
+    | Permissions.useApplicationCommands;
 Permissions.allVoice = Permissions.createInstantInvite
     | Permissions.manageChannels
     | Permissions.voicePrioritySpeaker

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -65,7 +65,7 @@ const Permissions = {
     manageRoles:          1n << 28n,
     manageWebhooks:       1n << 29n,
     manageEmojis:         1n << 30n,
-    useApplicationCommands:     1n << 31n, useSlashCommands: 1n << 31n, // [DEPRECATED]
+    useApplicationCommands: 1n << 31n, useSlashCommands: 1n << 31n, // [DEPRECATED]
     voiceRequestToSpeak:  1n << 32n
 };
 Permissions.allGuild = Permissions.kickMembers


### PR DESCRIPTION
This PR deprecates `useSlashCommands` and adds `useApplicationCommands` to permissions.

PR: https://github.com/discord/discord-api-docs/pull/3614