### PR TITLE
fix(userUpdate): Uncached users throwing undefined

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1965,7 +1965,7 @@ class Shard extends EventEmitter {
                     discriminator: user.discriminator,
                     avatar: user.avatar
                 };
-                this.emit("userUpdate", user.update(packet.d), oldUser);
+                this.emit("userUpdate", this.client.users.update(packet.d), oldUser);
                 break;
             }
             case "RELATIONSHIP_ADD": {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -621,7 +621,7 @@ class Shard extends EventEmitter {
                         * Fired when a user's avatar, discriminator or username changes
                         * @event Client#userUpdate
                         * @prop {User} user The updated user
-                        * @prop {Object?} oldUser The old user data
+                        * @prop {Object?} oldUser The old user data. If the user was uncached, this will be null
                         * @prop {String} oldUser.username The username of the user
                         * @prop {String} oldUser.discriminator The discriminator of the user
                         * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
@@ -1959,13 +1959,17 @@ class Shard extends EventEmitter {
                 break;
             }
             case "USER_UPDATE": {
-                const user = this.client.users.get(packet.d.id);
-                const oldUser = {
-                    username: user.username,
-                    discriminator: user.discriminator,
-                    avatar: user.avatar
-                };
-                this.emit("userUpdate", this.client.users.update(packet.d), oldUser);
+                let user = this.client.users.get(packet.d.id);
+                let oldUser = null;
+                if(user) {
+                    oldUser = {
+                        username: user.username,
+                        discriminator: user.discriminator,
+                        avatar: user.avatar
+                    };
+                }
+                user = this.client.users.update(packet.d, this.client);
+                this.emit("userUpdate", user, oldUser);
                 break;
             }
             case "RELATIONSHIP_ADD": {


### PR DESCRIPTION
when you update the bot username or avatar or discriminator it fires an undefined on the userUpdate event.