### PR TITLE
m.presence can be null in THREAD_MEMBERS_UPDATE

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2243,7 +2243,9 @@ class Shard extends EventEmitter {
                         m.member.id = m.member.user.id;
                         const guild = this.client.guilds.get(packet.d.guild_id);
                         if(guild) {
-                            guild.members.update(m.presence, guild);
+                            if(m.presence) {
+                                guild.members.update(m.presence, guild);
+                            }
                             guild.members.update(m.member);
                         }
                         return channel.members.update(m, this.client);


### PR DESCRIPTION
In the THREAD_MEMBERS_UPDATE event, the user is updated what also includes a presence update (m.presence). The m.presence object can be null resulting in a "Cannot read property 'id' of null" error.