### PR TITLE
Enable presences for `getAllUsers` if intents are right

### DIFF
--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -118,7 +118,9 @@ class Shard extends EventEmitter {
             this.syncGuild(guild.id);
         }
         if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
-            this.getGuildMembers(guild.id);
+            this.getGuildMembers(guild.id, {
+                presences: this.client.options.intents && this.client.options.intents & Constants.Intents.guildPresences
+            });
         }
         return guild;
     }


### PR DESCRIPTION
Based on conversation in `#support`: https://canary.discord.com/channels/831967755447828491/831974405701500931/979924040485568612

I've tested this in the following two scenarios:
 - Presence intent is enabled
   - result: no errors, everything (AFAICT) gets its proper presence
 - Presence intent is disabled
   - result: no errors, everything appears to be offline in cache