### PR TITLE
feat(VoiceChannel): Textable Voice Channels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -63,7 +63,7 @@ declare namespace Eris {
   type ChannelTypes = GuildChannelTypes | PrivateChannelTypes;
   type GuildChannelTypes = Exclude<Constants["ChannelTypes"][keyof Constants["ChannelTypes"]], PrivateChannelTypes>;
   type TextChannelTypes = GuildTextChannelTypes | PrivateChannelTypes;
-  type GuildTextChannelTypes = Constants["ChannelTypes"][keyof Pick<Constants["ChannelTypes"], "GUILD_TEXT" | "GUILD_NEWS">];
+  type GuildTextChannelTypes = Constants["ChannelTypes"][keyof Pick<Constants["ChannelTypes"], "GUILD_TEXT" | "GUILD_NEWS" | "GUILD_VOICE">];
   type GuildThreadChannelTypes = Constants["ChannelTypes"][keyof Pick<Constants["ChannelTypes"], "GUILD_NEWS_THREAD" | "GUILD_PRIVATE_THREAD" | "GUILD_PUBLIC_THREAD">];
   type GuildPublicThreadChannelTypes = Exclude<GuildThreadChannelTypes, Constants["ChannelTypes"]["GUILD_PRIVATE_THREAD"]>;
   type GuildVoiceChannelTypes = Constants["ChannelTypes"][keyof Pick<Constants["ChannelTypes"], "GUILD_VOICE" | "GUILD_STAGE">];
@@ -3382,13 +3382,22 @@ declare namespace Eris {
     on(event: string, listener: (...args: any[]) => void): this;
   }
 
-  export class StageChannel extends VoiceChannel {
+  export class StageChannel extends GuildChannel implements Invitable {
+    bitrate: number;
+    rtcRegion: string | null;
     topic?: string;
     type: Constants["ChannelTypes"]["GUILD_STAGE_VOICE"];
+    userLimit: number;
+    videoQualityMode: VideoQualityMode;
+    voiceMembers: Collection<Member>;
     createInstance(options: StageInstanceOptions): Promise<StageInstance>;
+    createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
     deleteInstance(): Promise<void>;
     editInstance(options: StageInstanceOptions): Promise<StageInstance>;
     getInstance(): Promise<StageInstance>;
+    getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
+    join(options?: JoinVoiceChannelOptions): Promise<VoiceConnection>;
+    leave(): void;
   }
 
   export class StageInstance extends Base {
@@ -3543,15 +3552,15 @@ declare namespace Eris {
     removeRelationship(): Promise<void>;
   }
 
-  export class VoiceChannel extends GuildChannel implements Invitable {
+  export class VoiceChannel extends TextChannel {
     bitrate: number;
     rtcRegion: string | null;
-    type: GuildVoiceChannelTypes;
+    type: Constants["ChannelTypes"]["GUILD_VOICE"];
     userLimit: number;
     videoQualityMode: VideoQualityMode;
     voiceMembers: Collection<Member>;
-    createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", VoiceChannel>>;
-    getInvites(): Promise<(Invite<"withMetadata", VoiceChannel>)[]>;
+    createInvite(options?: CreateInviteOptions, reason?: string): Promise<Invite<"withMetadata", this>>;
+    getInvites(): Promise<(Invite<"withMetadata", this>)[]>;
     join(options?: JoinVoiceChannelOptions): Promise<VoiceConnection>;
     leave(): void;
   }

--- a/lib/structures/StageChannel.js
+++ b/lib/structures/StageChannel.js
@@ -1,15 +1,42 @@
 "use strict";
 
-const VoiceChannel = require("./VoiceChannel");
+const Collection = require("../util/Collection");
+const GuildChannel = require("./GuildChannel");
+const Member = require("./Member");
 
 /**
-* Represents a guild stage channel. See VoiceChannel for more properties and methods.
-* @extends VoiceChannel
+* Represents a guild stage channel. See GuildChannel for more properties and methods.
+* @extends GuildChannel
+* @prop {Number?} bitrate The bitrate of the channel
+* @prop {String?} rtcRegion The RTC region ID of the channel (automatic when `null`)
 * @prop {String?} topic The topic of the channel
+* @prop {Number} type The type of the channel
+* @prop {Number?} userLimit The max number of users that can join the channel
+* @prop {Number?} videoQualityMode The camera video quality mode of the voice channel. `1` is auto, `2` is 720p
+* @prop {Collection<Member>} voiceMembers Collection of Members in this channel
 */
-class StageChannel extends VoiceChannel {
+class StageChannel extends GuildChannel {
+    constructor(data, client) {
+        super(data, client);
+        this.voiceMembers = new Collection(Member);
+        this.update(data);
+    }
+
     update(data) {
         super.update(data);
+
+        if(data.bitrate !== undefined) {
+            this.bitrate = data.bitrate;
+        }
+        if(data.rtc_region !== undefined) {
+            this.rtcRegion = data.rtc_region;
+        }
+        if(data.user_limit !== undefined) {
+            this.userLimit = data.user_limit;
+        }
+        if(data.video_quality_mode !== undefined) {
+            this.videoQualityMode = data.video_quality_mode;
+        }
         if(data.topic !== undefined) {
             this.topic = data.topic;
         }
@@ -27,6 +54,20 @@ class StageChannel extends VoiceChannel {
     }
 
     /**
+    * Create an invite for the channel
+    * @arg {Object} [options] Invite generation options
+    * @arg {Number} [options.maxAge] How long the invite should last in seconds
+    * @arg {Number} [options.maxUses] How many uses the invite should last for
+    * @arg {Boolean} [options.temporary] Whether the invite grants temporary membership or not
+    * @arg {Boolean} [options.unique] Whether the invite is unique or not
+    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @returns {Promise<Invite>}
+    */
+    createInvite(options, reason) {
+        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
+    }
+
+    /**
     * Delete the stage instance for this channel
     * @returns {Promise}
     */
@@ -41,6 +82,7 @@ class StageChannel extends VoiceChannel {
     * @arg {String} [options.topic] The stage instance topic
     * @returns {Promise<StageInstance>}
     */
+
     editInstance(options) {
         return this.client.editStageInstance.call(this.client, this.id, options);
     }
@@ -53,8 +95,41 @@ class StageChannel extends VoiceChannel {
         return this.client.getStageInstance.call(this.client, this.id);
     }
 
+    /**
+    * Get all invites in the channel
+    * @returns {Promise<Array<Invite>>}
+    */
+    getInvites() {
+        return this.client.getChannelInvites.call(this.client, this.id);
+    }
+
+    /**
+    * Joins the channel.
+    * @arg {Object} [options] VoiceConnection constructor options
+    * @arg {Object} [options.opusOnly] Skip opus encoder initialization. You should not enable this unless you know what you are doing
+    * @arg {Object} [options.shared] Whether the VoiceConnection will be part of a SharedStream or not
+    * @arg {Boolean} [options.selfMute] Whether the bot joins the channel muted or not
+    * @arg {Boolean} [options.selfDeaf] Whether the bot joins the channel deafened or not
+    * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
+    */
+    join(options) {
+        return this.client.joinVoiceChannel.call(this.client, this.id, options);
+    }
+
+    /**
+    * Leaves the channel.
+    */
+    leave() {
+        return this.client.leaveVoiceChannel.call(this.client, this.id);
+    }
+
     toJSON(props = []) {
         return super.toJSON([
+            "bitrate",
+            "rtcRegion",
+            "userLimit",
+            "videoQualityMode",
+            "voiceMembers",
             "topic",
             ...props
         ]);

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -1,12 +1,12 @@
 "use strict";
 
 const Collection = require("../util/Collection");
-const GuildChannel = require("./GuildChannel");
 const Member = require("./Member");
+const TextChannel = require("./TextChannel");
 
 /**
-* Represents a guild voice channel. See GuildChannel for more properties and methods.
-* @extends GuildChannel
+* Represents a guild voice channel. See TextChannel for more properties and methods.
+* @extends TextChannel
 * @prop {Number?} bitrate The bitrate of the channel
 * @prop {String?} rtcRegion The RTC region ID of the channel (automatic when `null`)
 * @prop {Number} type The type of the channel
@@ -14,7 +14,7 @@ const Member = require("./Member");
 * @prop {Number?} videoQualityMode The camera video quality mode of the voice channel. `1` is auto, `2` is 720p
 * @prop {Collection<Member>} voiceMembers Collection of Members in this channel
 */
-class VoiceChannel extends GuildChannel {
+class VoiceChannel extends TextChannel {
     constructor(data, client) {
         super(data, client);
         this.voiceMembers = new Collection(Member);


### PR DESCRIPTION
This pr is currently just some guesswork & assumptions since no documentation exists for this yet.

Currently, `VoiceChannel` has been fitted to extend `TextChannel` & `GuildStage` now extends `GuildChannel` instead of `VoiceChannel`.