### PR TITLE
fix(editChannel): fix videoQualityMode & add permissionOverwrites

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -291,7 +291,7 @@ declare namespace Eris {
     topic?: string;
     userLimit?: number;
   }
-  interface EditChannelOptions extends Omit<CreateChannelOptions, "permissionOverwrites" | "reason"> {
+  interface EditChannelOptions extends Omit<CreateChannelOptions, "reason"> {
     archived?: boolean;
     autoArchiveDuration?: AutoArchiveDuration;
     defaultAutoArchiveDuration?: AutoArchiveDuration;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -468,7 +468,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.bitrate] The bitrate of the channel (voice channels only)
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {String?} [options.parentID] The ID of the parent category channel for this channel
-    * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
+    * @arg {Array<Object>} [options.permissionOverwrites] An array containing permission overwrite objects
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String} [options.reason] The reason to be displayed in audit logs
     * @arg {String} [options.topic] The topic of the channel (text channels only)
@@ -1237,12 +1237,12 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild channels only)
     * @arg {String} [options.ownerID] The ID of the channel owner (group channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
+    * @arg {Array<Object>} [options.permissionOverwrites] An array containing permission overwrite objects
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
     * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
     * @arg {String} [options.topic] The topic of the channel (guild text channels only)
     * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
     * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
-    * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | GroupChannel | TextChannel | VoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1264,7 +1264,7 @@ class Client extends EventEmitter {
             topic: options.topic,
             user_limit: options.userLimit,
             video_quality_mode: options.videoQualityMode,
-            permission_overwrites:options.permissionOverwrites,
+            permission_overwrites: options.permissionOverwrites,
             reason: reason
         }).then((channel) => Channel.from(channel, this));
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1242,6 +1242,7 @@ class Client extends EventEmitter {
     * @arg {String} [options.topic] The topic of the channel (guild text channels only)
     * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
     * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
+    * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | GroupChannel | TextChannel | VoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */
@@ -1262,7 +1263,8 @@ class Client extends EventEmitter {
             rtc_region: options.rtcRegion,
             topic: options.topic,
             user_limit: options.userLimit,
-            voice_quality_mode: options.voiceQualityMode,
+            video_quality_mode: options.videoQualityMode,
+            permission_overwrites:options.permissionOverwrites,
             reason: reason
         }).then((channel) => Channel.from(channel, this));
     }

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -73,18 +73,19 @@ class GuildChannel extends Channel {
     * @arg {Object} options The properties to edit
     * @arg {Boolean} [options.archived] The archive status of the channel (thread channels only)
     * @arg {Number} [options.autoArchiveDuration] The duration in minutes to automatically archive the thread after recent activity, either 60, 1440, 4320 or 10080 (thread channels only)
+    * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
     * @arg {Number?} [options.defaultAutoArchiveDuration] The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080) (guild text/news channels only)
     * @arg {Boolean} [options.invitable] Whether non-moderators can add other non-moderators to the channel (private thread channels only)
     * @arg {Boolean} [options.locked] The lock status of the channel (thread channels only)
     * @arg {String} [options.name] The name of the channel
-    * @arg {String} [options.topic] The topic of the channel (guild text channels only)
-    * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
-    * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
-    * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
-    * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
-    * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {Number?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only) or the channel ID where the thread originated from (thread channels only)
+    * @arg {Array<Object>} [options.permissionOverwrites] An array containing permission overwrite objects
+    * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
+    * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
+    * @arg {String} [options.topic] The topic of the channel (guild text channels only)
+    * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
+    * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | GroupChannel | TextChannel | VoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */


### PR DESCRIPTION
Corrects the option key for "video_quality_mode" and adds option key "permission_overwrites" per the `PATCH /channels/{channel.id}` endpoint spec at https://discord.com/developers/docs/resources/channel#modify-channel

This commit does NOT fix the types associated with the modified function.