### PR TITLE
feat(permissions): Slash Permissions v2

### DIFF
--- a/esm.mjs
+++ b/esm.mjs
@@ -5,6 +5,7 @@ export default function(token, options) {
 }
 
 export const {
+  ApplicationCommand,
   AutocompleteInteraction,
   Base,
   Bucket,

--- a/index.d.ts
+++ b/index.d.ts
@@ -683,7 +683,7 @@ declare namespace Eris {
     selfVideo: boolean;
   }
   interface EventListeners {
-    applicationCommandPermissionsUpdate: [applicationCommandPermissions: GuildApplicationCommandPermissions]
+    applicationCommandPermissionsUpdate: [applicationCommandPermissions: GuildApplicationCommandPermissions];
     callCreate: [call: Call];
     callDelete: [call: Call];
     callRing: [call: Call];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1474,8 +1474,8 @@ declare namespace Eris {
       NUMBER:            10;
     };
     ApplicationCommandPermissionTypes: {
-      ROLE: 1;
-      USER: 2;
+      ROLE:    1;
+      USER:    2;
       CHANNEL: 3;
     };
     ApplicationCommandTypes: {

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,7 +175,8 @@ declare namespace Eris {
   // Application Commands
   interface ApplicationCommand<T extends ApplicationCommandTypes = ApplicationCommandTypes> {
     application_id: string;
-    defaultPermission?: boolean;
+    defaultMemberPermissions?: string;
+    DMPermission?: boolean;
     description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : never;
     guild_id?: string;
     id: string;
@@ -682,6 +683,7 @@ declare namespace Eris {
     selfVideo: boolean;
   }
   interface EventListeners {
+    applicationCommandPermissionsUpdate: [applicationCommandPermissions: GuildApplicationCommandPermissions]
     callCreate: [call: Call];
     callDelete: [call: Call];
     callRing: [call: Call];
@@ -1474,6 +1476,7 @@ declare namespace Eris {
     ApplicationCommandPermissionTypes: {
       ROLE: 1;
       USER: 2;
+      CHANNEL: 3;
     };
     ApplicationCommandTypes: {
       CHAT_INPUT: 1;
@@ -2117,7 +2120,6 @@ declare namespace Eris {
     addRelationship(userID: string, block?: boolean): Promise<void>;
     addSelfPremiumSubscription(token: string, plan: string): Promise<void>;
     banGuildMember(guildID: string, userID: string, deleteMessageDays?: number, reason?: string): Promise<void>;
-    bulkEditCommandPermissions(guildID: string, permissions: { id: string; permissions: ApplicationCommandPermissions[] }[]): Promise<GuildApplicationCommandPermissions[]>;
     bulkEditCommands(commands: ApplicationCommandStructure[]): Promise<ApplicationCommand[]>;
     bulkEditGuildCommands(guildID: string, commands: ApplicationCommandStructure[]): Promise<ApplicationCommand[]>;
     closeVoiceConnection(guildID: string): void;
@@ -2234,7 +2236,7 @@ declare namespace Eris {
     createCommand(command: ApplicationCommandStructure): Promise<ApplicationCommand>;
     createGroupChannel(userIDs: string[]): Promise<GroupChannel>;
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
-    createGuildCommand(guildID: string, command: ApplicationCommandStructure): Promise<ApplicationCommand>;
+    createGuildCommand(guildID: string, command: Omit<ApplicationCommandStructure, 'DMPermission'>): Promise<Omit<ApplicationCommand, 'DMPermission'>>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,7 +175,7 @@ declare namespace Eris {
   // Application Commands
   interface ApplicationCommand<T extends ApplicationCommandTypes = ApplicationCommandTypes> {
     application_id: string;
-    defaultMemberPermissions?: string;
+    defaultMemberPermissions?: bigint | number | string | Permission;
     dmPermission?: boolean;
     description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : never;
     guild_id?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -176,7 +176,7 @@ declare namespace Eris {
   interface ApplicationCommand<T extends ApplicationCommandTypes = ApplicationCommandTypes> {
     application_id: string;
     defaultMemberPermissions?: string;
-    DMPermission?: boolean;
+    dmPermission?: boolean;
     description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : never;
     guild_id?: string;
     id: string;
@@ -2236,7 +2236,7 @@ declare namespace Eris {
     createCommand(command: ApplicationCommandStructure): Promise<ApplicationCommand>;
     createGroupChannel(userIDs: string[]): Promise<GroupChannel>;
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
-    createGuildCommand(guildID: string, command: Omit<ApplicationCommandStructure, 'DMPermission'>): Promise<Omit<ApplicationCommand, 'DMPermission'>>;
+    createGuildCommand(guildID: string, command: Omit<ApplicationCommandStructure, 'dmPermission'>): Promise<Omit<ApplicationCommand, 'dmPermission'>>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2236,7 +2236,7 @@ declare namespace Eris {
     createCommand(command: ApplicationCommandStructure): Promise<ApplicationCommand>;
     createGroupChannel(userIDs: string[]): Promise<GroupChannel>;
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
-    createGuildCommand(guildID: string, command: Omit<ApplicationCommandStructure, 'dmPermission'>): Promise<Omit<ApplicationCommand, 'dmPermission'>>;
+    createGuildCommand(guildID: string, command: Omit<ApplicationCommandStructure, "dmPermission">): Promise<Omit<ApplicationCommand, "dmPermission">>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
     createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2479,7 +2479,7 @@ declare namespace Eris {
     editChannelPosition(channelID: string, position: number, options?: EditChannelPositionOptions): Promise<void>;
     editChannelPositions(guildID: string, channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandTypes>(commandID: string, command: ApplicationCommandEditOptions<false, T>): Promise<ApplicationCommand<false, T>>;
-    editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[]): Promise<GuildApplicationCommandPermissions>;
+    editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[], reason?: string): Promise<GuildApplicationCommandPermissions>;
     editGuild(guildID: string, options: GuildOptions, reason?: string): Promise<Guild>;
     editGuildCommand<T extends ApplicationCommandTypes>(guildID: string, commandID: string, command: ApplicationCommandEditOptions<true, T>): Promise<ApplicationCommand<true, T>>;
     editGuildDiscovery(guildID: string, options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
@@ -2923,7 +2923,7 @@ declare namespace Eris {
     edit(options: GuildOptions, reason?: string): Promise<Guild>;
     editChannelPositions(channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandTypes>(commandID: string, command: ApplicationCommandEditOptions<true, T>): Promise<ApplicationCommand<true, T>>;
-    editCommandPermissions(permissions: ApplicationCommandPermissions[]): Promise<GuildApplicationCommandPermissions[]>;
+    editCommandPermissions(permissions: ApplicationCommandPermissions[], reason?: string): Promise<GuildApplicationCommandPermissions[]>;
     editDiscovery(options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     editIntegration(integrationID: string, options: IntegrationOptions): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -175,6 +175,7 @@ declare namespace Eris {
   /** Generic T is `true` if editing Guild scoped commands, and `false` if not */
   interface ApplicationCommandEditOptions<T extends boolean, U = ApplicationCommandTypes> {
     defaultMemberPermissions?: bigint | number | string | Permission | null;
+    /** @deprecated */
     defaultPermission?: boolean;
     description?: U extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : "" | void;
     descriptionLocalizations?: U extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? { [s: string]: string } | null : null;
@@ -2163,6 +2164,8 @@ declare namespace Eris {
   export class ApplicationCommand<T extends boolean, U = ApplicationCommandTypes> extends Base {
     applicationID: string;
     defaultMemberPermissions: Permission;
+    /** @deprecated */
+    defaultPermission?: boolean | null;
     description: U extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : "";
     descriptionLocalizations?: U extends "CHAT_INPUT" ? Record<string, string> | null : null;
     dmPermission?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -180,17 +180,6 @@ declare namespace Eris {
   }
 
   // Application Commands
-  interface ApplicationCommand<T extends ApplicationCommandTypes = ApplicationCommandTypes> {
-    application_id: string;
-    defaultMemberPermissions?: bigint | number | string | Permission;
-    dmPermission?: boolean;
-    description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : never;
-    guild_id?: string;
-    id: string;
-    name: string;
-    options?: ApplicationCommandOptions[];
-    type: T;
-  }
   interface ApplicationCommandOptionsSubCommand {
     description: string;
     name: string;
@@ -260,7 +249,7 @@ declare namespace Eris {
     application_id: string;
     guild_id: string;
     id: string;
-    permissions?: ApplicationCommandPermissions[];
+    permissions: ApplicationCommandPermissions[];
   }
 
   // Channel
@@ -2154,6 +2143,23 @@ declare namespace Eris {
     show_current_game: boolean;
     status: string;
     theme: string;
+  }
+
+  export class ApplicationCommand<T = ApplicationCommandTypes> extends Base {
+    applicationID: string;
+    defaultMemberPermissions: Permission;
+    description: T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? string : "";
+    descriptionLocalizations?: T extends "CHAT_INPUT" ? Record<string, string> | null : null;
+    dmPermission?: boolean;
+    guild?: PossiblyUncachedGuild;
+    name: string;
+    nameLocalizations?: Record<string, string> | null;
+    nsfw?: boolean;
+    options?: ApplicationCommandOptions[];
+    type?: T;
+    version: string;
+    delete(): Promise<void>;
+    edit(options: Omit<T extends Constants["ApplicationCommandTypes"]["CHAT_INPUT"] ? ChatInputApplicationCommandStructure : T extends Constants["ApplicationCommandTypes"]["USER"] ? UserApplicationCommandStructure : T extends Constants["ApplicationCommandTypes"]["MESSAGE"] ? MessageApplicationCommandStructure : never, "type">): Promise<ApplicationCommand<T>>;
   }
 
   class Base implements SimpleJSON {

--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ function Eris(token, options) {
     return new Client(token, options);
 }
 
+Eris.ApplicationCommand = require("./lib/structures/ApplicationCommand");
 Eris.AutocompleteInteraction = require("./lib/structures/AutocompleteInteraction");
 Eris.Base = require("./lib/structures/Base");
 Eris.Bucket = require("./lib/util/Bucket");

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -540,7 +540,7 @@ class Client extends EventEmitter {
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
     * @arg {String} [command.defaultMemberPermissions] The default member permissions represented as a
-    * @arg {Boolean} [command.DMPermission] The default role permissions
+    * @arg {Boolean} [command.dmPermission] The default role permissions
     * @returns {Promise<Object>} Resolves with a commands object
     */
     createCommand(command) {
@@ -554,7 +554,7 @@ class Client extends EventEmitter {
         }
 
         command.default_member_permissions = command.defaultMemberPermissions;
-        command.dm_permission = command.DMPermission;
+        command.dm_permission = command.dmPermission;
 
         return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
     }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -345,21 +345,6 @@ class Client extends EventEmitter {
     }
 
     /**
-    * Edits command permissions for a multiple commands in a guild.
-    * Note: You can only add up to 10 permission overwrites for a command.
-    * @arg {String} guildID The guild id
-    * @arg {Array<Object>} permissions An array of [partial guild command permissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure)
-    * @returns {Promise<Array<Object>>} Returns an array of [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) objects.
-    */
-    bulkEditCommandPermissions(guildID, permissions) {
-        if(!guildID) {
-            throw new Error("You must provide an id of the guild whose permissions you want to edit.");
-        }
-
-        return this.requestHandler.request("PUT", Endpoints.GUILD_COMMAND_PERMISSIONS(this.application.id, guildID), true, permissions);
-    }
-
-    /**
     * Bulk create/edit global application commands
     * @arg {Array<Object>} commands An array of [Command objects](https://discord.com/developers/docs/interactions/application-commands#application-command-object)
     * @returns {Promise<Array>} Resolves with an array of commands objects
@@ -554,7 +539,8 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {Boolean} [command.defaultPermission=true] Whether the command is enabled by default when the app is added to a guild
+    * @arg {String} [command.defaultMemberPermissions] The default member permissions
+    * @arg {Boolean} [command.DMPermission] The default role permissions
     * @returns {Promise<Object>} Resolves with a commands object
     */
     createCommand(command) {
@@ -566,7 +552,10 @@ class Client extends EventEmitter {
                 }
             }
         }
-        command.default_permission = command.defaultPermission;
+
+        command.default_member_permissions = command.defaultMemberPermissions;
+        command.dm_permission = command.DMPermission;
+
         return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
     }
 
@@ -636,7 +625,9 @@ class Client extends EventEmitter {
                 }
             }
         }
-        command.default_permission = command.defaultPermission;
+
+        command.default_member_permissions = command.defaultMemberPermissions;
+
         return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -539,7 +539,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String} [command.defaultMemberPermissions] The default member permissions represented as a
+    * @arg {String} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean} [command.dmPermission] The default role permissions
     * @returns {Promise<Object>} Resolves with a commands object
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -555,10 +555,8 @@ class Client extends EventEmitter {
                 }
             }
         }
-
         command.default_member_permissions = command.defaultMemberPermissions;
         command.dm_permission = command.dmPermission;
-
         return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -626,9 +626,7 @@ class Client extends EventEmitter {
                 }
             }
         }
-
         command.default_member_permissions = command.defaultMemberPermissions;
-
         return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -351,7 +351,7 @@ class Client extends EventEmitter {
     */
     bulkEditCommands(commands) {
         for(const command of commands) {
-            if(command.name !== undefined){
+            if(command.name !== undefined) {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -359,6 +359,8 @@ class Client extends EventEmitter {
                     }
                 }
             }
+            command.default_member_permissions = command.defaultMemberPermissions;
+            command.dm_permission = command.dmPermission;
         }
         return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands);
     }
@@ -371,7 +373,7 @@ class Client extends EventEmitter {
     */
     bulkEditGuildCommands(guildID, commands) {
         for(const command of commands) {
-            if(command.name !== undefined){
+            if(command.name !== undefined) {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -379,6 +381,7 @@ class Client extends EventEmitter {
                     }
                 }
             }
+            command.default_member_permissions = command.defaultMemberPermissions;
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands);
     }
@@ -539,12 +542,12 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @arg {Boolean} [command.dmPermission] The default role permissions
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
+     * @returns {Promise<Object>} Resolves with a commands object
     */
     createCommand(command) {
-        if(command.name !== undefined){
+        if(command.name !== undefined) {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -613,11 +616,11 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {Boolean} [command.defaultPermission] Whether the command is enabled by default when the app is added to a guild
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     createGuildCommand(guildID, command) {
-        if(command.name !== undefined){
+        if(command.name !== undefined) {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -1332,14 +1335,15 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Boolean} [command.defaultPermission] Whether the command is enabled by default when the app is added to a guild
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
+     * @returns {Promise<Object>} Resolves with a commands object
     */
     editCommand(commandID, command) {
         if(!commandID) {
             throw new Error("You must provide an id of the command to edit.");
         }
-        if(command.name !== undefined){
+        if(command.name !== undefined) {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -1347,7 +1351,8 @@ class Client extends EventEmitter {
                 }
             }
         }
-        command.default_permission = command.defaultPermission;
+        command.default_member_permissions = command.defaultMemberPermissions;
+        command.dm_permission = command.dmPermission;
         return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command);
     }
 
@@ -1425,14 +1430,14 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Boolean} [command.defaultPermission] Whether the command is enabled by default when the app is added to a guild
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     editGuildCommand(guildID, commandID, command) {
         if(!commandID) {
             throw new Error("You must provide an id of the command to edit.");
         }
-        if(command.name !== undefined){
+        if(command.name !== undefined) {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\w-]{1,32}$/)) {
@@ -1440,7 +1445,7 @@ class Client extends EventEmitter {
                 }
             }
         }
-        command.default_permission = command.defaultPermission;
+        command.default_member_permissions = command.defaultMemberPermissions;
         return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -539,7 +539,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String} [command.defaultMemberPermissions] The default member permissions
+    * @arg {String} [command.defaultMemberPermissions] The default member permissions represented as a
     * @arg {Boolean} [command.DMPermission] The default role permissions
     * @returns {Promise<Object>} Resolves with a commands object
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -368,6 +368,9 @@ class Client extends EventEmitter {
                     }
                 }
             }
+            if(command.defaultMemberPermissions !== undefined) {
+                command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+            }
             command.default_member_permissions = command.defaultMemberPermissions;
             command.dm_permission = command.dmPermission;
         }
@@ -389,6 +392,9 @@ class Client extends EventEmitter {
                         throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                     }
                 }
+            }
+            if(command.defaultMemberPermissions !== undefined) {
+                command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
             }
             command.default_member_permissions = command.defaultMemberPermissions;
         }
@@ -558,7 +564,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
      * @returns {Promise<Object>} Resolves with a commands object
     */
@@ -570,6 +576,9 @@ class Client extends EventEmitter {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
+        }
+        if(command.defaultMemberPermissions !== undefined) {
+            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
         command.dm_permission = command.dmPermission;
@@ -630,7 +639,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     createGuildCommand(guildID, command) {
@@ -641,6 +650,9 @@ class Client extends EventEmitter {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
+        }
+        if(command.defaultMemberPermissions !== undefined) {
+            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
         return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
@@ -1370,7 +1382,7 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
      * @returns {Promise<Object>} Resolves with a commands object
     */
@@ -1385,6 +1397,9 @@ class Client extends EventEmitter {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
+        }
+        if(command.defaultMemberPermissions !== undefined) {
+            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
         command.dm_permission = command.dmPermission;
@@ -1465,7 +1480,7 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     editGuildCommand(guildID, commandID, command) {
@@ -1479,6 +1494,9 @@ class Client extends EventEmitter {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
+        }
+        if(command.defaultMemberPermissions !== undefined) {
+            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
         }
         command.default_member_permissions = command.defaultMemberPermissions;
         return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1562,15 +1562,16 @@ class Client extends EventEmitter {
     * @arg {String} commandID The command id
     * @arg {Array<Object>} permissions An array of [permissions objects](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure)
     * @returns {Promise<Object>} Resolves with a [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) object.
+    * @arg {String} [reason] The reason to be displayed in audit logs
     */
-    editCommandPermissions(guildID, commandID, permissions) {
+    editCommandPermissions(guildID, commandID, permissions, reason) {
         if(!guildID) {
             throw new Error("You must provide an id of the guild whose permissions you want to edit.");
         }
         if(!commandID) {
             throw new Error("You must provide an id of the command whose permissions you want to edit.");
         }
-        return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, {permissions});
+        return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, {permissions, reason});
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -380,8 +380,19 @@ class Client extends EventEmitter {
 
     /**
     * Bulk create/edit global application commands
-    * @arg {Array<Object>} commands An array of [Command objects](https://discord.com/developers/docs/interactions/application-commands#application-command-object)
-    * @returns {Promise<Array>} Resolves with an array of commands objects
+    * @arg {Array<Object>} commands An array of command objects
+    * @arg {BigInt | Number | String | Permission?} commands[].defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [commands[].defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [commands[].description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [commands[].descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {Boolean?} [commands[].dmPermission=true] Whether the command is available in DMs with the app
+    * @arg {String} [commands[].id] The command ID, if known
+    * @arg {String} commands[].name The command name
+    * @arg {Object?} [commands[].nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [commands[].nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [commands[].options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [commands[].type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<Array<ApplicationCommand>>} Resolves with the overwritten application commands
     */
     bulkEditCommands(commands) {
         for(const command of commands) {
@@ -404,9 +415,19 @@ class Client extends EventEmitter {
 
     /**
     * Bulk create/edit guild application commands
-    * @arg {String} guildID Guild id to create the commands in
-    * @arg {Array<Object>} commands An array of [Command objects](https://discord.com/developers/docs/interactions/application-commands#application-command-object)
-    * @returns {Promise<Object>} Resolves with an array of commands objects
+    * @arg {String} guildID The ID of the guild
+    * @arg {Array<Object>} commands An array of command objects
+    * @arg {BigInt | Number | String | Permission?} commands[].defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [commands[].defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [commands[].description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [commands[].descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {String} [commands[].id] The command ID, if known
+    * @arg {String} commands[].name The command name
+    * @arg {Object?} [commands[].nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [commands[].nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [commands[].options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [commands[].type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<Array<ApplicationCommand>>} Resolves with the overwritten application commands
     */
     bulkEditGuildCommands(guildID, commands) {
         for(const command of commands) {
@@ -587,13 +608,17 @@ class Client extends EventEmitter {
     /**
     * Create a global application command
     * @arg {Object} command A command object
+    * @arg {BigInt | Number | String | Permission?} command.defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {Boolean?} [command.dmPermission=true] Whether the command is available in DMs with the app
     * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [command.type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<ApplicationCommand>} Resolves with the created application command
     */
     createCommand(command) {
         if(command.name !== undefined) {
@@ -660,14 +685,18 @@ class Client extends EventEmitter {
 
     /**
     * Create a guild application command
-    * @arg {String} guildID The ID of the guild to create the command in
+    * @arg {String} guildID The ID of the guild
     * @arg {Object} command A command object
+    * @arg {BigInt | Number | String | Permission?} command.defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
     * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Number} [command.type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [command.type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<ApplicationCommand>} Resolves with the created application command
     */
     createGuildCommand(guildID, command) {
         if(command.name !== undefined) {
@@ -1461,14 +1490,18 @@ class Client extends EventEmitter {
 
     /**
     * Edit a global application command
-    * @arg {String} commandID The command id
+    * @arg {String} commandID The command ID
     * @arg {Object} command A command object
-    * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {Boolean?} [command.dmPermission=true] Whether the command is available in DMs with the app
+    * @arg {String} [command.name] The command name
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @returns {Promise<ApplicationCommand>} Resolves with the edited application command
     */
     editCommand(commandID, command) {
         if(!commandID) {
@@ -1559,13 +1592,18 @@ class Client extends EventEmitter {
 
     /**
     * Edit a guild application command
-    * @arg {String} guildID The guild ID
+    * @arg {String} guildID The ID of the guild
+    * @arg {String} commandID The ID of the command
     * @arg {Object} command A command object
-    * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @returns {Promise<Object>} Resolves with a commands object
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {String} [command.name] The command name
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @returns {Promise<ApplicationCommand>} Resolves with the edited application command
     */
     editGuildCommand(guildID, commandID, command) {
         if(!commandID) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1,5 +1,6 @@
 "use strict";
 
+const ApplicationCommand = require("./structures/ApplicationCommand");
 const Base = require("./structures/Base");
 const Channel = require("./structures/Channel");
 const Collection = require("./util/Collection");
@@ -426,7 +427,7 @@ class Client extends EventEmitter {
             }
             command.dm_permission = command.dmPermission;
         }
-        return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands);
+        return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands).then((commands) => commands.map((command) => new ApplicationCommand(command, this)));
     }
 
     /**
@@ -464,7 +465,7 @@ class Client extends EventEmitter {
                 command.default_permission = command.defaultPermission;
             }
         }
-        return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands);
+        return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands).then((commands) => commands.map((command) => new ApplicationCommand(command, this)));
     }
 
     /**
@@ -658,7 +659,7 @@ class Client extends EventEmitter {
             command.default_permission = command.defaultPermission;
         }
         command.dm_permission = command.dmPermission;
-        return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
+        return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command).then((command) => new ApplicationCommand(command, this));
     }
 
     /**
@@ -739,7 +740,7 @@ class Client extends EventEmitter {
             this.emit("warn", "[DEPRECATED] createGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
             command.default_permission = command.defaultPermission;
         }
-        return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
+        return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command).then((command) => new ApplicationCommand(command, this));
     }
 
     /**
@@ -1552,7 +1553,7 @@ class Client extends EventEmitter {
             command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
         command.dm_permission = command.dmPermission;
-        return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command);
+        return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command).then((command) => new ApplicationCommand(command, this));
     }
 
     /**
@@ -1658,7 +1659,7 @@ class Client extends EventEmitter {
             this.emit("warn", "[DEPRECATED] editGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
             command.default_permission = command.defaultPermission;
         }
-        return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command);
+        return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command).then((command) => new ApplicationCommand(command, this));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -591,7 +591,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
      * @returns {Promise<Object>} Resolves with a commands object
     */
@@ -666,7 +666,7 @@ class Client extends EventEmitter {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     createGuildCommand(guildID, command) {
@@ -1466,9 +1466,9 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
-     * @returns {Promise<Object>} Resolves with a commands object
+    * @returns {Promise<Object>} Resolves with a commands object
     */
     editCommand(commandID, command) {
         if(!commandID) {
@@ -1564,7 +1564,7 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {bigint | number | string | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */
     editGuildCommand(guildID, commandID, command) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -394,10 +394,10 @@ class Client extends EventEmitter {
                 }
             }
             if(command.defaultMemberPermissions !== undefined) {
-                command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+                command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
             }
-            command.default_member_permissions = command.defaultMemberPermissions;
             command.dm_permission = command.dmPermission;
+            command.default_permission = command.defaultPermission;
         }
         return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands);
     }
@@ -419,9 +419,9 @@ class Client extends EventEmitter {
                 }
             }
             if(command.defaultMemberPermissions !== undefined) {
-                command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+                command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
             }
-            command.default_member_permissions = command.defaultMemberPermissions;
+            command.default_permission = command.defaultPermission;
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands);
     }
@@ -605,10 +605,10 @@ class Client extends EventEmitter {
             }
         }
         if(command.defaultMemberPermissions !== undefined) {
-            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+            command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_member_permissions = command.defaultMemberPermissions;
         command.dm_permission = command.dmPermission;
+        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
     }
 
@@ -679,9 +679,9 @@ class Client extends EventEmitter {
             }
         }
         if(command.defaultMemberPermissions !== undefined) {
-            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+            command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_member_permissions = command.defaultMemberPermissions;
+        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
     }
 
@@ -1483,10 +1483,10 @@ class Client extends EventEmitter {
             }
         }
         if(command.defaultMemberPermissions !== undefined) {
-            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+            command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_member_permissions = command.defaultMemberPermissions;
         command.dm_permission = command.dmPermission;
+        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command);
     }
 
@@ -1580,9 +1580,9 @@ class Client extends EventEmitter {
             }
         }
         if(command.defaultMemberPermissions !== undefined) {
-            command.defaultMemberPermissions = command.defaultMemberPermissions instanceof Permission ? String(command.defaultMemberPermissions.allow) : String(command.defaultMemberPermissions);
+            command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_member_permissions = command.defaultMemberPermissions;
+        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -665,7 +665,7 @@ class Client extends EventEmitter {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
+    * @arg {Number} [command.type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
     * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a commands object
     */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -833,7 +833,7 @@ class Client extends EventEmitter {
             options.data.embeds.push(options.data.embed);
         }
         if(file) {
-            options = { payload_json: options }
+            options = {payload_json: options};
         }
         return this.requestHandler.request("POST", Endpoints.INTERACTION_RESPOND(interactionID, interactionToken), true, options, file, "/interactions/:id/:token/callback");
     }
@@ -1859,7 +1859,7 @@ class Client extends EventEmitter {
             }
         }
         const file = content.file;
-        delete content.file
+        delete content.file;
         return this.requestHandler.request("PATCH", Endpoints.CHANNEL_MESSAGE(channelID, messageID), true, file ? {payload_json: content} : content, file).then((message) => new Message(message, this));
     }
 
@@ -2254,12 +2254,12 @@ class Client extends EventEmitter {
         delete options.file;
 
         if(options.embed) {
-            if(!data.embeds) {
-                data.embeds = [];
+            if(!options.embeds) {
+                options.embeds = [];
             }
-            data.embeds.push(options.embed);
+            options.embeds.push(options.embed);
         }
-        options.avatar_url = options.avatarURL
+        options.avatar_url = options.avatarURL;
         return this.requestHandler.request("POST", Endpoints.WEBHOOK_TOKEN(webhookID, token) + (qs ? "?" + qs : ""), !!options.auth, options.file ? {payload_json: options} : options, file).then((response) => options.wait ? new Message(response, this) : undefined);
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -593,7 +593,7 @@ class Client extends EventEmitter {
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
     * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @arg {Boolean?} [command.dmPermission] Indicates whether the command is available in DMs with the app. By default, commands are visible.
-     * @returns {Promise<Object>} Resolves with a commands object
+    * @returns {Promise<Object>} Resolves with a commands object
     */
     createCommand(command) {
         if(command.name !== undefined) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -404,11 +404,15 @@ class Client extends EventEmitter {
                     }
                 }
             }
+            if(command.defaultPermission !== undefined) {
+                emitDeprecation("DEFAULT_PERMISSION");
+                this.emit("warn", "[DEPRECATED] bulkEditCommands() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+                command.default_permission = command.defaultPermission;
+            }
             if(command.defaultMemberPermissions !== undefined) {
                 command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
             }
             command.dm_permission = command.dmPermission;
-            command.default_permission = command.defaultPermission;
         }
         return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands);
     }
@@ -442,7 +446,11 @@ class Client extends EventEmitter {
             if(command.defaultMemberPermissions !== undefined) {
                 command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
             }
-            command.default_permission = command.defaultPermission;
+            if(command.defaultPermission !== undefined) {
+                emitDeprecation("DEFAULT_PERMISSION");
+                this.emit("warn", "[DEPRECATED] bulkEditGuildCommands() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+                command.default_permission = command.defaultPermission;
+            }
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands);
     }
@@ -632,8 +640,12 @@ class Client extends EventEmitter {
         if(command.defaultMemberPermissions !== undefined) {
             command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
+        if(command.defaultPermission !== undefined) {
+            emitDeprecation("DEFAULT_PERMISSION");
+            this.emit("warn", "[DEPRECATED] createCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+            command.default_permission = command.defaultPermission;
+        }
         command.dm_permission = command.dmPermission;
-        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command);
     }
 
@@ -710,7 +722,11 @@ class Client extends EventEmitter {
         if(command.defaultMemberPermissions !== undefined) {
             command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_permission = command.defaultPermission;
+        if(command.defaultPermission !== undefined) {
+            emitDeprecation("DEFAULT_PERMISSION");
+            this.emit("warn", "[DEPRECATED] createGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+            command.default_permission = command.defaultPermission;
+        }
         return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command);
     }
 
@@ -1515,11 +1531,15 @@ class Client extends EventEmitter {
                 }
             }
         }
+        if(command.defaultPermission !== undefined) {
+            emitDeprecation("DEFAULT_PERMISSION");
+            this.emit("warn", "[DEPRECATED] editCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+            command.default_permission = command.defaultPermission;
+        }
         if(command.defaultMemberPermissions !== undefined) {
             command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
         command.dm_permission = command.dmPermission;
-        command.default_permission = command.defaultPermission;
         return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command);
     }
 
@@ -1620,7 +1640,11 @@ class Client extends EventEmitter {
         if(command.defaultMemberPermissions !== undefined) {
             command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
         }
-        command.default_permission = command.defaultPermission;
+        if(command.defaultPermission !== undefined) {
+            emitDeprecation("DEFAULT_PERMISSION");
+            this.emit("warn", "[DEPRECATED] editGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
+            command.default_permission = command.defaultPermission;
+        }
         return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command);
     }
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -26,8 +26,9 @@ module.exports.ApplicationCommandOptionTypes = {
 };
 
 module.exports.ApplicationCommandPermissionTypes = {
-    ROLE: 1,
-    USER: 2
+    ROLE:    1,
+    USER:    2,
+    CHANNEL: 3
 };
 
 module.exports.ApplicationCommandTypes = {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2332,7 +2332,7 @@ class Shard extends EventEmitter {
                 /**
                 * Fired when an interaction is created
                 * @event Client#interactionCreate
-                * @prop {PingInteraction | CommandInteraction | ComponentInteraction | AutocompleteInteraction | UnknownInteraction} Interaction The Interaction that was created
+                * @prop {PingInteraction | CommandInteraction | ComponentInteraction | AutocompleteInteraction | UnknownInteraction} interaction The Interaction that was created
                 */
                 this.emit("interactionCreate", Interaction.from(packet.d, this.client));
                 break;
@@ -2341,7 +2341,7 @@ class Shard extends EventEmitter {
                 /**
                  * Fired when an application command's permissions are updated
                  * @event Client#applicationCommandPermissionsUpdate
-                 * @prop {GuildApplicationCommandPermissions} GuildApplicationCommandPermissions The updated command permissions
+                 * @prop {GuildApplicationCommandPermissions} guildApplicationCommandPermissions The updated command permissions
                  */
                 this.emit("applicationCommandPermissionsUpdate", packet.d);
                 break;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2337,6 +2337,15 @@ class Shard extends EventEmitter {
                 this.emit("interactionCreate", Interaction.from(packet.d, this.client));
                 break;
             }
+            case "APPLICATION_COMMAND_PERMISSIONS_UPDATE": {
+                /**
+                 * Fired when an application command's permissions are updated
+                 * @event Client#applicationCommandPermissionsUpdate
+                 * @prop {GuildApplicationCommandPermissions} GuildApplicationCommandPermissions The updated command permissions
+                 */
+                this.emit("applicationCommandPermissionsUpdate", packet.d);
+                break;
+            }
             default: {
                 /**
                 * Fired when the shard encounters an unknown packet

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -2504,7 +2504,7 @@ class Shard extends EventEmitter {
                 /**
                  * Fired when an application command's permissions are updated
                  * @event Client#applicationCommandPermissionsUpdate
-                 * @prop {GuildApplicationCommandPermissions} guildApplicationCommandPermissions The updated command permissions
+                 * @prop {Object} guildApplicationCommandPermissions The updated command permissions
                  */
                 this.emit("applicationCommandPermissionsUpdate", packet.d);
                 break;

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -41,7 +41,7 @@ module.exports.GUILD_BAN =                                   (guildID, memberID)
 module.exports.GUILD_BANS =                                            (guildID) => `/guilds/${guildID}/bans`;
 module.exports.GUILD_CHANNELS =                                        (guildID) => `/guilds/${guildID}/channels`;
 module.exports.GUILD_COMMAND =               (applicationID, guildID, commandID) => `/applications/${applicationID}/guilds/${guildID}/commands/${commandID}`;
-module.exports.GUILD_COMMAND_PERMISSIONS =                    (applicationID, guildID) => `/applications/${applicationID}/guilds/${guildID}/commands/permissions`;
+module.exports.GUILD_COMMAND_PERMISSIONS =              (applicationID, guildID) => `/applications/${applicationID}/guilds/${guildID}/commands/permissions`;
 module.exports.GUILD_COMMANDS =                         (applicationID, guildID) => `/applications/${applicationID}/guilds/${guildID}/commands`;
 module.exports.GUILD_DISCOVERY =                                       (guildID) => `/guilds/${guildID}/discovery-metadata`;
 module.exports.GUILD_DISCOVERY_CATEGORY =                  (guildID, categoryID) => `/guilds/${guildID}/discovery-categories/${categoryID}`;

--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -69,20 +69,20 @@ class ApplicationCommand extends Base {
 
     /**
     * Edit this application command
-    * @arg {Object} options The properties to edit
-    * @arg {BigInt | Number | String | Permission?} [options.defaultMemberPermissions] The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
-    * @arg {Boolean} [options.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the app is added to a guild. Use `defaultMemberPermissions` instead.
-    * @arg {String} [options.description] The command description (chat input commands only)
-    * @arg {Object?} [options.descriptionLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
-    * @arg {Boolean} [options.dmPermission] If this command can be used in direct messages (global commands only)
-    * @arg {String} [options.name] The command name
-    * @arg {Object?} [options.nameLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
-    * @arg {Array<Object>} [options.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Boolean}
-    * @returns {Promise<ApplicationCommand>}
+    * @arg {Object} command A command object
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {Boolean?} [command.dmPermission=true] Whether the command is available in DMs with the app (Global applications only)
+    * @arg {String} [command.name] The command name
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @returns {Promise<ApplicationCommand>} Resolves with the edited application command
     */
-    edit(options) {
-        return this.guildID === undefined ? this._client.editCommand.call(this._client, this.id, options) : this._client.editGuildCommand.call(this._client, this.id, this.guildID, options);
+    edit(command) {
+        return this.guildID === undefined ? this._client.editCommand.call(this._client, this.id, command) : this._client.editGuildCommand.call(this._client, this.id, this.guildID, command);
     }
 
     toJSON(props = []) {

--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -1,0 +1,108 @@
+"use strict";
+
+const Base = require("./Base");
+const Permission = require("./Permission");
+
+/**
+* Represents an application command
+* @prop {String} applicationID The ID of the application that this command belongs to
+* @prop {Permission?} defaultMemberPermissions The permissions required by default for this command to be usable
+* @prop {Boolean?} defaultPermission [DEPRECATED] Indicates whether the command is enabled by default when the application is added to a guild
+* @prop {String} description The description of the command (empty for user & message commands)
+* @prop {Object?} descriptionLocalizations A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
+* @prop {Boolean?} dmPermission If this command can be used in direct messages (global commands only)
+* @prop {Guild?} guild The guild associated with this command (guild commands only)
+* @prop {String} id The ID of the application command
+* @prop {String} name The name of the command
+* @prop {Object?} nameLocalizations A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
+* @prop {Boolean?} nsfw Indicates whether the command is age-restricted
+* @prop {Array<Object>?} options The [options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure) associated with this command
+* @prop {Number} type The [command type](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-types)
+* @prop {String} version The id of the version of this command
+*/
+class ApplicationCommand extends Base {
+    constructor(data, client) {
+        super(data.id);
+        this._client = client;
+        this.applicationID = data.application_id;
+        this.name = data.name;
+        this.description = data.description;
+        this.defaultMemberPermissions = data.defaultMemberPermissions == null ? null : new Permission(data.default_member_permissions);
+        this.version = data.version;
+
+        if(data.type !== undefined) {
+            this.type = data.type;
+        }
+        if(data.guild_id !== undefined) {
+            this.guild = client.guilds.get(data.guild_id) || {
+                id: data.guild_id
+            };
+        }
+        if(data.name_localizations !== undefined) {
+            this.nameLocalizations = data.name_localizations;
+        }
+        if(data.description_localizations !== undefined) {
+            this.descriptionLocalizations = data.description_localizations;
+        }
+        if(data.options !== undefined) {
+            this.options = data.options;
+        }
+        if(data.dm_permission !== undefined) {
+            this.dmPermission = data.dm_permission;
+        }
+        if(data.default_permission !== undefined) {
+            this.defaultPermission = data.default_permission;
+        }
+        if(data.nsfw !== undefined) {
+            this.nsfw = data.nsfw;
+        }
+    }
+
+
+    /**
+    * Delete the command
+    * @returns {Promise}
+    */
+    delete() {
+        return this.guildID === undefined ? this._client.deleteCommand.call(this._client, this.id) : this._client.deleteGuildCommand.call(this._client, this.guildID, this.id);
+    }
+
+    /**
+    * Edit this application command
+    * @arg {Object} options The properties to edit
+    * @arg {String?} [options.defaultMemberPermissions] The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
+    * @arg {Boolean} [options.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the app is added to a guild. Use `defaultMemberPermissions` instead.
+    * @arg {String} [options.description] The command description (chat input commands only)
+    * @arg {Object?} [options.descriptionLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale
+    * @arg {Boolean} [options.dmPermission] If this command can be used in direct messages (global commands only)
+    * @arg {String} [options.name] The command name
+    * @arg {Object?} [options.nameLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to names for that locale
+    * @arg {Array<Object>} [options.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Boolean}
+    * @returns {Promise<ApplicationCommand>}
+    */
+    edit(options) {
+        return this.guildID === undefined ? this._client.editCommand.call(this._client, this.id, options) : this._client.editGuildCommand.call(this._client, this.id, this.guildID, options);
+    }
+
+    toJSON(props = []) {
+        return super.toJSON([
+            "applicationID",
+            "defaultMemberPermissions",
+            "defaultPermission",
+            "description",
+            "descriptionLocalizations",
+            "dmPermission",
+            "guild",
+            "name",
+            "nameLocalizations",
+            "nsfw",
+            "options",
+            "type",
+            "version",
+            ...props
+        ]);
+    }
+}
+
+module.exports = ApplicationCommand;

--- a/lib/structures/ApplicationCommand.js
+++ b/lib/structures/ApplicationCommand.js
@@ -70,7 +70,7 @@ class ApplicationCommand extends Base {
     /**
     * Edit this application command
     * @arg {Object} options The properties to edit
-    * @arg {String?} [options.defaultMemberPermissions] The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
+    * @arg {BigInt | Number | String | Permission?} [options.defaultMemberPermissions] The [permissions](https://discord.com/developers/docs/topics/permissions) required by default for this command to be usable
     * @arg {Boolean} [options.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the app is added to a guild. Use `defaultMemberPermissions` instead.
     * @arg {String} [options.description] The command description (chat input commands only)
     * @arg {Object?} [options.descriptionLocalizations] A map of [locales](https://discord.com/developers/docs/reference#locales) to descriptions for that locale

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -573,7 +573,7 @@ class Guild extends Base {
     * Get the guild's icon with the given format and size
     * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
     * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
-    * @returns {String}
+    * @returns {String?}
     */
     dynamicIconURL(format, size) {
         return this.icon ? this._client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -411,7 +411,7 @@ class Guild extends Base {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {Boolean} [command.defaultPermission] Whether the command is enabled by default when the app is added to a guild
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a command object
     */
     createCommand(command) {
@@ -573,7 +573,7 @@ class Guild extends Base {
     * Get the guild's icon with the given format and size
     * @arg {String} [format] The filetype of the icon ("jpg", "jpeg", "png", "gif", or "webp")
     * @arg {Number} [size] The size of the icon (any power of two between 16 and 4096)
-    * @returns {String?}
+    * @returns {String}
     */
     dynamicIconURL(format, size) {
         return this.icon ? this._client._formatImage(Endpoints.GUILD_ICON(this.id, this.icon), format, size) : null;
@@ -624,7 +624,7 @@ class Guild extends Base {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Boolean} [command.defaultPermission] Whether the command is enabled by default when the app is added to a guild
+    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a command object
     */
     editCommand(commandID, commands) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -417,7 +417,7 @@ class Guild extends Base {
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
     * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a command object
     */
     createCommand(command) {
@@ -672,7 +672,7 @@ class Guild extends Base {
     * @arg {String} command.name The command name
     * @arg {String} [command.description] The command description (Slash Commands Only)
     * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {String?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
     * @returns {Promise<Object>} Resolves with a command object
     */
     editCommand(commandID, commands) {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -704,10 +704,11 @@ class Guild extends Base {
     * Note: You can only add up to 10 permission overwrites for a command.
     * @arg {String} commandID The command id
     * @arg {Array<Object>} permissions An array of [permissions objects](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-application-command-permissions-structure)
+    * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise<Object>} Resolves with a [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) object.
     */
-    editCommandPermissions(commandID, permissions) {
-        return this._client.editCommandPermissions.call(this._client, this.id, commandID, permissions);
+    editCommandPermissions(commandID, permissions, reason) {
+        return this._client.editCommandPermissions.call(this._client, this.id, commandID, permissions, reason);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -382,9 +382,19 @@ class Guild extends Base {
     }
 
     /**
-    * Bulk create/edit guild application commands
-    * @arg {Array<Object>} commands An array of [Command objects](https://discord.com/developers/docs/interactions/application-commands#application-command-object)
-    * @returns {Promise<Object>} Resolves with a commands object
+    * Bulk create/edit the guild application commands
+    * @arg {Array<Object>} commands An array of command objects
+    * @arg {BigInt | Number | String | Permission?} commands[].defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [commands[].defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [commands[].description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [commands[].descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {String} [commands[].id] The command ID, if known
+    * @arg {String} commands[].name The command name
+    * @arg {Object?} [commands[].nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [commands[].nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [commands[].options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [commands[].type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<Array<ApplicationCommand>>} Resolves with the overwritten application commands
     */
     bulkEditCommands(commands) {
         return this._client.bulkEditGuildCommands.call(this._client, this.id, commands);
@@ -412,13 +422,17 @@ class Guild extends Base {
 
     /**
     * Create a guild application command
-    * @arg {Object} command A command object
+    * @arg {Object} command An array of command objects
+    * @arg {BigInt | Number | String | Permission?} command.defaultMemberPermissions The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission=true] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
     * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {Number} [type=1] The type of application command, 1 for slash command, 2 for user, and 3 for message
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @returns {Promise<Object>} Resolves with a command object
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw=false] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @arg {Number} [command.type=1] The command type, either `1` for `CHAT_INPUT`, `2` for `USER` or `3` for `MESSAGE`
+    * @returns {Promise<ApplicationCommand>} Resolves with the created application command
     */
     createCommand(command) {
         return this._client.createGuildCommand.call(this._client, this.id, command);
@@ -667,16 +681,20 @@ class Guild extends Base {
 
     /**
     * Edit a guild application command
-    * @arg {String} commandID The command id
-    * @arg {Object} command A command object
-    * @arg {String} command.name The command name
-    * @arg {String} [command.description] The command description (Slash Commands Only)
-    * @arg {Array<Object>} [command.options] An array of [command options](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)
-    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default member [permissions](https://discord.com/developers/docs/topics/permissions) represented as a bit set
-    * @returns {Promise<Object>} Resolves with a command object
+    * @arg {String} commandID The command ID
+    * @arg {Array<Object>} command An array of command objects
+    * @arg {BigInt | Number | String | Permission?} [command.defaultMemberPermissions] The default permissions the user must have to use the command
+    * @arg {Boolean} [command.defaultPermission] [DEPRECATED] Whether the command is enabled by default when the application is added to a guild. Replaced by `defaultMemberPermissions`
+    * @arg {String} [command.description] The command description, required for `CHAT_INPUT` commands
+    * @arg {Object?} [command.descriptionLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command description
+    * @arg {String} [command.name] The command name
+    * @arg {Object?} [command.nameLocalizations] Localization directory with keys in [available locales](https://discord.dev/reference#locales) for the command name
+    * @arg {Boolean} [command.nsfw] Whether the command is age-restricted
+    * @arg {Array<Object>} [command.options] The application command [options](https://discord.dev/interactions/application-commands#application-command-object-application-command-option-structure)
+    * @returns {Promise<ApplicationCommand>} Resolves with the edited application command
     */
-    editCommand(commandID, commands) {
-        return this._client.editGuildCommand.call(this._client, this.id, commandID, commands);
+    editCommand(commandID, command) {
+        return this._client.editGuildCommand.call(this._client, this.id, commandID, command);
     }
 
     /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -382,16 +382,6 @@ class Guild extends Base {
     }
 
     /**
-    * Edits command permissions for a multiple commands in a guild.
-    * Note: You can only add up to 10 permission overwrites for a command.
-    * @arg {Array<Object>} permissions An array of [partial guild command permissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure)
-    * @returns {Promise<Array<Object>>} Returns an array of [GuildApplicationCommandPermissions](https://discord.com/developers/docs/interactions/application-commands#application-command-permissions-object-guild-application-command-permissions-structure) objects.
-    */
-    bulkEditCommandPermissions(permissions) {
-        return this._client.bulkEditCommandPermissions.call(this._client, this.id, permissions);
-    }
-
-    /**
     * Bulk create/edit guild application commands
     * @arg {Array<Object>} commands An array of [Command objects](https://discord.com/developers/docs/interactions/application-commands#application-command-object)
     * @returns {Promise<Object>} Resolves with a commands object

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -1,5 +1,6 @@
 const warningMessages = {
     CREATE_CHANNEL_OPTIONS: "Passing parentID or reason string arguments directly to createChannel() is deprecated. Use an options object instead.",
+    DEFAULT_PERMISSION: "Passing a defaultPermission for application commands is deprecated. Use defaultMemberPermissions instead.",
     DM_REACTION_REMOVE: "Passing a userID when using removeMessageReaction() in a PrivateChannel is deprecated. This behavior is no longer supported by Discord.",
     GET_REACTION_BEFORE: "Passing the before parameter to getMessageReaction() is deprecated. Discord no longer supports this parameter.",
     MEMBER_PERMISSION: "Member#permission is deprecated. Use Member#permissions instead.",


### PR DESCRIPTION
Remove bulk editing of command permissions as the endpoint has been disabled, 
add defaultMemberPermissions and dmPermission in place of defaultPermission, 
add the applicationCommandPermissionsUpdate gateway event, 
add the ApplicationCommandPermissionTypes channel type, 
modify createGuildCommand to return without the new DMPermission field