### PR TITLE
Prevent heartbeat during identify

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2555,7 +2555,7 @@ declare namespace Eris {
     requestMembersPromise: { [s: string]: RequestMembersPromise };
     seq: number;
     sessionID: string | null;
-    status: "disconnected" | "connecting" | "handshaking" | "ready" | "resuming";
+    status: "connecting" | "disconnected" | "handshaking" | "identifying" | "ready" | "resuming";
     unsyncedGuilds: number;
     ws: WebSocket | BrowserWebSocket | null;
     constructor(id: number, client: Client);

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -286,7 +286,7 @@ class Shard extends EventEmitter {
     }
 
     heartbeat(normal) {
-        // Cannot heartbeat during an identify/resume otherwise session will be killed
+        // Can only heartbeat after identify/resume succeeds, session will be killed otherwise, discord/discord-api-docs#1619
         if(this.status === "resuming" || this.status === "identifying") {
             return;
         }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -48,7 +48,7 @@ try {
 * @prop {Number} lastHeartbeatSent Last time shard sent a heartbeat, null if shard has not sent heartbeat yet
 * @prop {Number} latency The current latency between the shard and Discord, in milliseconds
 * @prop {Boolean} ready Whether the shard is ready
-* @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"ready"
+* @prop {String} status The status of the shard. "disconnected"/"connecting"/"handshaking"/"ready"/"identifying"/"resuming"
 */
 class Shard extends EventEmitter {
     constructor(id, client) {
@@ -286,8 +286,8 @@ class Shard extends EventEmitter {
     }
 
     heartbeat(normal) {
-        // Can only heartbeat after resume succeeds, discord/discord-api-docs#1619
-        if(this.status === "resuming") {
+        // Cannot heartbeat during an identify/resume otherwise session will be killed
+        if(this.status === "resuming" || this.status === "identifying") {
             return;
         }
         if(normal) {
@@ -320,6 +320,7 @@ class Shard extends EventEmitter {
             this.emit("error", new Error("pako/zlib-sync not found, cannot decompress data"));
             return;
         }
+        this.status = "identifying";
         const identify = {
             token: this._token,
             v: GATEWAY_VERSION,


### PR DESCRIPTION
Discord confirmed that you should not be heartbeating in between both identify/resume and ready/resumed events respectively