### PR TITLE
Use the guild_id field from Discord payload.

### DIFF
--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -120,21 +120,22 @@ class Message extends Base {
             this.interaction = null;
         }
 
-        if(this.channel.guild) {
+        if(data.guild_id) {
+            const guild = this._client.guilds.get(data.guild_id);
             if(data.member) {
                 data.member.id = this.author.id;
                 if(data.author) {
                     data.member.user = data.author;
                 }
-                this.member = this.channel.guild.members.update(data.member, this.channel.guild);
-            } else if(this.channel.guild.members.has(this.author.id)) {
-                this.member = this.channel.guild.members.get(this.author.id);
+                this.member = guild.members.update(data.member, guild);
+            } else if(guild.members.has(this.author.id)) {
+                this.member = guild.members.get(this.author.id);
             } else {
                 this.member = null;
             }
 
             if(!this.guildID) {
-                this.guildID = this.channel.guild.id;
+                this.guildID = data.guild_id;
             }
         } else {
             this.member = null;

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -122,7 +122,7 @@ class Message extends Base {
 
         if(data.guild_id) {
             if(this._client.guilds.has(data.guild_id)) {
-                const guild = this._client.guilds.get(data.guild_id)
+                const guild = this._client.guilds.get(data.guild_id);
                 if(data.member) {
                     data.member.id = this.author.id;
                     if(data.author) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -122,6 +122,7 @@ class Message extends Base {
 
         if(data.guild_id) {
             if(this._client.guilds.has(data.guild_id)) {
+                const guild = this._client.guilds.get(data.guild_id)
                 if(data.member) {
                     data.member.id = this.author.id;
                     if(data.author) {

--- a/lib/structures/Message.js
+++ b/lib/structures/Message.js
@@ -121,17 +121,18 @@ class Message extends Base {
         }
 
         if(data.guild_id) {
-            const guild = this._client.guilds.get(data.guild_id);
-            if(data.member) {
-                data.member.id = this.author.id;
-                if(data.author) {
-                    data.member.user = data.author;
+            if(this._client.guilds.has(data.guild_id)) {
+                if(data.member) {
+                    data.member.id = this.author.id;
+                    if(data.author) {
+                        data.member.user = data.author;
+                    }
+                    this.member = guild.members.update(data.member, guild);
+                } else if(guild.members.has(this.author.id)) {
+                    this.member = guild.members.get(this.author.id);
+                } else {
+                    this.member = null;
                 }
-                this.member = guild.members.update(data.member, guild);
-            } else if(guild.members.has(this.author.id)) {
-                this.member = guild.members.get(this.author.id);
-            } else {
-                this.member = null;
             }
 
             if(!this.guildID) {


### PR DESCRIPTION
Currently when we uncache a guild text channel, the Message instance returns always null for the member field.
We can use the "message.guild_id" coming from the Discord payload to search for the guild and member.