### PR TITLE
fix(rest): combine routes for GET /guilds/:id/channels

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -404,7 +404,7 @@ class RequestHandler {
                 method += "_OLD";
             }
             route = method + route;
-        } else if(method === "GET" && /\/guilds\/\d+\/channels$/.test(route)) {
+        } else if(method === "GET" && /\/guilds\/[0-9]+\/channels$/.test(route)) {
             route = "/guilds/:id/channels";
         }
         if(method === "PUT" || method === "DELETE") {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -404,6 +404,8 @@ class RequestHandler {
                 method += "_OLD";
             }
             route = method + route;
+        } else if(method === "GET" && /\/guilds\/\d+\/channels$/.test(route)) {
+            route = "/guilds/:id/channels";
         }
         if(method === "PUT" || method === "DELETE") {
             const index = route.indexOf("/reactions");


### PR DESCRIPTION
Confirmed by Zeyla that /guilds/:id/channels share a single rate limit bucket regardless of the major param (differing guild IDs)