### PR TITLE
fix(voice): properly ignore non-voice packets

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -276,7 +276,7 @@ class VoiceConnection extends EventEmitter {
                     this.reconnecting = false;
                     this.ready = true;
                     // Send audio to properly establish the socket (e.g. for voice receive)
-                    this._sendAudioFrame(SILENCE_FRAME);
+                    this.sendAudioFrame(SILENCE_FRAME);
                     /**
                     * Fired when the voice connection turns ready
                     * @event VoiceConnection#ready

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -276,7 +276,7 @@ class VoiceConnection extends EventEmitter {
                     this.reconnecting = false;
                     this.ready = true;
                     // Send audio to properly establish the socket (e.g. for voice receive)
-                    this.sendAudioFrame(SILENCE_FRAME);
+                    this._sendAudioFrame(SILENCE_FRAME);
                     /**
                     * Fired when the voice connection turns ready
                     * @event VoiceConnection#ready

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -561,6 +561,10 @@ class VoiceConnection extends EventEmitter {
 
     registerReceiveEventHandler() {
         this.udpSocket.on("message", (msg) => {
+            if(msg[1] !== 0x78) { // unknown payload type, ignore
+                return;
+            }
+
             const nonce = Buffer.alloc(24);
             msg.copy(nonce, 0, 0, 12);
             let data;

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -590,11 +590,7 @@ class VoiceConnection extends EventEmitter {
             // Not a RFC5285 One Byte Header Extension (not negotiated)
             if(hasExtension) { // RFC3550 5.3.1: RTP Header Extension
                 const l = data[2] << 8 | data[3];
-                let index = 4 + l * 4;
-                while(data[index] == 0) {
-                    ++index;
-                }
-                data = data.subarray(index);
+                data = data.subarray(4 + l * 4);
             }
             if(this.receiveStreamOpus) {
                 /**


### PR DESCRIPTION
- Fixed opus decode error when receiving voice from browser clients.
Error:
![image](https://user-images.githubusercontent.com/66310990/142040700-ea2eda1e-85a3-4d96-918a-4697d8e0854d.png)

- Fixed constant "Failed to decrypt received packet" warnings by ignoring unknown payload types (2nd byte different from 0x78).
- Fixed the error below when joining voice channels by using the internal method to send initial silence frame instead of the public one.
![image](https://user-images.githubusercontent.com/66310990/142042268-c924471d-2c1b-4515-8bc0-1cd388322074.png)
