### PR TITLE
API v10 changes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2338,8 +2338,6 @@ declare namespace Eris {
     executeWebhook(webhookID: string, token: string, options: WebhookPayload): Promise<void>;
     followChannel(channelID: string, webhookChannelID: string): Promise<ChannelFollow>;
     getActiveGuildThreads(guildID: string): Promise<ListedGuildThreads>;
-    /** @deprecated */
-    getActiveThreads(channelID: string): Promise<ListedChannelThreads>;
     getArchivedThreads(channelID: string, type: "private", options?: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PrivateThreadChannel>>;
     getArchivedThreads(channelID: string, type: "public", options?: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PublicThreadChannel>>;
     getBotGateway(): Promise<{ session_start_limit: { max_concurrency: number; remaining: number; reset_after: number; total: number }; shards: number; url: string }>;
@@ -3430,8 +3428,6 @@ declare namespace Eris {
     deleteMessages(messageIDs: string[], reason?: string): Promise<void>;
     edit(options: Omit<EditChannelOptions, "icon" | "ownerID">, reason?: string): Promise<this>;
     editMessage(messageID: string, content: MessageContentEdit): Promise<Message<this>>;
-    /** @deprecated */
-    getActiveThreads(): Promise<ListedChannelThreads>;
     getArchivedThreads(type: "private", options?: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PrivateThreadChannel>>;
     getArchivedThreads(type: "public", options?: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PublicThreadChannel>>;
     getInvites(): Promise<(Invite<"withMetadata", TextChannel>)[]>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -936,7 +936,7 @@ declare namespace Eris {
     icon: string | null;
     id: string;
     name: string;
-    summary: string;
+    summary: ""; // Returns an empty string
   }
   interface IntegrationOptions {
     enableEmoticons?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1671,9 +1671,10 @@ declare namespace Eris {
       directMessages:         4096;
       directMessageReactions: 8192;
       directMessageTyping:    16384;
+      messageContent:         32768;
       allNonPrivileged:       32509;
-      allPrivileged:          258;
-      all:                    32767;
+      allPrivileged:          33026;
+      all:                    65535;
     };
     InteractionResponseTypes: {
       PONG:                                    1;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2096,21 +2096,6 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [DEPRECATED] Get all active threads in a channel. Use getActiveGuildThreads instead
-    * @arg {String} channelID The ID of the channel
-    * @returns {Promise<Object>} An object containing an array of `threads`, an array of `members` and whether the response `hasMore` threads that could be returned in a subsequent call
-    */
-    getActiveThreads(channelID) {
-        return this.requestHandler.request("GET", Endpoints.THREADS_ACTIVE(channelID), true).then((response) => {
-            return {
-                hasMore: response.has_more,
-                members: response.members.map((member) => new ThreadMember(member, this)),
-                threads: response.threads.map((thread) => Channel.from(thread, this))
-            };
-        });
-    }
-
-    /**
     * Get all archived threads in a channel
     * @arg {String} channelID The ID of the channel
     * @arg {String} type The type of thread channel, either "public" or "private"

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,7 +1,7 @@
 "use strict";
 
-module.exports.GATEWAY_VERSION = 9;
-module.exports.REST_VERSION = 9;
+module.exports.GATEWAY_VERSION = 10;
+module.exports.REST_VERSION = 10;
 
 module.exports.ActivityTypes = {
     GAME:      0,
@@ -233,8 +233,10 @@ const Intents = {
     guildMessageTyping:     1 << 11,
     directMessages:         1 << 12,
     directMessageReactions: 1 << 13,
-    directMessageTyping:    1 << 14
+    directMessageTyping:    1 << 14,
+    messageContent:         1 << 15
 };
+
 Intents.allNonPrivileged = Intents.guilds
     | Intents.guildBans
     | Intents.guildEmojisAndStickers

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -251,7 +251,8 @@ Intents.allNonPrivileged = Intents.guilds
     | Intents.directMessageReactions
     | Intents.directMessageTyping;
 Intents.allPrivileged = Intents.guildMembers
-    | Intents.guildPresences;
+    | Intents.guildPresences
+    | Intents.messageContent;
 Intents.all = Intents.allNonPrivileged | Intents.allPrivileged;
 module.exports.Intents = Intents;
 

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -85,7 +85,6 @@ module.exports.THREAD_MEMBER =                               (channelID, userID)
 module.exports.THREAD_MEMBERS =                                      (channelID) => `/channels/${channelID}/thread-members`;
 module.exports.THREAD_WITH_MESSAGE =                          (channelID, msgID) => `/channels/${channelID}/messages/${msgID}/threads`;
 module.exports.THREAD_WITHOUT_MESSAGE =                              (channelID) => `/channels/${channelID}/threads`;
-module.exports.THREADS_ACTIVE =                                      (channelID) => `/channels/${channelID}/threads/active`;
 module.exports.THREADS_ARCHIVED =                              (channelID, type) => `/channels/${channelID}/threads/archived/${type}`;
 module.exports.THREADS_ARCHIVED_JOINED =                             (channelID) => `/channels/${channelID}/users/@me/threads/archived/private`;
 module.exports.THREADS_GUILD_ACTIVE =                                  (guildID) => `/guilds/${guildID}/threads/active`;

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -203,14 +203,6 @@ class TextChannel extends GuildChannel {
     }
 
     /**
-    * [DEPRECATED] Get all active threads in this channel. Use guild.getActiveThreads instead
-    * @returns {Promise<Object>} An object containing an array of `threads`, an array of `members` and whether the response `hasMore` threads that could be returned in a subsequent call
-    */
-    getActiveThreads() {
-        return this.client.getActiveThreads.call(this.client, this.id);
-    }
-
-    /**
     * Get all archived threads in this channel
     * @arg {String} type The type of thread channel, either "public" or "private"
     * @arg {Object} [options] Additional options when requesting archived threads


### PR DESCRIPTION
## Breaking
- getActiveThreads has been removed, as the endpoint is no longer available 

## Additions
- messageContent intent added

## Changes
- Gateway/REST version 9 -> 10
- application.summary type changed from string to explicit ""

## TODO:
- document attachments changes, if anyone cares
- check if achievements are actually cared about
