### PR TITLE
fix(deleteMessages): Properly pass through `reason` option

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1093,7 +1093,7 @@ class Client extends EventEmitter {
             return Promise.resolve();
         }
         if(messageIDs.length === 1) {
-            return this.deleteMessage(channelID, messageIDs[0]);
+            return this.deleteMessage(channelID, messageIDs[0], reason);
         }
 
         const oldestAllowedSnowflake = (Date.now() - 1421280000000) * 4194304;
@@ -1106,7 +1106,7 @@ class Client extends EventEmitter {
             return this.requestHandler.request("POST", Endpoints.CHANNEL_BULK_DELETE(channelID), true, {
                 messages: messageIDs.splice(0, 100),
                 reason: reason
-            }).then(() => this.deleteMessages(channelID, messageIDs));
+            }).then(() => this.deleteMessages(channelID, messageIDs, reason));
         }
         return this.requestHandler.request("POST", Endpoints.CHANNEL_BULK_DELETE(channelID), true, {
             messages: messageIDs,


### PR DESCRIPTION
Currently, the `reason` option is dropped within subsequent requests, or if only one message is provided.