### PR TITLE
fix(gateway): fix zlib data error

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -140,6 +140,7 @@ class Shard extends EventEmitter {
         }
 
         if(this.ws.readyState !== WebSocket.CLOSED) {
+            this.ws.removeListener("message", this._onWSMessage);
             this.ws.removeListener("close", this._onWSClose);
             try {
                 if(options.reconnect && this.sessionID) {


### PR DESCRIPTION
That error was happening because the new zlib context was trying to decompress packets from the old websocket connection, on reconnects.

Debug logs:
```js
1650119933984 /gateway 200: 86ms (8ms avg) | 1/1 left | Reset 1650119933984 (0ms left)
Initializing zlib-sync-based compression
Shard ID 0 connected.
{"op":2,"d":{"v":9,"compress":true,"large_threshold":250,"intents":32767,"properties":{"os":"linux","browser":"Eris","device":"Eris"},"presence":{"activities":null,"afk":false,"since":null,"status":"offline"}}} 0
Ready!
Disconnected // client.on('disconnect')
Immediately reconnecting for potential resume | Attempt 0 0
Initializing zlib-sync-based compression
Shard ID 0 connected. // client.on('connect')
{"op":6,"d":{"session_id":"ed34c5e8998ebd5739a8b1e0596de2e4","seq":229}} 0
{"op":1,"d":236} 0
Ready!
Disconnected // client.on('disconnect')
Immediately reconnecting for potential resume | Attempt 0 0
Initializing zlib-sync-based compression // <----------------------- *
Error: zlib error -3: data error
    at Shard._onWSMessage (/home/david/Desktop/zlibtest/node_modules/eris/lib/gateway/Shard.js:2431:44)
    at WebSocket.emit (node:events:526:28)
    at Receiver.receiverOnMessage (/home/david/Desktop/zlibtest/node_modules/ws/lib/websocket.js:1137:20)
    (...)
Shard ID 0 connected. // client.on('connect') <--------------------- *
Error: zlib error -3: data error
    at Shard._onWSMessage (/home/david/Desktop/zlibtest/node_modules/eris/lib/gateway/Shard.js:2431:44)
    at WebSocket.emit (node:events:526:28)
    at Receiver.receiverOnMessage (/home/david/Desktop/zlibtest/node_modules/ws/lib/websocket.js:1137:20)
    (...)
```

\* As you can see from the debug logs above, the new zlib inflater tried to decompress a payload from the old websocket connection, as the client#connect event was only fired after the zlib error. So the fix is just to remove the old websocket message listener on disconnect method.

P.S.: This issue happens more often on large bots, due to high amount of incoming gateway packets. I tested on my main bot (116 guilds) and it happens, but not on my testing bot (1 guild).

Closes #1144 