### PR TITLE
Use maxShards instead of lastShardID

### DIFF
--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -81,7 +81,7 @@ class Guild extends Base {
     constructor(data, client) {
         super(data.id);
         this._client = client;
-        this.shard = client.shards.get(client.guildShardMap[this.id] || (Base.getDiscordEpoch(data.id) % client.options.lastShardID) || 0);
+        this.shard = client.shards.get(client.guildShardMap[this.id] || (Base.getDiscordEpoch(data.id) % client.options.maxShards) || 0);
         this.unavailable = !!data.unavailable;
         this.joinedAt = Date.parse(data.joined_at);
         this.voiceStates = new Collection(VoiceState);


### PR DESCRIPTION
If we spawn a client with a defined range of shards, a guild may point to the wrong shard id.