### PR TITLE
Improved max_concurrency aware ShardManager

### DIFF
--- a/examples/sharding.js
+++ b/examples/sharding.js
@@ -1,0 +1,26 @@
+const Eris = require("eris");
+
+// Replace TOKEN with your bot account's token
+const bot = new Eris("Bot TOKEN", {
+    firstShardID: 0,
+    lastShardID: 15,
+    maxShards: 16,
+    getAllUsers: false,
+    intents: ["guilds", "guildMembers", "guildPresences"]
+});
+
+bot.on("ready", () => { // When the bot is ready
+    console.log("Ready!"); // Log "Ready!"
+    console.timeEnd("ready");
+});
+
+bot.on("error", (err) => {
+    console.error(err); // or your preferred logger
+});
+
+bot.on("shardReady", (id) => {
+    console.log(`Shard ${id} ready!`);
+});
+
+console.time("ready");
+bot.connect(); // Get the bot to connect to Discord

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -445,7 +445,7 @@ class Client extends EventEmitter {
             }
 
             for(let i = this.options.firstShardID; i <= this.options.lastShardID; ++i) {
-                this.shards.spawn(i);
+                await this.shards.spawn(i);
             }
         } catch(err) {
             if(!this.options.autoreconnect) {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -1854,7 +1854,7 @@ class Shard extends EventEmitter {
                 this.connectTimeout = null;
                 this.status = "ready";
                 this.presence.status = "online";
-                this.client.shards._readyPacketCB();
+                this.client.shards._readyPacketCB(this.id);
 
                 if(packet.t === "RESUMED") {
                     // Can only heartbeat after resume succeeds, discord/discord-api-docs#1619

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -5,8 +5,6 @@ const Collection = require("../util/Collection");
 const Endpoints = require("../rest/Endpoints");
 const Shard = require("./Shard");
 
-const SHARD_IDENTIFY_RATELIMIT = 5000; // 5s
-
 class ShardManager extends Collection {
     constructor(client) {
         super(Shard);
@@ -117,9 +115,9 @@ class ShardManager extends Collection {
             const rateLimitKey = (shard.id % this.concurrency) || 0;
             const lastConnect = this.buckets.get(rateLimitKey) || 0;
 
-            // has enough time passed since the last connect for this bucket?
+            // has enough time passed since the last connect for this bucket (5s/bucket)?
             // alternatively if we have a sessionID, we can skip this check
-            if(!shard.sessionID && Date.now() - lastConnect < SHARD_IDENTIFY_RATELIMIT) {
+            if(!shard.sessionID && Date.now() - lastConnect < 5000) {
                 continue;
             }
 

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -146,7 +146,10 @@ class ShardManager extends Collection {
         }
     }
 
-    _readyPacketCB() {
+    _readyPacketCB(shardID) {
+        const rateLimitKey = (shardID % this.concurrency) || 0;
+        this.buckets.set(rateLimitKey, Date.now());
+
         this.tryConnect();
     }
 

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -2,7 +2,10 @@
 
 const Base = require("../structures/Base");
 const Collection = require("../util/Collection");
+const Endpoints = require("../rest/Endpoints");
 const Shard = require("./Shard");
+
+const SHARD_IDENTIFY_RATELIMIT = 5000; // 5s
 
 class ShardManager extends Collection {
     constructor(client) {
@@ -10,21 +13,28 @@ class ShardManager extends Collection {
         this._client = client;
 
         this.connectQueue = [];
-        this.lastConnect = 0;
         this.connectTimeout = null;
+
+        this.concurrency = null;
+        this.buckets = new Map();
     }
 
-    connect(shard) {
-        if(shard.sessionID || (this.lastConnect <= Date.now() - 5000 && !this.find((shard) => shard.connecting))) {
-            shard.connect();
-            this.lastConnect = Date.now() + 7500;
-        } else {
-            this.connectQueue.push(shard);
-            this.tryConnect();
+    async connect(shard) {
+        // fetch max_concurrency if needed
+        if(!this.concurrency) {
+            const gateway = await this._client.requestHandler.request("GET", Endpoints.GATEWAY_BOT, true);
+            if(gateway.session_start_limit && gateway.session_start_limit.max_concurrency) {
+                this.concurrency = gateway.session_start_limit.max_concurrency;
+            } else {
+                this.concurrency = 1;
+            }
         }
+
+        this.connectQueue.push(shard);
+        this.tryConnect();
     }
 
-    spawn(id) {
+    async spawn(id) {
         let shard = this.get(id);
         if(!shard) {
             shard = this.add(new Shard(id, this._client));
@@ -91,27 +101,52 @@ class ShardManager extends Collection {
             });
         }
         if(shard.status === "disconnected") {
-            this.connect(shard);
+            return this.connect(shard);
         }
     }
 
     tryConnect() {
-        if(this.connectQueue.length > 0) {
-            if(this.lastConnect <= Date.now() - 5000) {
-                const shard = this.connectQueue.shift();
-                shard.connect();
-                this.lastConnect = Date.now() + 7500;
-            } else if(!this.connectTimeout) {
-                this.connectTimeout = setTimeout(() => {
-                    this.connectTimeout = null;
-                    this.tryConnect();
-                }, 1000);
+        // nothing in queue
+        if(this.connectQueue.length === 0) {
+            return;
+        }
+
+        // loop over the connectQueue
+        for(const shard of this.connectQueue) {
+            // find the bucket for our shard
+            const rateLimitKey = (shard.id % this.concurrency) || 0;
+            const lastConnect = this.buckets.get(rateLimitKey) || 0;
+
+            // has enough time passed since the last connect for this bucket?
+            // alternatively if we have a sessionID, we can skip this check
+            if(!shard.sessionID && Date.now() - lastConnect < SHARD_IDENTIFY_RATELIMIT) {
+                continue;
             }
+
+            // Are there any connecting shards in the same bucket we should wait on?
+            if(this.some((s) => s.connecting && ((s.id % this.concurrency) || 0) === rateLimitKey)) {
+                continue;
+            }
+
+            // connect the shard
+            shard.connect();
+            this.buckets.set(rateLimitKey, Date.now());
+
+            // remove the shard from the queue
+            const index = this.connectQueue.findIndex((s) => s.id === shard.id);
+            this.connectQueue.splice(index, 1);
+        }
+
+        // set the next timeout if we have more shards to connect
+        if(!this.connectTimeout && this.connectQueue.length > 0) {
+            this.connectTimeout = setTimeout(() => {
+                this.connectTimeout = null;
+                this.tryConnect();
+            }, 1000);
         }
     }
 
     _readyPacketCB() {
-        this.lastConnect = Date.now();
         this.tryConnect();
     }
 

--- a/lib/gateway/ShardManager.js
+++ b/lib/gateway/ShardManager.js
@@ -2,7 +2,6 @@
 
 const Base = require("../structures/Base");
 const Collection = require("../util/Collection");
-const Endpoints = require("../rest/Endpoints");
 const Shard = require("./Shard");
 
 class ShardManager extends Collection {
@@ -20,7 +19,7 @@ class ShardManager extends Collection {
     async connect(shard) {
         // fetch max_concurrency if needed
         if(!this.concurrency) {
-            const gateway = await this._client.requestHandler.request("GET", Endpoints.GATEWAY_BOT, true);
+            const gateway = await this._client.getBotGateway();
             if(gateway.session_start_limit && gateway.session_start_limit.max_concurrency) {
                 this.concurrency = gateway.session_start_limit.max_concurrency;
             } else {
@@ -140,7 +139,7 @@ class ShardManager extends Collection {
             this.connectTimeout = setTimeout(() => {
                 this.connectTimeout = null;
                 this.tryConnect();
-            }, 1000);
+            }, 500);
         }
     }
 


### PR DESCRIPTION
This PR makes ShardManager `max_concurrency` aware. Shards in different `rate_limit_key` (https://discord.com/developers/docs/topics/gateway#sharding-max-concurrency) buckets start in parallel resulting in significantly faster startup times across the board for large scale discord bots. Here is a table (these were tested from intent enabled tokens):

| Old time | New Time | concur | % faster      | shards/total | other              |
|----------|----------|--------|---------------|--------------|--------------------|
| 224.251s | 68.312s  | 16     | ~69.5% (nice) | 16/1024      | getAllUsers: true  |
| 431.849s | 70.237s  | 16     | ~83.7%        | 32/1024      | getAllUsers: false |
| 79.591s  | 76.640s   | 1      | margin of err | 16/16        | getAllUsers: false |