### PR TITLE
fix(structs): fix incorrect thread method references

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -826,7 +826,7 @@ class Guild extends Base {
     * @returns {Promise<Object>} An object containing an array of `threads` and an array of `members`
     */
     getActiveThreads() {
-        return this.client.getActiveThreads.call(this.client, this.id);
+        return this._client.getActiveThreads.call(this._client, this.id);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -826,7 +826,7 @@ class Guild extends Base {
     * @returns {Promise<Object>} An object containing an array of `threads` and an array of `members`
     */
     getActiveThreads() {
-        return this._client.getActiveThreads.call(this._client, this.id);
+        return this._client.getActiveGuildThreads.call(this._client, this.id);
     }
 
     /**

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -401,7 +401,7 @@ class Message extends Base {
     * @returns {Promise<NewsThreadChannel | PublicThreadChannel>}
     */
     createThreadWithMessage(options) {
-        return this.client.createThreadWithMessage.call(this.client, this.channel.id, this.id, options);
+        return this._client.createThreadWithMessage.call(this._client, this.channel.id, this.id, options);
     }
 
     /**


### PR DESCRIPTION
There were 2 broken methods there instead of **this._client** it was still using **this.client** resulting in a "Cannot read property 'methods' of undefined" error