### PR TITLE
fix(getGuildAuditLog): cache users & threads earlier

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2293,11 +2293,13 @@ class Client extends EventEmitter {
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_AUDIT_LOGS(guildID), true, options).then((data) => {
             const guild = this.guilds.get(guildID);
+            const threads = data.threads.map((thread) => guild.threads.update(thread, this));
+            const users = data.users.map((user) => this.users.add(user, this));
             return {
                 entries: data.audit_log_entries.map((entry) => new GuildAuditLogEntry(entry, guild)),
                 integrations: data.integrations.map((integration) => new GuildIntegration(integration, guild)),
-                threads: data.threads.map((thread) => guild.threads.update(thread, this)),
-                users: data.users.map((user) => this.users.add(user, this)),
+                threads: threads,
+                users: users,
                 webhooks: data.webhooks
             };
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2293,8 +2293,8 @@ class Client extends EventEmitter {
         }
         return this.requestHandler.request("GET", Endpoints.GUILD_AUDIT_LOGS(guildID), true, options).then((data) => {
             const guild = this.guilds.get(guildID);
-            const threads = data.threads.map((thread) => guild.threads.update(thread, this));
             const users = data.users.map((user) => this.users.add(user, this));
+            const threads = data.threads.map((thread) => guild.threads.update(thread, this));
             return {
                 entries: data.audit_log_entries.map((entry) => new GuildAuditLogEntry(entry, guild)),
                 integrations: data.integrations.map((integration) => new GuildIntegration(integration, guild)),


### PR DESCRIPTION
Currently, users are added to the cache too late when audit log entries are fetched, so they will not be present in the entry itself if the user was not previously cached. This pull request remedies that by pulling it out of the object itself, and making it before the entries are constructed.