### PR TITLE
premiumProgressBarEnabled & nullable maxPresences

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2305,7 +2305,7 @@ declare namespace Eris {
     joinedAt: number;
     large: boolean;
     maxMembers: number;
-    maxPresences: number;
+    maxPresences: number | null;
     maxVideoChannelUsers?: number;
     memberCount: number;
     members: Collection<Member>;
@@ -2316,6 +2316,7 @@ declare namespace Eris {
     nsfwLevel: NSFWLevel;
     ownerID: string;
     preferredLocale: string;
+    premiumProgressBarEnabled: boolean;
     premiumSubscriptionCount?: number;
     premiumTier: PremiumTier;
     primaryCategory?: DiscoveryCategory;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2305,7 +2305,7 @@ declare namespace Eris {
     joinedAt: number;
     large: boolean;
     maxMembers: number;
-    maxPresences: number | null;
+    maxPresences?: number | null;
     maxVideoChannelUsers?: number;
     memberCount: number;
     members: Collection<Member>;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -49,6 +49,7 @@ const {Permissions} = require("../Constants");
 * @prop {Number} nsfwLevel The guild NSFW level designated by Discord
 * @prop {String} ownerID The ID of the user that is the guild owner
 * @prop {String} preferredLocale Preferred "COMMUNITY" guild language used in server discovery and notices from Discord
+* @prop {Boolean} premiumProgressBarEnabled If the boost progress bar is enabled
 * @prop {Number?} premiumSubscriptionCount The total number of users currently boosting this guild
 * @prop {Number} premiumTier Nitro boost level of the guild
 * @prop {Object?} primaryCategory The guild's primary discovery category
@@ -246,6 +247,9 @@ class Guild extends Base {
         }
         if(data.system_channel_flags !== undefined) {
             this.systemChannelFlags = data.system_channel_flags;
+        }
+        if(data.premium_progress_bar_enabled !== undefined) {
+            this.premiumProgressBarEnabled = data.premium_progress_bar_enabled;
         }
         if(data.premium_tier !== undefined) {
             this.premiumTier = data.premium_tier;
@@ -1189,6 +1193,7 @@ class Guild extends Base {
             "ownerID",
             "pendingVoiceStates",
             "preferredLocale",
+            "premiumProgressBarEnabled",
             "premiumSubscriptionCount",
             "premiumTier",
             "primaryCategory",


### PR DESCRIPTION
There's also some `hub_type` I'm seeing but there's no documentation on it.

`premium_progress_bar_enabled` also isn't on the docs but it's easy enough to discern what it is.

And for nullable `maxPresences`:
![](https://butts-are.cool/chrome_11-06-2021_12-12-15.png)