### PR TITLE
Handle Shared Ratelimits & Parse retryAfter Correctly

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from "events";
 import { Duplex, Readable as ReadableStream, Stream } from "stream";
 import { Agent as HTTPSAgent } from "https";
-import { IncomingMessage, ClientRequest } from "http";
+import { IncomingMessage, ClientRequest, IncomingHttpHeaders } from "http";
 import OpusScript = require("opusscript"); // Thanks TypeScript
 import { URL } from "url";
 import { Socket as DgramSocket } from "dgram";
@@ -2568,6 +2568,7 @@ declare namespace Eris {
 
   export class DiscordHTTPError extends Error {
     code: number;
+    headers: IncomingHttpHeaders;
     name: "DiscordHTTPError";
     req: ClientRequest;
     res: IncomingMessage;
@@ -2578,6 +2579,7 @@ declare namespace Eris {
 
   export class DiscordRESTError extends Error {
     code: number;
+    headers: IncomingHttpHeaders;
     name: string;
     req: ClientRequest;
     res: IncomingMessage;

--- a/lib/errors/DiscordHTTPError.js
+++ b/lib/errors/DiscordHTTPError.js
@@ -38,6 +38,10 @@ class DiscordHTTPError extends Error {
         }
     }
 
+    get headers() {
+        return this.response.headers;
+    }
+
     get name() {
         return this.constructor.name;
     }

--- a/lib/errors/DiscordRESTError.js
+++ b/lib/errors/DiscordRESTError.js
@@ -42,6 +42,10 @@ class DiscordRESTError extends Error {
         }
     }
 
+    get headers() {
+        return this.response.headers;
+    }
+
     get name() {
         return `${this.constructor.name} [${this.code}]`;
     }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -350,12 +350,6 @@ class RequestHandler {
                             } else {
                                 err = new DiscordHTTPError(req, resp, response, stack);
                             }
-                            if (err.code === 429) {
-                                Object.defineProperty(err, 'headers', {
-                                    value: resp.headers,
-                                    enumerable: false
-                                })
-                            }
                             reject(err);
                             return;
                         }

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -273,7 +273,7 @@ class RequestHandler {
 
                         this.ratelimits[route].remaining = resp.headers["x-ratelimit-remaining"] === undefined ? 1 : +resp.headers["x-ratelimit-remaining"] || 0;
 
-                        const retryAfter = parseInt(resp.headers["x-ratelimit-reset-after"] || resp.headers["retry-after"]) * 1000;
+                        const retryAfter = Number(resp.headers["x-ratelimit-reset-after"] || resp.headers["retry-after"]) * 1000;
                         if(retryAfter >= 0) {
                             if(resp.headers["x-ratelimit-global"]) {
                                 this.globalBlock = true;
@@ -299,12 +299,13 @@ class RequestHandler {
                         if(resp.statusCode >= 300) {
                             if(resp.statusCode === 429) {
                                 const content = typeof body === "object" ? `${body.content} ` : "";
-                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${this.ratelimits[route].reset} (${this.ratelimits[route].reset - now}ms left)`);
-                                if(retryAfter) {
+                                const delay = resp.headers['retry-after'] ? Number(resp.headers['retry-after']) * 1000 : retryAfter
+                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left)`);
+                                if(delay) {
                                     setTimeout(() => {
                                         cb();
                                         this.request(method, url, auth, body, file, route, true).then(resolve).catch(reject);
-                                    }, retryAfter);
+                                    }, delay);
                                     return;
                                 } else {
                                     cb();

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -300,7 +300,7 @@ class RequestHandler {
                             if(resp.statusCode === 429) {
                                 const content = typeof body === "object" ? `${body.content} ` : "";
                                 let delay = retryAfter;
-                                if(resp.headers['x-ratelimit-scope'] === 'shared') {
+                                if(resp.headers["x-ratelimit-scope"] === "shared") {
                                     try {
                                         delay = JSON.parse(response).retry_after * 1000;
                                     } catch(err) {
@@ -308,7 +308,7 @@ class RequestHandler {
                                         return;
                                     }
                                 }
-                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left) | Scope ${resp.headers['x-ratelimit-scope']}`);
+                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left) | Scope ${resp.headers["x-ratelimit-scope"]}`);
                                 if(delay) {
                                     setTimeout(() => {
                                         cb();

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -299,8 +299,8 @@ class RequestHandler {
                         if(resp.statusCode >= 300) {
                             if(resp.statusCode === 429) {
                                 const content = typeof body === "object" ? `${body.content} ` : "";
-                                let delay = retryAfter
-                                if (resp.headers['x-ratelimit-scope'] === 'shared') {
+                                let delay = retryAfter;
+                                if(resp.headers['x-ratelimit-scope'] === 'shared') {
                                     try {
                                         delay = JSON.parse(response).retry_after * 1000;
                                     } catch(err) {

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -299,8 +299,16 @@ class RequestHandler {
                         if(resp.statusCode >= 300) {
                             if(resp.statusCode === 429) {
                                 const content = typeof body === "object" ? `${body.content} ` : "";
-                                const delay = resp.headers['retry-after'] ? Number(resp.headers['retry-after']) * 1000 : retryAfter
-                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left)`);
+                                let delay = retryAfter
+                                if (resp.headers['x-ratelimit-scope'] === 'shared') {
+                                    try {
+                                        delay = JSON.parse(response).retry_after * 1000;
+                                    } catch(err) {
+                                        reject(err);
+                                        return;
+                                    }
+                                }
+                                this._client.emit("debug", `${resp.headers["x-ratelimit-global"] ? "Global" : "Unexpected"} 429 (╯°□°）╯︵ ┻━┻: ${response}\n${content} ${now} ${route} ${resp.statusCode}: ${latency}ms (${this.latencyRef.latency}ms avg) | ${this.ratelimits[route].remaining}/${this.ratelimits[route].limit} left | Reset ${delay} (${this.ratelimits[route].reset - now}ms left) | Scope ${resp.headers['x-ratelimit-scope']}`);
                                 if(delay) {
                                     setTimeout(() => {
                                         cb();

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -333,6 +333,9 @@ class RequestHandler {
                                 if(resp.headers["content-type"] === "application/json") {
                                     try {
                                         response = JSON.parse(response);
+                                        if(resp.statusCode === 429) {
+                                            response.scope = resp.headers['x-ratelimit-scope']
+                                        }
                                     } catch(err) {
                                         reject(err);
                                         return;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -333,9 +333,6 @@ class RequestHandler {
                                 if(resp.headers["content-type"] === "application/json") {
                                     try {
                                         response = JSON.parse(response);
-                                        if(resp.statusCode === 429) {
-                                            response.scope = resp.headers['x-ratelimit-scope']
-                                        }
                                     } catch(err) {
                                         reject(err);
                                         return;
@@ -352,6 +349,12 @@ class RequestHandler {
                                 err = new DiscordRESTError(req, resp, response, stack);
                             } else {
                                 err = new DiscordHTTPError(req, resp, response, stack);
+                            }
+                            if (err.code === 429) {
+                                Object.defineProperty(err, 'headers', {
+                                    value: resp.headers,
+                                    enumerable: false
+                                })
                             }
                             reject(err);
                             return;


### PR DESCRIPTION
Currently, Eris uses parseInt to parse the ratelimit x-ratelimit-reset-after header. parseInt slices off the decimal of the ratelimit header, and as such, Eris makes requests too early sometimes. Try to send any request as fast as possible, and log the debug event. When you're at the limit exhausting a ratelimit bucket, Eris will make requests too early, and the printed retryAfter is the time sliced off the decimal + network latency.

Similarly, Eris does not handle shared ratelimits. If you log the debug event and send 100 webhook messages to a channel as fast as possible, you will encounter a shared ratelimit after many messages are sent. Eris continues to use x-ratelimit-reset-after, while the retry-after header has the true shared ratelimit. In production, this can cause Cloudflare bans when using webhooks heavily (Eris waiting 2000ms from x-ratelimit-reset-after header, while retry-after is 40+ seconds).