### PR TITLE
fix(voice): avoid bitwise overflow error

### DIFF
--- a/lib/voice/SharedStream.js
+++ b/lib/voice/SharedStream.js
@@ -188,7 +188,7 @@ class SharedStream extends EventEmitter {
 
     _incrementTimestamps(val) {
         for(const vc of this.voiceConnections.values()) {
-            vc.timestamp = (vc.timestamp + val) & 0xFFFFFFFF;
+            vc.timestamp = (vc.timestamp + val) >>> 0;
         }
     }
 

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -641,7 +641,7 @@ class VoiceConnection extends EventEmitter {
     * @arg {Number} [frameSize] The size (in samples) of the Opus audio frame
     */
     sendAudioFrame(frame, frameSize = this.frameSize) {
-        this.timestamp = (this.timestamp + frameSize) & 0xFFFFFFFF;
+        this.timestamp = (this.timestamp + frameSize) >>> 0;
         this.sequence = (this.sequence + 1) & 0xFFFF;
 
         return this._sendAudioFrame(frame);
@@ -790,7 +790,7 @@ class VoiceConnection extends EventEmitter {
                 this.setSpeaking(0);
             }
             this.current.pausedTime += 4 * this.current.options.frameDuration;
-            this.timestamp = (this.timestamp + 3 * this.current.options.frameSize) & 0xFFFFFFFF;
+            this.timestamp = (this.timestamp + 3 * this.current.options.frameSize) >>> 0;
             this.current.timeout = setTimeout(this._send, 4 * this.current.options.frameDuration);
             return;
         } else {


### PR DESCRIPTION
JavaScript converts operands to 32-bit signed int before doing bitwise operations.

Fix crash:
```
node:internal/buffer:72
    throw new ERR_OUT_OF_RANGE('value', range, value);
    ^

RangeError [ERR_OUT_OF_RANGE]: The value of "value" is out of range. It must be >= 0 and <= 4294967295. Received -2147482816
    at new NodeError (node:internal/errors:371:5)
    at checkInt (node:internal/buffer:72:11)
    at writeU_Int32BE (node:internal/buffer:802:3)
    at Buffer.writeUInt32BE (node:internal/buffer:815:10)
    at VoiceConnection._sendAudioFrame (/home/james58899/MusicBot/node_modules/eris/lib/voice/VoiceConnection.js:807:24)
    at VoiceConnection.sendAudioFrame (/home/james58899/MusicBot/node_modules/eris/lib/voice/VoiceConnection.js:647:21)
    at VoiceConnection._send (/home/james58899/MusicBot/node_modules/eris/lib/voice/VoiceConnection.js:800:14)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7) {
  code: 'ERR_OUT_OF_RANGE'
}
```