### PR TITLE
fix(constants): Include manageThreads, manageEvents in Permissions.all

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1807,10 +1807,10 @@ declare namespace Eris {
       sendMessagesInThreads:   274877906944n;
       startEmbeddedActivities: 549755813888n;
       moderateMembers:         1099511627776n;
-      allGuild:                1101592527038n;
+      allGuild:                1127362330814n;
       allText:                 518349388881n;
       allVoice:                554385278737n;
-      all:                     1228360646655n;
+      all:                     2199023255551n;
     };
     PremiumTiers: {
       NONE:   0;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1807,8 +1807,8 @@ declare namespace Eris {
       sendMessagesInThreads:   274877906944n;
       startEmbeddedActivities: 549755813888n;
       moderateMembers:         1099511627776n;
-      allGuild:                1127362330814n;
-      allText:                 518349388881n;
+      allGuild:                1110182461630n;
+      allText:                 535529258065n;
       allVoice:                554385278737n;
       all:                     2199023255551n;
     };

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -396,6 +396,8 @@ Permissions.allGuild = Permissions.kickMembers
     | Permissions.manageRoles
     | Permissions.manageWebhooks
     | Permissions.manageEmojisAndStickers
+    | Permissions.manageEvents
+    | Permissions.manageThreads
     | Permissions.moderateMembers;
 Permissions.allText = Permissions.createInstantInvite
     | Permissions.manageChannels

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -397,7 +397,6 @@ Permissions.allGuild = Permissions.kickMembers
     | Permissions.manageWebhooks
     | Permissions.manageEmojisAndStickers
     | Permissions.manageEvents
-    | Permissions.manageThreads
     | Permissions.moderateMembers;
 Permissions.allText = Permissions.createInstantInvite
     | Permissions.manageChannels
@@ -414,6 +413,7 @@ Permissions.allText = Permissions.createInstantInvite
     | Permissions.manageRoles
     | Permissions.manageWebhooks
     | Permissions.useApplicationCommands
+    | Permissions.manageThreads
     | Permissions.createPublicThreads
     | Permissions.createPrivateThreads
     | Permissions.useExternalStickers


### PR DESCRIPTION
Adds the permissions constants `manageThreads` to `allText` and `manageEvents` to `allGuild`. Recalculates the constant types of `all`, `allText`, and `allGuild` in typings. #1271 mistakenly removed `manageThreads` from `allText` and introduced `manageEvents` without adding it to `allGuild`.