### PR TITLE
`ApplicationCommandOptionsChannel.channel_types` to array of channel types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -189,7 +189,7 @@ declare namespace Eris {
   // User
   type ApplicationCommandOptionsUser = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["USER"]>;
   // Channel
-  type ApplicationCommandOptionsChannel = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["CHANNEL"]> & { channel_types?: ChannelTypes };
+  type ApplicationCommandOptionsChannel = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["CHANNEL"]> & { channel_types?: ChannelTypes[] };
   // Role
   type ApplicationCommandOptionsRole = ApplicationCommandOption<Constants["ApplicationCommandOptionTypes"]["ROLE"]>;
   // Mentionable


### PR DESCRIPTION
Currently `ApplicationCommandOptionsChannel.channel_types` has the type `ChannelTypes | undefined`, it should be `ChannelTypes[] | undefined`.

https://discord.com/developers/docs/interactions/application-commands#:~:text=be%20the%20parameters-,channel_types,-%3F