### PR TITLE
fix(messageUpdate): fix `oldMessage#mentions` type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -644,7 +644,7 @@ declare namespace Eris {
     embeds: Embed[];
     flags: number;
     mentionedBy?: unknown;
-    mentions: string[];
+    mentions: User[];
     pinned: boolean;
     roleMentions: string[];
     tts: boolean;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -899,7 +899,7 @@ class Shard extends EventEmitter {
                 * @prop {Array<Object>} oldMessage.embeds Array of embeds
                 * @prop {Number} oldMessage.flags Old message flags (see constants)
                 * @prop {Object} oldMessage.mentionedBy Object of if different things mention the bot user
-                * @prop {Array<String>} oldMessage.mentions Array of mentioned users' ids
+                * @prop {Array<User>} oldMessage.mentions Array of mentioned users' ids
                 * @prop {Boolean} oldMessage.pinned Whether the message was pinned or not
                 * @prop {Array<String>} oldMessage.roleMentions Array of mentioned roles' ids.
                 * @prop {Boolean} oldMessage.tts Whether to play the message using TTS or not


### PR DESCRIPTION
`OldMessage#mentions` is currently documented as a string array, but is actually an array of users.