### PR TITLE
fix(defaultPermissionTypings): Corrected defaultPermission

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -220,7 +220,7 @@ declare namespace Eris {
     description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : never;
     options?: ApplicationCommandOptions[];
     type: T;
-    defaultPermission?: boolean;
+    default_permission?: boolean;
   }
 
   type AnyApplicationCommand = ChatInputApplicationCommand | MessageApplicationCommand | UserApplicationCommand;


### PR DESCRIPTION
Updated `defaultPermission` to `default_permission` for the `ApplicationCommand` interface as shown in https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permission-type