### PR TITLE
chore(Base): document props, static methods

### DIFF
--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -20,7 +20,6 @@ class Base {
 
     /**
      * Calculates the timestamp in milliseconds associated with a Discord ID/snowflake
-     * @static
      * @param {String} id The ID of a structure
      * @returns {Number}
      */
@@ -30,7 +29,6 @@ class Base {
 
     /**
      * Gets the number of milliseconds since epoch represented by an ID/snowflake
-     * @static
      * @param {string} id The ID of a structure
      * @returns {number}
      */

--- a/lib/structures/Base.js
+++ b/lib/structures/Base.js
@@ -2,6 +2,11 @@
 
 const util = require("util");
 
+/**
+ * Provides utilities for working with many Discord structures
+ * @prop {string} id A Discord snowflake identifying the object
+ * @prop {Number} createdAt Timestamp of structure creation
+ */
 class Base {
     constructor(id) {
         if(id) {
@@ -13,10 +18,22 @@ class Base {
         return Base.getCreatedAt(this.id);
     }
 
+    /**
+     * Calculates the timestamp in milliseconds associated with a Discord ID/snowflake
+     * @static
+     * @param {String} id The ID of a structure
+     * @returns {Number}
+     */
     static getCreatedAt(id) {
         return Base.getDiscordEpoch(id) + 1420070400000;
     }
 
+    /**
+     * Gets the number of milliseconds since epoch represented by an ID/snowflake
+     * @static
+     * @param {string} id The ID of a structure
+     * @returns {number}
+     */
     static getDiscordEpoch(id) {
         return Math.floor(id / 4194304);
     }


### PR DESCRIPTION
Adds doc comments to the Base class and its useful static methods.

[As discussed on Discord](https://discord.com/channels/831967755447828491/831975480877514822/974743465906819093), I don't know if the docs setup being used for Eris right now actually knows how to handle `@static`; that should be checked before merging this.