### PR TITLE
fix(rest): add separate ratelimit for messages <=10s old

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -396,6 +396,8 @@ class RequestHandler {
             const createdAt = Base.getCreatedAt(messageID);
             if(Date.now() - this.latencyRef.latency - createdAt >= 1000 * 60 * 60 * 24 * 14) {
                 method += "_OLD";
+            } else if(Date.now() - this.latencyRef.latency - createdAt <= 1000 * 10) {
+                method += "_NEW";
             }
             route = method + route;
         }


### PR DESCRIPTION
My 10 second message age confusion from #1173 was figured out - messages less than 10 seconds old have a rate limit of 3/1. The parent rate limit of 5/5 still exists, as well as the other subroute limit of 30/120 for messages older than 14 days