### PR TITLE
Fix CommandInteraction and rawWS deep reference editing

### DIFF
--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -52,7 +52,7 @@ class CommandInteraction extends Interaction {
             this.data.options = {
                 name: info.data.options.name,
                 type: info.data.options.type
-            }
+            };
         }
 
         if(info.data.resolved !== undefined) {

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -41,9 +41,22 @@ class CommandInteraction extends Interaction {
             id: info.channel_id
         };
 
-        this.data = info.data;
+        this.data = {
+            id: info.data.id,
+            name: info.data.name,
+            type: info.data.type,
+            target_id: info.data.target_id,
+        };
+
+        if(info.data.options) {
+            this.data.options = {
+                name: info.data.options.name,
+                type: info.data.options.type
+            }
+        }
 
         if(info.data.resolved !== undefined) {
+            this.data.resolved = {};
             //Users
             if(info.data.resolved.users !== undefined) {
                 const usermap = new Collection(User);

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -51,7 +51,9 @@ class CommandInteraction extends Interaction {
         if(info.data.options) {
             this.data.options = {
                 name: info.data.options.name,
-                type: info.data.options.type
+                type: info.data.options.type,
+                value: info.data.options.value,
+                options: info.data.options.options
             };
         }
 

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -41,24 +41,9 @@ class CommandInteraction extends Interaction {
             id: info.channel_id
         };
 
-        this.data = {
-            id: info.data.id,
-            name: info.data.name,
-            type: info.data.type,
-            target_id: info.data.target_id
-        };
-
-        if(info.data.options) {
-            this.data.options = {
-                name: info.data.options.name,
-                type: info.data.options.type,
-                value: info.data.options.value,
-                options: info.data.options.options
-            };
-        }
+        this.data = JSON.parse(JSON.stringify(info.data));
 
         if(info.data.resolved !== undefined) {
-            this.data.resolved = {};
             //Users
             if(info.data.resolved.users !== undefined) {
                 const usermap = new Collection(User);

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -45,7 +45,7 @@ class CommandInteraction extends Interaction {
             id: info.data.id,
             name: info.data.name,
             type: info.data.type,
-            target_id: info.data.target_id,
+            target_id: info.data.target_id
         };
 
         if(info.data.options) {


### PR DESCRIPTION
While i hate this but it's the only way to fix data.resolved being overwrited in rawWS. 
this is the style of code that has been followed in all other events.