### PR TITLE
Prevent "User associated with Member not found"

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -124,7 +124,9 @@ class Message extends Base {
         if(this.channel.guild) {
             if(data.member) {
                 data.member.id = this.author.id;
-                if(data.author) data.member.user = data.author;
+                if(data.author) {
+                    data.member.user = data.author;
+                }
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
             } else if(this.channel.guild.members.has(this.author.id)) {
                 this.member = this.channel.guild.members.get(this.author.id);

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -124,6 +124,7 @@ class Message extends Base {
         if(this.channel.guild) {
             if(data.member) {
                 data.member.id = this.author.id;
+                if(data.author) data.member.user = data.author;
                 this.member = this.channel.guild.members.update(data.member, this.channel.guild);
             } else if(this.channel.guild.members.has(this.author.id)) {
                 this.member = this.channel.guild.members.get(this.author.id);


### PR DESCRIPTION
When `client.users.limit` is set to `0`, new messages throw `Error: User associated with Member not found` due to the user not being cached. Virtually, it should also happen when the cache limit is set to a really low value and the client receives a lot of messages at once. 

As a fix, send "user" along with "member" when creating a Message. This should make the client use `data.user` in the absence of a cached user.