### PR TITLE
Add position to `CreateChannelOptions`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -286,6 +286,7 @@ declare namespace Eris {
     nsfw?: boolean;
     parentID?: string;
     permissionOverwrites?: Overwrite[];
+    position?: number;
     rateLimitPerUser?: number;
     reason?: string;
     topic?: string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -469,6 +469,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {String?} [options.parentID] The ID of the parent category channel for this channel
     * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
+    * @arg {Number} [options.position] The sorting position of the channel
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String} [options.reason] The reason to be displayed in audit logs
     * @arg {String} [options.topic] The topic of the channel (text channels only)
@@ -497,6 +498,7 @@ class Client extends EventEmitter {
             nsfw: options.nsfw,
             parent_id: options.parentID,
             permission_overwrites: options.permissionOverwrites,
+            position: options.position,
             rate_limit_per_user: options.rateLimitPerUser,
             reason: options.reason,
             topic: options.topic,
@@ -1239,6 +1241,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild channels only)
     * @arg {String} [options.ownerID] The ID of the channel owner (group channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
+    * @arg {Number} [options.position] The sorting position of the channel
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
     * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
     * @arg {String} [options.topic] The topic of the channel (guild text channels only)
@@ -1260,6 +1263,7 @@ class Client extends EventEmitter {
             nsfw: options.nsfw,
             owner_id: options.ownerID,
             parent_id: options.parentID,
+            position: options.position,
             rate_limit_per_user: options.rateLimitPerUser,
             rtc_region: options.rtcRegion,
             topic: options.topic,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1241,7 +1241,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel (guild channels only)
     * @arg {String} [options.ownerID] The ID of the channel owner (group channels only)
     * @arg {String?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only)
-    * @arg {Number} [options.position] The sorting position of the channel
+    * @arg {Number} [options.position] The sorting position of the channel (guild channels only)
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
     * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
     * @arg {String} [options.topic] The topic of the channel (guild text channels only)

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -393,6 +393,7 @@ class Guild extends Base {
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {String?} [options.parentID] The ID of the parent category channel for this channel
     * @arg {Array} [options.permissionOverwrites] An array containing permission overwrite objects
+    * @arg {Number} [options.position] The sorting position of the channel
     * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (text channels only)
     * @arg {String} [options.reason] The reason to be displayed in audit logs
     * @arg {String} [options.topic] The topic of the channel (text channels only)

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -73,18 +73,19 @@ class GuildChannel extends Channel {
     * @arg {Object} options The properties to edit
     * @arg {Boolean} [options.archived] The archive status of the channel (thread channels only)
     * @arg {Number} [options.autoArchiveDuration] The duration in minutes to automatically archive the thread after recent activity, either 60, 1440, 4320 or 10080 (thread channels only)
+    * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
     * @arg {Number?} [options.defaultAutoArchiveDuration] The default duration of newly created threads in minutes to automatically archive the thread after inactivity (60, 1440, 4320, 10080) (guild text/news channels only)
     * @arg {Boolean} [options.invitable] Whether non-moderators can add other non-moderators to the channel (private thread channels only)
     * @arg {Boolean} [options.locked] The lock status of the channel (thread channels only)
     * @arg {String} [options.name] The name of the channel
-    * @arg {String} [options.topic] The topic of the channel (guild text channels only)
-    * @arg {Number} [options.bitrate] The bitrate of the channel (guild voice channels only)
-    * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
-    * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
-    * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
-    * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
     * @arg {Boolean} [options.nsfw] The nsfw status of the channel
     * @arg {Number?} [options.parentID] The ID of the parent channel category for this channel (guild text/voice channels only) or the channel ID where the thread originated from (thread channels only)
+    * @arg {Number} [options.position] The sorting position of the channel
+    * @arg {Number} [options.rateLimitPerUser] The time in seconds a user has to wait before sending another message (does not affect bots or users with manageMessages/manageChannel permissions) (guild text and thread channels only)
+    * @arg {String?} [options.rtcRegion] The RTC region ID of the channel (automatic if `null`) (guild voice channels only)
+    * @arg {String} [options.topic] The topic of the channel (guild text channels only)
+    * @arg {Number} [options.userLimit] The channel user limit (guild voice channels only)
+    * @arg {Number} [options.videoQualityMode] The camera video quality mode of the channel (guild voice channels only). `1` is auto, `2` is 720p
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<CategoryChannel | GroupChannel | TextChannel | VoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */


### PR DESCRIPTION
`position` should be included as an optional parameter when creating or modifying a guild channel. 

Create: https://discord.com/developers/docs/resources/guild#:~:text=%2C%20are%20unaffected-,position,-integer

Modify: https://discord.com/developers/docs/resources/channel#:~:text=Text%2C%20News-,position,-%3Finteger

NOTE: Also fixed the order of `options` parameters in `GuildChannel#edit()` (should have been alphabetical)