### PR TITLE
update member on THREAD_MEMBERS_UPDATE

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2246,7 +2246,7 @@ class Shard extends EventEmitter {
                         const guild = this.client.guilds.get(packet.d.guild_id);
                         if(guild) {
                             guild.members.update(m.presence, guild);
-                            guild.members.update(m.member);
+                            guild.members.update(m.member, guild);
                         }
                         return channel.members.update(m, this.client);
                     });


### PR DESCRIPTION
Updating the guild member on THREAD_MEMBERS_UPDATE without passing a guild param will throw a "Missing client in constructor" in user structure for #1306 and #1313 

This happens when an offline member is mentioned in a thread.