### PR TITLE
Convert remaining #client to #_client

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2092,7 +2092,6 @@ declare namespace Eris {
   }
 
   export class Channel extends Base {
-    client: Client;
     createdAt: number;
     id: string;
     mention: string;
@@ -3335,7 +3334,6 @@ declare namespace Eris {
   }
 
   export class Shard extends EventEmitter implements SimpleJSON {
-    client: Client;
     connectAttempts: number;
     connecting: boolean;
     connectTimeout: NodeJS.Timeout | null;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -58,7 +58,7 @@ class Shard extends EventEmitter {
         super();
 
         this.id = id;
-        this.client = client;
+        this._client = client;
 
         this.onPacket = this.onPacket.bind(this);
         this._onWSOpen = this._onWSOpen.bind(this);
@@ -111,15 +111,15 @@ class Shard extends EventEmitter {
     }
 
     createGuild(_guild) {
-        this.client.guildShardMap[_guild.id] = this.id;
-        const guild = this.client.guilds.add(_guild, this.client, true);
-        if(this.client.bot === false) {
+        this._client.guildShardMap[_guild.id] = this.id;
+        const guild = this._client.guilds.add(_guild, this._client, true);
+        if(this._client.bot === false) {
             ++this.unsyncedGuilds;
             this.syncGuild(guild.id);
         }
-        if(this.client.options.getAllUsers && guild.members.size < guild.memberCount) {
+        if(this._client.options.getAllUsers && guild.members.size < guild.memberCount) {
             this.getGuildMembers(guild.id, {
-                presences: this.client.options.intents && this.client.options.intents & Constants.Intents.guildPresences
+                presences: this._client.options.intents && this._client.options.intents & Constants.Intents.guildPresences
             });
         }
         return guild;
@@ -173,12 +173,12 @@ class Shard extends EventEmitter {
         */
         super.emit("disconnect", error);
 
-        if(this.sessionID && this.connectAttempts >= this.client.options.maxResumeAttempts) {
+        if(this.sessionID && this.connectAttempts >= this._client.options.maxResumeAttempts) {
             this.emit("debug", `Automatically invalidating session due to excessive resume attempts | Attempt ${this.connectAttempts}`, this.id);
             this.sessionID = null;
         }
 
-        if(options.reconnect === "auto" && this.client.options.autoreconnect) {
+        if(options.reconnect === "auto" && this._client.options.autoreconnect) {
             /**
             * Fired when stuff happens and gives more info
             * @event Client#debug
@@ -187,11 +187,11 @@ class Shard extends EventEmitter {
             */
             if(this.sessionID) {
                 this.emit("debug", `Immediately reconnecting for potential resume | Attempt ${this.connectAttempts}`, this.id);
-                this.client.shards.connect(this);
+                this._client.shards.connect(this);
             } else {
                 this.emit("debug", `Queueing reconnect in ${this.reconnectInterval}ms | Attempt ${this.connectAttempts}`, this.id);
                 setTimeout(() => {
-                    this.client.shards.connect(this);
+                    this._client.shards.connect(this);
                 }, this.reconnectInterval);
                 this.reconnectInterval = Math.min(Math.round(this.reconnectInterval * (Math.random() * 2 + 1)), 30000);
             }
@@ -242,7 +242,7 @@ class Shard extends EventEmitter {
     }
 
     emit(event, ...args) {
-        this.client.emit.call(this.client, event, ...args);
+        this._client.emit.call(this._client, event, ...args);
         if(event !== "error" || this.listeners("error").length > 0) {
             super.emit.call(this, event, ...args);
         }
@@ -254,8 +254,8 @@ class Shard extends EventEmitter {
         }
         this.getAllUsersCount[guildID] = true;
         // Using intents, request one guild at a time
-        if(this.client.options.intents) {
-            if(!(this.client.options.intents & Constants.Intents.guildMembers)) {
+        if(this._client.options.intents) {
+            if(!(this._client.options.intents & Constants.Intents.guildMembers)) {
                 throw new Error("Cannot request all members without guildMembers intent");
             }
             this.requestGuildMembers([guildID], timeout);
@@ -282,12 +282,12 @@ class Shard extends EventEmitter {
         this.guildCreateTimeout = null;
         this.globalBucket = new Bucket(120, 60000, {reservedTokens: 5});
         this.presenceUpdateBucket = new Bucket(5, 20000);
-        this.presence = JSON.parse(JSON.stringify(this.client.presence)); // Fast copy
+        this.presence = JSON.parse(JSON.stringify(this._client.presence)); // Fast copy
         Object.defineProperty(this, "_token", {
             configurable: true,
             enumerable: false,
             writable: true,
-            value: this.client._token
+            value: this._client._token
         });
     }
 
@@ -316,7 +316,7 @@ class Shard extends EventEmitter {
     }
 
     identify() {
-        if(this.client.options.compress && !ZlibSync) {
+        if(this._client.options.compress && !ZlibSync) {
             /**
             * Fired when the shard encounters an error
             * @event Client#error
@@ -330,17 +330,17 @@ class Shard extends EventEmitter {
         const identify = {
             token: this._token,
             v: GATEWAY_VERSION,
-            compress: !!this.client.options.compress,
-            large_threshold: this.client.options.largeThreshold,
-            intents: this.client.options.intents,
+            compress: !!this._client.options.compress,
+            large_threshold: this._client.options.largeThreshold,
+            intents: this._client.options.intents,
             properties: {
                 "os": process.platform,
                 "browser": "Eris",
                 "device": "Eris"
             }
         };
-        if(this.client.options.maxShards > 1) {
-            identify.shard = [this.id, this.client.options.maxShards];
+        if(this._client.options.maxShards > 1) {
+            identify.shard = [this.id, this._client.options.maxShards];
         }
         if(this.presence.status) {
             identify.presence = this.presence;
@@ -354,13 +354,13 @@ class Shard extends EventEmitter {
         }
 
         this.status = "connecting";
-        if(this.client.options.compress) {
+        if(this._client.options.compress) {
             this.emit("debug", "Initializing zlib-sync-based compression");
             this._zlibSync = new ZlibSync.Inflate({
                 chunkSize: 128 * 1024
             });
         }
-        this.ws = new WebSocket(this.client.gatewayURL, this.client.options.ws);
+        this.ws = new WebSocket(this._client.gatewayURL, this._client.options.ws);
         this.ws.on("open", this._onWSOpen);
         this.ws.on("message", this._onWSMessage);
         this.ws.on("error", this._onWSError);
@@ -372,11 +372,11 @@ class Shard extends EventEmitter {
                     reconnect: "auto"
                 }, new Error("Connection timeout"));
             }
-        }, this.client.options.connectionTimeout);
+        }, this._client.options.connectionTimeout);
     }
 
     onPacket(packet) {
-        if(this.listeners("rawWS").length > 0 || this.client.listeners("rawWS").length) {
+        if(this.listeners("rawWS").length > 0 || this._client.listeners("rawWS").length) {
             /**
             * Fired when the shard receives a websocket packet
             * @event Client#rawWS
@@ -401,7 +401,7 @@ class Shard extends EventEmitter {
 
         switch(packet.op) {
             case GatewayOPCodes.DISPATCH: {
-                if(!this.client.options.disableEvents[packet.t]) {
+                if(!this._client.options.disableEvents[packet.t]) {
                     this.wsEvent(packet);
                 }
                 break;
@@ -480,10 +480,10 @@ class Shard extends EventEmitter {
         if(!opts.user_ids && !opts.query) {
             opts.query = "";
         }
-        if(!opts.query && !opts.user_ids && (this.client.options.intents && !(this.client.options.intents & Constants.Intents.guildMembers))) {
+        if(!opts.query && !opts.user_ids && (this._client.options.intents && !(this._client.options.intents & Constants.Intents.guildMembers))) {
             throw new Error("Cannot request all members without guildMembers intent");
         }
-        if(opts.presences && (this.client.options.intents && !(this.client.options.intents & Constants.Intents.guildPresences))) {
+        if(opts.presences && (this._client.options.intents && !(this._client.options.intents & Constants.Intents.guildPresences))) {
             throw new Error("Cannot request members presences without guildPresences intent");
         }
         if(opts.user_ids && opts.user_ids.length > 100) {
@@ -497,7 +497,7 @@ class Shard extends EventEmitter {
             timeout: setTimeout(() => {
                 res(this.requestMembersPromise[opts.nonce].members);
                 delete this.requestMembersPromise[opts.nonce];
-            }, (options && options.timeout) || this.client.options.requestTimeout)
+            }, (options && options.timeout) || this._client.options.requestTimeout)
         });
     }
 
@@ -542,12 +542,12 @@ class Shard extends EventEmitter {
             this.guildCreateTimeout = null;
         }
         if(!this.ready) {
-            if(this.client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
+            if(this._client.unavailableGuilds.size === 0 && this.unsyncedGuilds === 0) {
                 return this.checkReady();
             }
             this.guildCreateTimeout = setTimeout(() => {
                 this.checkReady();
-            }, this.client.options.guildCreateTimeout);
+            }, this._client.options.guildCreateTimeout);
         }
     }
 
@@ -608,7 +608,7 @@ class Shard extends EventEmitter {
         switch(packet.t) { /* eslint-disable no-redeclare */ // (╯°□°）╯︵ ┻━┻
             case "PRESENCE_UPDATE": {
                 if(packet.d.user.username !== undefined) {
-                    let user = this.client.users.get(packet.d.user.id);
+                    let user = this._client.users.get(packet.d.user.id);
                     let oldUser = null;
                     if(user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
@@ -618,7 +618,7 @@ class Shard extends EventEmitter {
                         };
                     }
                     if(!user || oldUser) {
-                        user = this.client.users.update(packet.d.user, this.client);
+                        user = this._client.users.update(packet.d.user, this._client);
                         /**
                         * Fired when a user's avatar, discriminator or username changes
                         * @event Client#userUpdate
@@ -633,7 +633,7 @@ class Shard extends EventEmitter {
                 }
                 if(!packet.d.guild_id) {
                     packet.d.id = packet.d.user.id;
-                    const relationship = this.client.relationships.get(packet.d.id);
+                    const relationship = this._client.relationships.get(packet.d.id);
                     if(!relationship) { // Removing relationships
                         break;
                     }
@@ -653,10 +653,10 @@ class Shard extends EventEmitter {
                     * @prop {String} oldPresence.clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
                     * @prop {String} oldPresence.status The other user's old status. Either "online", "idle", or "offline"
                     */
-                    this.emit("presenceUpdate", this.client.relationships.update(packet.d), oldPresence);
+                    this.emit("presenceUpdate", this._client.relationships.update(packet.d), oldPresence);
                     break;
                 }
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", "Rogue presence update: " + JSON.stringify(packet), this.id);
                     break;
@@ -677,11 +677,11 @@ class Shard extends EventEmitter {
                 break;
             }
             case "VOICE_STATE_UPDATE": { // (╯°□°）╯︵ ┻━┻
-                if(packet.d.guild_id && packet.d.user_id === this.client.user.id) {
-                    const voiceConnection = this.client.voiceConnections.get(packet.d.guild_id);
+                if(packet.d.guild_id && packet.d.user_id === this._client.user.id) {
+                    const voiceConnection = this._client.voiceConnections.get(packet.d.guild_id);
                     if(voiceConnection) {
                         if(packet.d.channel_id === null) {
-                            this.client.voiceConnections.leave(packet.d.guild_id);
+                            this._client.voiceConnections.leave(packet.d.guild_id);
                         } else if(voiceConnection.channelID !== packet.d.channel_id) {
                             voiceConnection.switchChannel(packet.d.channel_id, true);
                         }
@@ -694,7 +694,7 @@ class Shard extends EventEmitter {
                     packet.d.id = packet.d.user_id;
                     if(packet.d.channel_id === null) {
                         let flag = false;
-                        for(const groupChannel of this.client.groupChannels) {
+                        for(const groupChannel of this._client.groupChannels) {
                             const call = (groupChannel[1].call || groupChannel[1].lastCall);
                             if(call && call.voiceStates.remove(packet.d)) {
                                 flag = true;
@@ -702,7 +702,7 @@ class Shard extends EventEmitter {
                             }
                         }
                         if(!flag) {
-                            for(const privateChannel of this.client.privateChannels) {
+                            for(const privateChannel of this._client.privateChannels) {
                                 const call = (privateChannel[1].call || privateChannel[1].lastCall);
                                 if(call && call.voiceStates.remove(packet.d)) {
                                     flag = true;
@@ -715,7 +715,7 @@ class Shard extends EventEmitter {
                             }
                         }
                     } else {
-                        const channel = this.client.getChannel(packet.d.channel_id);
+                        const channel = this._client.getChannel(packet.d.channel_id);
                         if(!channel.call && !channel.lastCall) {
                             this.emit("debug", new Error("VOICE_STATE_UPDATE for untracked call"));
                             break;
@@ -724,7 +724,7 @@ class Shard extends EventEmitter {
                     }
                     break;
                 }
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     break;
                 }
@@ -767,7 +767,7 @@ class Shard extends EventEmitter {
                     selfVideo: member.voiceState.selfVideo
                 };
                 const oldChannelID = member.voiceState.channelID;
-                member.update(packet.d, this.client);
+                member.update(packet.d, this._client);
                 if(oldChannelID != packet.d.channel_id) {
                     let oldChannel, newChannel;
                     if(oldChannelID) {
@@ -827,12 +827,12 @@ class Shard extends EventEmitter {
             }
             case "TYPING_START": {
                 let member = null;
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(guild) {
                     packet.d.member.id = packet.d.user_id;
                     member = guild.members.update(packet.d.member, guild);
                 }
-                if(this.client.listeners("typingStart").length > 0) {
+                if(this._client.listeners("typingStart").length > 0) {
                     /**
                     * Fired when a user begins typing
                     * @event Client#typingStart
@@ -840,12 +840,12 @@ class Shard extends EventEmitter {
                     * @prop {User | Object} user The user. If the user is not cached, this will be an object with an `id` key. No other property is guaranteed
                     * @prop {Member?} member The guild member, if typing in a guild channel, or `null`, if typing in a PrivateChannel
                     */
-                    this.emit("typingStart", this.client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this.client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
+                    this.emit("typingStart", this._client.getChannel(packet.d.channel_id) || {id: packet.d.channel_id}, this._client.users.get(packet.d.user_id) || {id: packet.d.user_id}, member);
                 }
                 break;
             }
             case "MESSAGE_CREATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(channel) { // MESSAGE_CREATE just when deleting o.o
                     channel.lastMessageID = packet.d.id;
                     /**
@@ -853,14 +853,14 @@ class Shard extends EventEmitter {
                     * @event Client#messageCreate
                     * @prop {Message} message The message.
                     */
-                    this.emit("messageCreate", channel.messages.add(packet.d, this.client));
+                    this.emit("messageCreate", channel.messages.add(packet.d, this._client));
                 } else {
-                    this.emit("messageCreate", new Message(packet.d, this.client));
+                    this.emit("messageCreate", new Message(packet.d, this._client));
                 }
                 break;
             }
             case "MESSAGE_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel) {
                     packet.d.channel = {
                         id: packet.d.channel_id
@@ -906,11 +906,11 @@ class Shard extends EventEmitter {
                 * @prop {Array<String>} oldMessage.roleMentions Array of mentioned roles' ids.
                 * @prop {Boolean} oldMessage.tts Whether to play the message using TTS or not
                 */
-                this.emit("messageUpdate", channel.messages.update(packet.d, this.client), oldMessage);
+                this.emit("messageUpdate", channel.messages.update(packet.d, this._client), oldMessage);
                 break;
             }
             case "MESSAGE_DELETE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
 
                 /**
                 * Fired when a cached message is deleted
@@ -928,7 +928,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_DELETE_BULK": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
 
                 /**
                 * Fired when a bulk delete occurs
@@ -945,7 +945,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_ADD": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 let message;
                 let member;
                 if(channel) {
@@ -962,13 +962,13 @@ class Shard extends EventEmitter {
                     const reaction = packet.d.emoji.id ? `${packet.d.emoji.name}:${packet.d.emoji.id}` : packet.d.emoji.name;
                     if(message.reactions[reaction]) {
                         ++message.reactions[reaction].count;
-                        if(packet.d.user_id === this.client.user.id) {
+                        if(packet.d.user_id === this._client.user.id) {
                             message.reactions[reaction].me = true;
                         }
                     } else {
                         message.reactions[reaction] = {
                             count: 1,
-                            me: packet.d.user_id === this.client.user.id
+                            me: packet.d.user_id === this._client.user.id
                         };
                     }
                 } else {
@@ -998,7 +998,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 let message;
                 if(channel) {
                     message = channel.messages.get(packet.d.message_id);
@@ -1010,7 +1010,7 @@ class Shard extends EventEmitter {
                         --reactionObj.count;
                         if(reactionObj.count === 0) {
                             delete message.reactions[reaction];
-                        } else if(packet.d.user_id === this.client.user.id) {
+                        } else if(packet.d.user_id === this._client.user.id) {
                             reactionObj.me = false;
                         }
                     }
@@ -1041,7 +1041,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_ALL": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 let message;
                 if(channel) {
                     message = channel.messages.get(packet.d.message_id);
@@ -1070,7 +1070,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "MESSAGE_REACTION_REMOVE_EMOJI": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 let message;
                 if(channel) {
                     message = channel.messages.get(packet.d.message_id);
@@ -1104,7 +1104,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_MEMBER_ADD": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) { // Eventual Consistency™ (╯°□°）╯︵ ┻━┻
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_MEMBER_ADD`);
                     break;
@@ -1122,8 +1122,8 @@ class Shard extends EventEmitter {
             }
             case "GUILD_MEMBER_UPDATE": {
                 // Check for member update if guildPresences intent isn't set, to prevent emitting twice
-                if(!(this.client.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
-                    let user = this.client.users.get(packet.d.user.id);
+                if(!(this._client.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
+                    let user = this._client.users.get(packet.d.user.id);
                     let oldUser = null;
                     if(user && (user.username !== packet.d.user.username || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
                         oldUser = {
@@ -1133,11 +1133,11 @@ class Shard extends EventEmitter {
                         };
                     }
                     if(!user || oldUser) {
-                        user = this.client.users.update(packet.d.user, this.client);
+                        user = this._client.users.update(packet.d.user, this._client);
                         this.emit("userUpdate", user, oldUser);
                     }
                 }
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_MEMBER_UPDATE`);
                     break;
@@ -1172,10 +1172,10 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_MEMBER_REMOVE": {
-                if(packet.d.user.id === this.client.user.id) { // The bot is probably leaving
+                if(packet.d.user.id === this._client.user.id) { // The bot is probably leaving
                     break;
                 }
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     break;
                 }
@@ -1189,7 +1189,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("guildMemberRemove", guild, guild.members.remove(packet.d) || {
                     id: packet.d.id,
-                    user: new User(packet.d.user, this.client)
+                    user: new User(packet.d.user, this._client)
                 });
                 break;
             }
@@ -1197,7 +1197,7 @@ class Shard extends EventEmitter {
                 if(!packet.d.unavailable) {
                     const guild = this.createGuild(packet.d);
                     if(this.ready) {
-                        if(this.client.unavailableGuilds.remove(packet.d)) {
+                        if(this._client.unavailableGuilds.remove(packet.d)) {
                             /**
                             * Fired when a guild becomes available
                             * @event Client#guildAvailable
@@ -1215,22 +1215,22 @@ class Shard extends EventEmitter {
                             this.emit("guildCreate", guild);
                         }
                     } else {
-                        this.client.unavailableGuilds.remove(packet.d);
+                        this._client.unavailableGuilds.remove(packet.d);
                         this.restartGuildCreateTimeout();
                     }
                 } else {
-                    this.client.guilds.remove(packet.d);
+                    this._client.guilds.remove(packet.d);
                     /**
                     * Fired when an unavailable guild is created
                     * @event Client#unavailableGuildCreate
                     * @prop {UnavailableGuild} guild The unavailable guild
                     */
-                    this.emit("unavailableGuildCreate", this.client.unavailableGuilds.add(packet.d, this.client));
+                    this.emit("unavailableGuildCreate", this._client.unavailableGuilds.add(packet.d, this._client));
                 }
                 break;
             }
             case "GUILD_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.id);
+                const guild = this._client.guilds.get(packet.d.id);
                 if(!guild) {
                     this.emit("debug", `Guild ${packet.d.id} undefined in GUILD_UPDATE`);
                     break;
@@ -1300,24 +1300,24 @@ class Shard extends EventEmitter {
                 * @prop {String?} oldGuild.vanityURL The vanity URL of the guild (VIP only)
                 * @prop {Number} oldGuild.verificationLevel The guild verification level
                 */
-                this.emit("guildUpdate", this.client.guilds.update(packet.d, this.client), oldGuild);
+                this.emit("guildUpdate", this._client.guilds.update(packet.d, this._client), oldGuild);
                 break;
             }
             case "GUILD_DELETE": {
-                const voiceConnection = this.client.voiceConnections.get(packet.d.id);
+                const voiceConnection = this._client.voiceConnections.get(packet.d.id);
                 if(voiceConnection) {
                     if(voiceConnection.channelID) {
-                        this.client.leaveVoiceChannel(voiceConnection.channelID);
+                        this._client.leaveVoiceChannel(voiceConnection.channelID);
                     } else {
-                        this.client.voiceConnections.leave(packet.d.id);
+                        this._client.voiceConnections.leave(packet.d.id);
                     }
                 }
 
-                delete this.client.guildShardMap[packet.d.id];
-                const guild = this.client.guilds.remove(packet.d);
+                delete this._client.guildShardMap[packet.d.id];
+                const guild = this._client.guilds.remove(packet.d);
                 if(guild) { // Discord sends GUILD_DELETE for guilds that were previously unavailable in READY
                     guild.channels.forEach((channel) => {
-                        delete this.client.channelGuildMap[channel.id];
+                        delete this._client.channelGuildMap[channel.id];
                     });
                 }
                 if(packet.d.unavailable) {
@@ -1326,7 +1326,7 @@ class Shard extends EventEmitter {
                     * @event Client#guildUnavailable
                     * @prop {Guild} guild The guild
                     */
-                    this.emit("guildUnavailable", this.client.unavailableGuilds.add(packet.d, this.client));
+                    this.emit("guildUnavailable", this._client.unavailableGuilds.add(packet.d, this._client));
                 } else {
                     /**
                     * Fired when a guild is deleted. This happens when:
@@ -1349,7 +1349,7 @@ class Shard extends EventEmitter {
                 * @prop {Guild} guild The guild
                 * @prop {User} user The banned user
                 */
-                this.emit("guildBanAdd", this.client.guilds.get(packet.d.guild_id), this.client.users.update(packet.d.user, this.client));
+                this.emit("guildBanAdd", this._client.guilds.get(packet.d.guild_id), this._client.users.update(packet.d.user, this._client));
                 break;
             }
             case "GUILD_BAN_REMOVE": {
@@ -1359,7 +1359,7 @@ class Shard extends EventEmitter {
                 * @prop {Guild} guild The guild
                 * @prop {User} user The banned user
                 */
-                this.emit("guildBanRemove", this.client.guilds.get(packet.d.guild_id), this.client.users.update(packet.d.user, this.client));
+                this.emit("guildBanRemove", this._client.guilds.get(packet.d.guild_id), this._client.users.update(packet.d.user, this._client));
                 break;
             }
             case "GUILD_ROLE_CREATE": {
@@ -1369,7 +1369,7 @@ class Shard extends EventEmitter {
                 * @prop {Guild} guild The guild
                 * @prop {Role} role The role
                 */
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_ROLE_CREATE`);
                     break;
@@ -1378,7 +1378,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_ROLE_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Guild ${packet.d.guild_id} undefined in GUILD_ROLE_UPDATE`);
                     break;
@@ -1427,7 +1427,7 @@ class Shard extends EventEmitter {
                 * @prop {Guild} guild The guild
                 * @prop {Role} role The role
                 */
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in GUILD_ROLE_DELETE`);
                     break;
@@ -1440,12 +1440,12 @@ class Shard extends EventEmitter {
                 break;
             }
             case "INVITE_CREATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_CREATE`);
                     break;
                 }
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_CREATE`);
                     break;
@@ -1460,16 +1460,16 @@ class Shard extends EventEmitter {
                     ...packet.d,
                     guild,
                     channel
-                }, this.client));
+                }, this._client));
                 break;
             }
             case "INVITE_DELETE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in INVITE_DELETE`);
                     break;
                 }
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.channel_id} in INVITE_DELETE`);
                     break;
@@ -1484,21 +1484,21 @@ class Shard extends EventEmitter {
                     ...packet.d,
                     guild,
                     channel
-                }, this.client));
+                }, this._client));
                 break;
             }
             case "CHANNEL_CREATE": {
-                const channel = Channel.from(packet.d, this.client);
+                const channel = Channel.from(packet.d, this._client);
                 if(packet.d.guild_id) {
                     if(!channel.guild) {
-                        channel.guild = this.client.guilds.get(packet.d.guild_id);
+                        channel.guild = this._client.guilds.get(packet.d.guild_id);
                         if(!channel.guild) {
                             this.emit("debug", `Received CHANNEL_CREATE for channel in missing guild ${packet.d.guild_id}`);
                             break;
                         }
                     }
-                    channel.guild.channels.add(channel, this.client);
-                    this.client.channelGuildMap[packet.d.id] = packet.d.guild_id;
+                    channel.guild.channels.add(channel, this._client);
+                    this._client.channelGuildMap[packet.d.id] = packet.d.guild_id;
                     /**
                     * Fired when a channel is created
                     * @event Client#channelCreate
@@ -1512,7 +1512,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_UPDATE": {
-                let channel = this.client.getChannel(packet.d.id);
+                let channel = this._client.getChannel(packet.d.id);
                 if(!channel) {
                     break;
                 }
@@ -1546,22 +1546,22 @@ class Shard extends EventEmitter {
                     channel.update(packet.d);
                 } else {
                     this.emit("debug", `Channel ${packet.d.id} changed from type ${oldType} to ${packet.d.type}`);
-                    const newChannel = Channel.from(packet.d, this.client);
+                    const newChannel = Channel.from(packet.d, this._client);
                     if(packet.d.guild_id) {
-                        const guild = this.client.guilds.get(packet.d.guild_id);
+                        const guild = this._client.guilds.get(packet.d.guild_id);
                         if(!guild) {
                             this.emit("debug", `Received CHANNEL_UPDATE for channel in missing guild ${packet.d.guild_id}`);
                             break;
                         }
                         guild.channels.remove(channel);
-                        guild.channels.add(newChannel, this.client);
+                        guild.channels.add(newChannel, this._client);
                     } else if(channel instanceof PrivateChannel) {
                         if(channel instanceof GroupChannel) {
-                            this.client.groupChannels.remove(channel);
-                            this.client.groupChannels.add(newChannel, this.client);
+                            this._client.groupChannels.remove(channel);
+                            this._client.groupChannels.add(newChannel, this._client);
                         } else {
-                            this.client.privateChannels.remove(channel);
-                            this.client.privateChannels.add(newChannel, this.client);
+                            this._client.privateChannels.remove(channel);
+                            this._client.privateChannels.add(newChannel, this._client);
                         }
                     } else {
                         this.emit("warn", new Error("Unhandled CHANNEL_UPDATE type: " + JSON.stringify(packet, null, 2)));
@@ -1594,9 +1594,9 @@ class Shard extends EventEmitter {
             case "CHANNEL_DELETE": {
                 if(packet.d.type === ChannelTypes.DM || packet.d.type === undefined) {
                     if(this.id === 0) {
-                        const channel = this.client.privateChannels.remove(packet.d);
+                        const channel = this._client.privateChannels.remove(packet.d);
                         if(channel) {
-                            delete this.client.privateChannelMap[channel.recipient.id];
+                            delete this._client.privateChannelMap[channel.recipient.id];
                             /**
                             * Fired when a channel is deleted
                             * @event Client#channelDelete
@@ -1606,8 +1606,8 @@ class Shard extends EventEmitter {
                         }
                     }
                 } else if(packet.d.guild_id) {
-                    delete this.client.channelGuildMap[packet.d.id];
-                    const guild = this.client.guilds.get(packet.d.guild_id);
+                    delete this._client.channelGuildMap[packet.d.id];
+                    const guild = this._client.guilds.get(packet.d.guild_id);
                     if(!guild) {
                         this.emit("debug", `Missing guild ${packet.d.guild_id} in CHANNEL_DELETE`);
                         break;
@@ -1625,7 +1625,7 @@ class Shard extends EventEmitter {
                     this.emit("channelDelete", channel);
                 } else if(packet.d.type === ChannelTypes.GROUP_DM) {
                     if(this.id === 0) {
-                        this.emit("channelDelete", this.client.groupChannels.remove(packet.d));
+                        this.emit("channelDelete", this._client.groupChannels.remove(packet.d));
                     }
                 } else {
                     this.emit("warn", new Error("Unhandled CHANNEL_DELETE type: " + JSON.stringify(packet, null, 2)));
@@ -1634,7 +1634,7 @@ class Shard extends EventEmitter {
             }
             case "CALL_CREATE": {
                 packet.d.id = packet.d.message_id;
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(channel.call) {
                     channel.call.update(packet.d);
                 } else {
@@ -1657,7 +1657,7 @@ class Shard extends EventEmitter {
                     if(overflow) {
                         incrementedID = overflow + incrementedID;
                     }
-                    this.client.getMessages(channel.id, {
+                    this._client.getMessages(channel.id, {
                         limit: 1,
                         before: incrementedID
                     }).catch((err) => this.emit("error", err));
@@ -1671,7 +1671,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CALL_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel.call) {
                     throw new Error("CALL_UPDATE but channel has no call");
                 }
@@ -1697,7 +1697,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CALL_DELETE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel.call) {
                     throw new Error("CALL_DELETE but channel has no call");
                 }
@@ -1712,18 +1712,18 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_RECIPIENT_ADD": {
-                const channel = this.client.groupChannels.get(packet.d.channel_id);
+                const channel = this._client.groupChannels.get(packet.d.channel_id);
                 /**
                 * Fired when a user joins a group channel
                 * @event Client#channelRecipientAdd
                 * @prop {GroupChannel} channel The channel
                 * @prop {User} user The user
                 */
-                this.emit("channelRecipientAdd", channel, channel.recipients.add(this.client.users.update(packet.d.user, this.client)));
+                this.emit("channelRecipientAdd", channel, channel.recipients.add(this._client.users.update(packet.d.user, this._client)));
                 break;
             }
             case "CHANNEL_RECIPIENT_REMOVE": {
-                const channel = this.client.groupChannels.get(packet.d.channel_id);
+                const channel = this._client.groupChannels.get(packet.d.channel_id);
                 /**
                 * Fired when a user leaves a group channel
                 * @event Client#channelRecipientRemove
@@ -1743,7 +1743,7 @@ class Shard extends EventEmitter {
                 * @prop {String} reasons.platform_type Platform you share with the user
                 * @prop {Number} reasons.type Type of reason?
                 */
-                this.emit("friendSuggestionCreate", new User(packet.d.suggested_user, this.client), packet.d.reasons);
+                this.emit("friendSuggestionCreate", new User(packet.d.suggested_user, this._client), packet.d.reasons);
                 break;
             }
             case "FRIEND_SUGGESTION_DELETE": {
@@ -1752,13 +1752,13 @@ class Shard extends EventEmitter {
                 * @event Client#friendSuggestionDelete
                 * @prop {User} user The suggested user
                 */
-                this.emit("friendSuggestionDelete", this.client.users.get(packet.d.suggested_user_id));
+                this.emit("friendSuggestionDelete", this._client.users.get(packet.d.suggested_user_id));
                 break;
             }
             case "GUILD_MEMBERS_CHUNK": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
-                    this.emit("debug", `Received GUILD_MEMBERS_CHUNK, but guild ${packet.d.guild_id} is ` + (this.client.unavailableGuilds.has(packet.d.guild_id) ? "unavailable" : "missing"), this.id);
+                    this.emit("debug", `Received GUILD_MEMBERS_CHUNK, but guild ${packet.d.guild_id} is ` + (this._client.unavailableGuilds.has(packet.d.guild_id) ? "unavailable" : "missing"), this.id);
                     break;
                 }
 
@@ -1805,14 +1805,14 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_SYNC": {// (╯°□°）╯︵ ┻━┻ thx Discord devs
-                const guild = this.client.guilds.get(packet.d.id);
+                const guild = this._client.guilds.get(packet.d.id);
                 for(const member of packet.d.members) {
                     member.id = member.user.id;
                     guild.members.add(member, guild);
                 }
                 for(const presence of packet.d.presences) {
                     if(!guild.members.get(presence.user.id)) {
-                        let userData = this.client.users.get(presence.user.id);
+                        let userData = this._client.users.get(presence.user.id);
                         if(userData) {
                             userData = `{username: ${userData.username}, id: ${userData.id}, discriminator: ${userData.discriminator}}`;
                         }
@@ -1831,11 +1831,11 @@ class Shard extends EventEmitter {
                         const channel = guild.channels.get(voiceState.channel_id);
                         if(channel) {
                             channel.voiceMembers.add(guild.members.update(voiceState));
-                            if(this.client.options.seedVoiceConnections && voiceState.id === this.client.user.id && !this.client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
-                                this.client.joinVoiceChannel(channel.id);
+                            if(this._client.options.seedVoiceConnections && voiceState.id === this._client.user.id && !this._client.voiceConnections.get(channel.guild ? channel.guild.id : "call")) {
+                                this._client.joinVoiceChannel(channel.id);
                             }
                         } else { // Phantom voice states from connected users in deleted channels (╯°□°）╯︵ ┻━┻
-                            this.client.emit("debug", "Phantom voice state received but channel not found | Guild: " + guild.id + " | Channel: " + voiceState.channel_id);
+                            this._client.emit("debug", "Phantom voice state received but channel not found | Guild: " + guild.id + " | Channel: " + voiceState.channel_id);
                         }
                     }
                 }
@@ -1856,7 +1856,7 @@ class Shard extends EventEmitter {
                 this.connectTimeout = null;
                 this.status = "ready";
                 this.presence.status = "online";
-                this.client.shards._readyPacketCB(this.id);
+                this._client.shards._readyPacketCB(this.id);
 
                 if(packet.t === "RESUMED") {
                     // Can only heartbeat after resume succeeds, discord/discord-api-docs#1619
@@ -1873,21 +1873,21 @@ class Shard extends EventEmitter {
                     break;
                 }
 
-                this.client.user = this.client.users.update(new ExtendedUser(packet.d.user, this.client), this.client);
-                if(this.client.user.bot) {
-                    this.client.bot = true;
-                    if(!this.client._token.startsWith("Bot ")) {
-                        this.client._token = "Bot " + this.client._token;
+                this._client.user = this._client.users.update(new ExtendedUser(packet.d.user, this._client), this._client);
+                if(this._client.user.bot) {
+                    this._client.bot = true;
+                    if(!this._client._token.startsWith("Bot ")) {
+                        this._client._token = "Bot " + this._client._token;
                     }
                 } else {
-                    this.client.bot = false;
-                    this.client.userGuildSettings = {};
+                    this._client.bot = false;
+                    this._client.userGuildSettings = {};
                     if(packet.d.user_guild_settings) {
                         packet.d.user_guild_settings.forEach((guildSettings) => {
-                            this.client.userGuildSettings[guildSettings.guild_id] = guildSettings;
+                            this._client.userGuildSettings[guildSettings.guild_id] = guildSettings;
                         });
                     }
-                    this.client.userSettings = packet.d.user_settings;
+                    this._client.userSettings = packet.d.user_settings;
                 }
 
                 if(packet.d._trace) {
@@ -1898,19 +1898,19 @@ class Shard extends EventEmitter {
 
                 packet.d.guilds.forEach((guild) => {
                     if(guild.unavailable) {
-                        this.client.guilds.remove(guild);
-                        this.client.unavailableGuilds.add(guild, this.client, true);
+                        this._client.guilds.remove(guild);
+                        this._client.unavailableGuilds.add(guild, this._client, true);
                     } else {
-                        this.client.unavailableGuilds.remove(this.createGuild(guild));
+                        this._client.unavailableGuilds.remove(this.createGuild(guild));
                     }
                 });
 
                 packet.d.private_channels.forEach((channel) => {
                     if(channel.type === undefined || channel.type === ChannelTypes.DM) {
-                        this.client.privateChannelMap[channel.recipients[0].id] = channel.id;
-                        this.client.privateChannels.add(channel, this.client, true);
+                        this._client.privateChannelMap[channel.recipients[0].id] = channel.id;
+                        this._client.privateChannels.add(channel, this._client, true);
                     } else if(channel.type === ChannelTypes.GROUP_DM) {
-                        this.client.groupChannels.add(channel, this.client, true);
+                        this._client.groupChannels.add(channel, this._client, true);
                     } else {
                         this.emit("warn", new Error("Unhandled READY private_channel type: " + JSON.stringify(channel, null, 2)));
                     }
@@ -1918,24 +1918,24 @@ class Shard extends EventEmitter {
 
                 if(packet.d.relationships) {
                     packet.d.relationships.forEach((relationship) => {
-                        this.client.relationships.add(relationship, this.client, true);
+                        this._client.relationships.add(relationship, this._client, true);
                     });
                 }
 
                 if(packet.d.presences) {
                     packet.d.presences.forEach((presence) => {
-                        if(this.client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
+                        if(this._client.relationships.get(presence.user.id)) { // Avoid DM channel presences which are also in here
                             presence.id = presence.user.id;
-                            this.client.relationships.update(presence, null, true);
+                            this._client.relationships.update(presence, null, true);
                         }
                     });
                 }
 
                 if(packet.d.notes) {
-                    this.client.notes = packet.d.notes;
+                    this._client.notes = packet.d.notes;
                 }
 
-                this.client.application = packet.d.application;
+                this._client.application = packet.d.application;
 
                 this.preReady = true;
                 /**
@@ -1945,7 +1945,7 @@ class Shard extends EventEmitter {
                 */
                 this.emit("shardPreReady", this.id);
 
-                if(this.client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
+                if(this._client.unavailableGuilds.size > 0 && packet.d.guilds.length > 0) {
                     this.restartGuildCreateTimeout();
                 } else {
                     this.checkReady();
@@ -1955,13 +1955,13 @@ class Shard extends EventEmitter {
             }
             case "VOICE_SERVER_UPDATE": {
                 packet.d.session_id = this.sessionID;
-                packet.d.user_id = this.client.user.id;
+                packet.d.user_id = this._client.user.id;
                 packet.d.shard = this;
-                this.client.voiceConnections.voiceServerUpdate(packet.d);
+                this._client.voiceConnections.voiceServerUpdate(packet.d);
                 break;
             }
             case "USER_UPDATE": {
-                let user = this.client.users.get(packet.d.id);
+                let user = this._client.users.get(packet.d.id);
                 let oldUser = null;
                 if(user) {
                     oldUser = {
@@ -1970,15 +1970,15 @@ class Shard extends EventEmitter {
                         avatar: user.avatar
                     };
                 }
-                user = this.client.users.update(packet.d, this.client);
+                user = this._client.users.update(packet.d, this._client);
                 this.emit("userUpdate", user, oldUser);
                 break;
             }
             case "RELATIONSHIP_ADD": {
-                if(this.client.bot) {
+                if(this._client.bot) {
                     break;
                 }
-                const relationship = this.client.relationships.get(packet.d.id);
+                const relationship = this._client.relationships.get(packet.d.id);
                 if(relationship) {
                     const oldRelationship = {
                         type: relationship.type
@@ -1990,19 +1990,19 @@ class Shard extends EventEmitter {
                     * @prop {Object} oldRelationship The old relationship data
                     * @prop {Number} oldRelationship.type The old type of the relationship
                     */
-                    this.emit("relationshipUpdate", this.client.relationships.update(packet.d), oldRelationship);
+                    this.emit("relationshipUpdate", this._client.relationships.update(packet.d), oldRelationship);
                 } else {
                     /**
                     * Fired when a relationship is added
                     * @event Client#relationshipAdd
                     * @prop {Relationship} relationship The relationship
                     */
-                    this.emit("relationshipAdd", this.client.relationships.add(packet.d, this.client));
+                    this.emit("relationshipAdd", this._client.relationships.add(packet.d, this._client));
                 }
                 break;
             }
             case "RELATIONSHIP_REMOVE": {
-                if(this.client.bot) {
+                if(this._client.bot) {
                     break;
                 }
                 /**
@@ -2010,11 +2010,11 @@ class Shard extends EventEmitter {
                 * @event Client#relationshipRemove
                 * @prop {Relationship} relationship The relationship
                 */
-                this.emit("relationshipRemove", this.client.relationships.remove(packet.d));
+                this.emit("relationshipRemove", this._client.relationships.remove(packet.d));
                 break;
             }
             case "GUILD_EMOJIS_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 let oldEmojis = null;
                 let emojis = packet.d.emojis;
                 if(guild) {
@@ -2033,7 +2033,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "GUILD_STICKERS_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 let oldStickers = null;
                 let stickers = packet.d.stickers;
                 if(guild) {
@@ -2052,7 +2052,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "CHANNEL_PINS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.channel_id);
+                const channel = this._client.getChannel(packet.d.channel_id);
                 if(!channel) {
                     this.emit("debug", `CHANNEL_PINS_UPDATE target channel ${packet.d.channel_id} not found`);
                     break;
@@ -2085,7 +2085,7 @@ class Shard extends EventEmitter {
             }
             case "PRESENCES_REPLACE": {
                 for(const presence of packet.d) {
-                    const guild = this.client.guilds.get(presence.guild_id);
+                    const guild = this._client.guilds.get(presence.guild_id);
                     if(!guild) {
                         this.emit("debug", "Rogue presences replace: " + JSON.stringify(presence), this.id);
                         continue;
@@ -2100,27 +2100,27 @@ class Shard extends EventEmitter {
             }
             case "USER_NOTE_UPDATE": {
                 if(packet.d.note) {
-                    this.client.notes[packet.d.id] = packet.d.note;
+                    this._client.notes[packet.d.id] = packet.d.note;
                 } else {
-                    delete this.client.notes[packet.d.id];
+                    delete this._client.notes[packet.d.id];
                 }
                 break;
             }
             case "USER_GUILD_SETTINGS_UPDATE": {
-                this.client.userGuildSettings[packet.d.guild_id] = packet.d;
+                this._client.userGuildSettings[packet.d.guild_id] = packet.d;
                 break;
             }
             case "THREAD_CREATE": {
-                const channel = Channel.from(packet.d, this.client);
+                const channel = Channel.from(packet.d, this._client);
                 if(!channel.guild) {
-                    channel.guild = this.client.guilds.get(packet.d.guild_id);
+                    channel.guild = this._client.guilds.get(packet.d.guild_id);
                     if(!channel.guild) {
                         this.emit("debug", `Received THREAD_CREATE for channel in missing guild ${packet.d.guild_id}`);
                         break;
                     }
                 }
-                channel.guild.threads.add(channel, this.client);
-                this.client.threadGuildMap[packet.d.id] = packet.d.guild_id;
+                channel.guild.threads.add(channel, this._client);
+                this._client.threadGuildMap[packet.d.id] = packet.d.guild_id;
                 /**
                 * Fired when a channel is created
                 * @event Client#threadCreate
@@ -2130,11 +2130,11 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this._client.getChannel(packet.d.id);
                 if(!channel) {
-                    const thread = Channel.from(packet.d, this.client);
-                    this.emit("threadUpdate", this.client.guilds.get(packet.d.guild_id).threads.add(thread, this.client), null);
-                    this.client.threadGuildMap[packet.d.id] = packet.d.guild_id;
+                    const thread = Channel.from(packet.d, this._client);
+                    this.emit("threadUpdate", this._client.guilds.get(packet.d.guild_id).threads.add(thread, this._client), null);
+                    this._client.threadGuildMap[packet.d.id] = packet.d.guild_id;
                     break;
                 }
                 if(!(channel instanceof ThreadChannel)) {
@@ -2165,8 +2165,8 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_DELETE": {
-                delete this.client.threadGuildMap[packet.d.id];
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                delete this._client.threadGuildMap[packet.d.id];
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in THREAD_DELETE`);
                     break;
@@ -2184,15 +2184,15 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_LIST_SYNC": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in THREAD_LIST_SYNC`);
                     break;
                 }
                 const deletedThreads = (packet.d.channel_ids || guild.threads.map((c) => c.id)) // REVIEW Is this a good name?
                     .filter((c) => !packet.d.threads.some((t) => t.id === c)).map((id) => guild.threads.remove({id}) || {id});
-                const activeThreads = packet.d.threads.map((t) => guild.threads.update(t, this.client));
-                const joinedThreadsMember = packet.d.members.map((m) => guild.threads.get(m.id).members.update(m, this.client));
+                const activeThreads = packet.d.threads.map((t) => guild.threads.update(t, this._client));
+                const joinedThreadsMember = packet.d.members.map((m) => guild.threads.get(m.id).members.update(m, this._client));
                 /**
                 * Fired when the current user gains access to a channel
                 * @event Client#threadListSync
@@ -2205,7 +2205,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBER_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this._client.getChannel(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBER_UPDATE`);
                     break;
@@ -2219,7 +2219,7 @@ class Shard extends EventEmitter {
                         flags: member.flags
                     };
                 }
-                member = channel.members.update(packet.d, this.client);
+                member = channel.members.update(packet.d, this._client);
                 /**
                 * Fired when a thread member is updated
                 * @event Client#threadMemberUpdate
@@ -2232,7 +2232,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "THREAD_MEMBERS_UPDATE": {
-                const channel = this.client.getChannel(packet.d.id);
+                const channel = this._client.getChannel(packet.d.id);
                 if(!channel) {
                     this.emit("debug", `Missing channel ${packet.d.id} in THREAD_MEMBERS_UPDATE`);
                     break;
@@ -2244,20 +2244,20 @@ class Shard extends EventEmitter {
                     addedMembers = packet.d.added_members.map((m) => {
                         if(m.presence) {
                             m.presence.id = m.presence.user.id;
-                            this.client.users.update(m.presence.user, this.client);
+                            this._client.users.update(m.presence.user, this._client);
                         }
 
                         m.thread_id = m.id;
                         m.id = m.user_id;
                         m.member.id = m.member.user.id;
-                        const guild = this.client.guilds.get(packet.d.guild_id);
+                        const guild = this._client.guilds.get(packet.d.guild_id);
                         if(guild) {
                             if(m.presence) {
                                 guild.members.update(m.presence, guild);
                             }
                             guild.members.update(m.member, guild);
                         }
-                        return channel.members.update(m, this.client);
+                        return channel.members.update(m, this._client);
                     });
                 }
                 if(packet.d.removed_member_ids) {
@@ -2274,7 +2274,7 @@ class Shard extends EventEmitter {
                 break;
             }
             case "STAGE_INSTANCE_CREATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("debug", `Missing guild ${packet.d.guild_id} in STAGE_INSTANCE_CREATE`);
                     break;
@@ -2284,11 +2284,11 @@ class Shard extends EventEmitter {
                 * @event Client#stageInstanceCreate
                 * @prop {StageInstance} stageInstance The stage instance
                 */
-                this.emit("stageInstanceCreate", guild.stageInstances.add(packet.d, this.client));
+                this.emit("stageInstanceCreate", guild.stageInstances.add(packet.d, this._client));
                 break;
             }
             case "STAGE_INSTANCE_UPDATE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
                     this.emit("stageInstanceUpdate", packet.d, null);
                     break;
@@ -2311,13 +2311,13 @@ class Shard extends EventEmitter {
                 * @prop {Number} oldStageInstance.privacyLevel The privacy level of the stage instance. 1 is public, 2 is guild only
                 * @prop {String} oldStageInstance.topic The stage instance topic
                 */
-                this.emit("stageInstanceUpdate", guild.stageInstances.update(packet.d, this.client), oldStageInstance);
+                this.emit("stageInstanceUpdate", guild.stageInstances.update(packet.d, this._client), oldStageInstance);
                 break;
             }
             case "STAGE_INSTANCE_DELETE": {
-                const guild = this.client.guilds.get(packet.d.guild_id);
+                const guild = this._client.guilds.get(packet.d.guild_id);
                 if(!guild) {
-                    this.emit("stageInstanceDelete", new StageInstance(packet.d, this.client));
+                    this.emit("stageInstanceDelete", new StageInstance(packet.d, this._client));
                     break;
                 }
                 /**
@@ -2325,7 +2325,7 @@ class Shard extends EventEmitter {
                 * @event Client#stageInstanceDelete
                 * @prop {StageInstance} stageInstance The deleted stage instance
                 */
-                this.emit("stageInstanceDelete", guild.stageInstances.remove(packet.d) || new StageInstance(packet.d, this.client));
+                this.emit("stageInstanceDelete", guild.stageInstances.remove(packet.d) || new StageInstance(packet.d, this._client));
                 break;
             }
             case "MESSAGE_ACK": // Ignore these
@@ -2340,7 +2340,7 @@ class Shard extends EventEmitter {
                 * @event Client#interactionCreate
                 * @prop {PingInteraction | CommandInteraction | ComponentInteraction | AutocompleteInteraction | UnknownInteraction} Interaction The Interaction that was created
                 */
-                this.emit("interactionCreate", Interaction.from(packet.d, this.client));
+                this.emit("interactionCreate", Interaction.from(packet.d, this._client));
                 break;
             }
             default: {
@@ -2428,13 +2428,13 @@ class Shard extends EventEmitter {
     _onWSMessage(data) {
         try {
             if(data instanceof ArrayBuffer) {
-                if(this.client.options.compress || Erlpack) {
+                if(this._client.options.compress || Erlpack) {
                     data = Buffer.from(data);
                 }
             } else if(Array.isArray(data)) { // Fragmented messages
                 data = Buffer.concat(data); // Copyfull concat is slow, but no alternative
             }
-            if(this.client.options.compress) {
+            if(this._client.options.compress) {
                 if(data.length >= 4 && data.readUInt32BE(data.length - 4) === 0xFFFF) {
                     this._zlibSync.push(data, ZlibSync.Z_SYNC_FLUSH);
                     if(this._zlibSync.err) {

--- a/lib/structures/Channel.js
+++ b/lib/structures/Channel.js
@@ -5,7 +5,6 @@ const {ChannelTypes} = require("../Constants");
 
 /**
 * Represents a channel. You also probably want to look at CategoryChannel, GroupChannel, NewsChannel, PrivateChannel, TextChannel, and TextVoiceChannel.
-* @prop {Client} client The client that initialized the channel
 * @prop {Number} createdAt Timestamp of the channel's creation
 * @prop {String} id The ID of the channel
 * @prop {String} mention A string that mentions the channel
@@ -15,7 +14,7 @@ class Channel extends Base {
     constructor(data, client) {
         super(data.id);
         this.type = data.type;
-        this.client = client;
+        this._client = client;
     }
 
     get mention() {

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -40,7 +40,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     get iconURL() {
-        return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon)) : null;
+        return this.icon ? this._client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon)) : null;
     }
 
     /**
@@ -49,7 +49,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise}
     */
     addRecipient(userID) {
-        return this.client.addGroupRecipient.call(this.client, this.id, userID);
+        return this._client.addGroupRecipient.call(this._client, this.id, userID);
     }
 
     /**
@@ -59,7 +59,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {String?}
     */
     dynamicIconURL(format, size) {
-        return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
+        return this.icon ? this._client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
     }
 
     /**
@@ -71,7 +71,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise<GroupChannel>}
     */
     edit(options) {
-        return this.client.editChannel.call(this.client, this.id, options);
+        return this._client.editChannel.call(this._client, this.id, options);
     }
 
     /**
@@ -80,7 +80,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     * @returns {Promise}
     */
     removeRecipient(userID) {
-        return this.client.removeGroupRecipient.call(this.client, this.id, userID);
+        return this._client.removeGroupRecipient.call(this._client, this.id, userID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/GuildAuditLogEntry.js
+++ b/lib/structures/GuildAuditLogEntry.js
@@ -43,7 +43,7 @@ class GuildAuditLogEntry extends Base {
 
         this.actionType = data.action_type;
         this.reason = data.reason || null;
-        this.user = guild.shard.client.users.get(data.user_id);
+        this.user = guild.shard._client.users.get(data.user_id);
         this.before = null;
         this.after = null;
         if(data.changes) {
@@ -117,13 +117,13 @@ class GuildAuditLogEntry extends Base {
                 max_uses: changes.max_uses,
                 max_age: changes.max_age,
                 temporary: changes.temporary
-            }, this.guild && this.guild.shard.client);
+            }, this.guild && this.guild.shard._client);
         } else if(this.actionType < 60) { // Webhook
             return null; // Go get the webhook yourself
         } else if(this.actionType < 70) { // Emoji
             return this.guild && this.guild.emojis.find((emoji) => emoji.id === this.targetID);
         } else if(this.actionType < 80) { // Message
-            return this.guild && this.guild.shard.client.users.get(this.targetID);
+            return this.guild && this.guild.shard._client.users.get(this.targetID);
         } else if(this.actionType < 83) { // Integrations
             return null;
         } else if(this.actionType < 90) { // Stage Instances

--- a/lib/structures/GuildChannel.js
+++ b/lib/structures/GuildChannel.js
@@ -55,7 +55,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     delete(reason) {
-        return this.client.deleteChannel.call(this.client, this.id, reason);
+        return this._client.deleteChannel.call(this._client, this.id, reason);
     }
 
     /**
@@ -65,7 +65,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     deletePermission(overwriteID, reason) {
-        return this.client.deleteChannelPermission.call(this.client, this.id, overwriteID, reason);
+        return this._client.deleteChannelPermission.call(this._client, this.id, overwriteID, reason);
     }
 
     /**
@@ -91,7 +91,7 @@ class GuildChannel extends Channel {
     * @returns {Promise<CategoryChannel | GroupChannel | TextChannel | TextVoiceChannel | NewsChannel | NewsThreadChannel | PrivateThreadChannel | PublicThreadChannel>}
     */
     edit(options, reason) {
-        return this.client.editChannel.call(this.client, this.id, options, reason);
+        return this._client.editChannel.call(this._client, this.id, options, reason);
     }
 
     /**
@@ -104,7 +104,7 @@ class GuildChannel extends Channel {
     * @returns {Promise<PermissionOverwrite>}
     */
     editPermission(overwriteID, allow, deny, type, reason) {
-        return this.client.editChannelPermission.call(this.client, this.id, overwriteID, allow, deny, type, reason);
+        return this._client.editChannelPermission.call(this._client, this.id, overwriteID, allow, deny, type, reason);
     }
 
     /**
@@ -116,7 +116,7 @@ class GuildChannel extends Channel {
     * @returns {Promise}
     */
     editPosition(position, options) {
-        return this.client.editChannelPosition.call(this.client, this.id, position, options);
+        return this._client.editChannelPosition.call(this._client, this.id, position, options);
     }
 
     /**

--- a/lib/structures/GuildIntegration.js
+++ b/lib/structures/GuildIntegration.js
@@ -33,7 +33,7 @@ class GuildIntegration extends Base {
             this.roleID = data.role_id;
         }
         if(data.user) {
-            this.user = guild.shard.client.users.add(data.user, guild.shard.client);
+            this.user = guild.shard._client.users.add(data.user, guild.shard._client);
         }
         this.account = data.account; // not worth making a class for
         this.update(data);
@@ -72,7 +72,7 @@ class GuildIntegration extends Base {
     * @returns {Promise}
     */
     delete() {
-        return this.guild.shard.client.deleteGuildIntegration.call(this.guild.shard.client, this.guild.id, this.id);
+        return this.guild.shard._client.deleteGuildIntegration.call(this.guild.shard._client, this.guild.id, this.id);
     }
 
     /**
@@ -84,7 +84,7 @@ class GuildIntegration extends Base {
     * @returns {Promise}
     */
     edit(options) {
-        return this.guild.shard.client.editGuildIntegration.call(this.guild.shard.client, this.guild.id, this.id, options);
+        return this.guild.shard._client.editGuildIntegration.call(this.guild.shard._client, this.guild.id, this.id, options);
     }
 
     /**
@@ -92,7 +92,7 @@ class GuildIntegration extends Base {
     * @returns {Promise}
     */
     sync() {
-        return this.guild.shard.client.syncGuildIntegration.call(this.guild.shard.client, this.guild.id, this.id);
+        return this.guild.shard._client.syncGuildIntegration.call(this.guild.shard._client, this.guild.id, this.id);
     }
 
     toJSON(props = []) {

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -50,9 +50,9 @@ class Member extends Base {
             data.id = data.user.id;
         }
         if((this.guild = guild)) {
-            this.user = guild.shard.client.users.get(data.id);
+            this.user = guild.shard._client.users.get(data.id);
             if(!this.user && data.user) {
-                this.user = guild.shard.client.users.add(data.user, guild.shard.client);
+                this.user = guild.shard._client.users.add(data.user, guild.shard._client);
             }
             if(!this.user) {
                 throw new Error("User associated with Member not found: " + data.id);
@@ -124,7 +124,7 @@ class Member extends Base {
     }
 
     get avatarURL() {
-        return this.avatar ? this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar)) : this.user.avatarURL;
+        return this.avatar ? this.guild.shard._client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar)) : this.user.avatarURL;
     }
 
     get banner() {
@@ -160,7 +160,7 @@ class Member extends Base {
     }
 
     get permission() {
-        this.guild.shard.client.emit("warn", "[DEPRECATED] Member#permission is deprecated. Use Member#permissions instead");
+        this.guild.shard._client.emit("warn", "[DEPRECATED] Member#permission is deprecated. Use Member#permissions instead");
         return this.permissions;
     }
 
@@ -197,7 +197,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     addRole(roleID, reason) {
-        return this.guild.shard.client.addGuildMemberRole.call(this.guild.shard.client, this.guild.id, this.id, roleID, reason);
+        return this.guild.shard._client.addGuildMemberRole.call(this.guild.shard._client, this.guild.id, this.id, roleID, reason);
     }
 
     /**
@@ -207,7 +207,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     ban(deleteMessageDays, reason) {
-        return this.guild.shard.client.banGuildMember.call(this.guild.shard.client, this.guild.id, this.id, deleteMessageDays, reason);
+        return this.guild.shard._client.banGuildMember.call(this.guild.shard._client, this.guild.id, this.id, deleteMessageDays, reason);
     }
 
     /**
@@ -223,7 +223,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     edit(options, reason) {
-        return this.guild.shard.client.editGuildMember.call(this.guild.shard.client, this.guild.id, this.id, options, reason);
+        return this.guild.shard._client.editGuildMember.call(this.guild.shard._client, this.guild.id, this.id, options, reason);
     }
 
     /**
@@ -232,7 +232,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     kick(reason) {
-        return this.guild.shard.client.kickGuildMember.call(this.guild.shard.client, this.guild.id, this.id, reason);
+        return this.guild.shard._client.kickGuildMember.call(this.guild.shard._client, this.guild.id, this.id, reason);
     }
 
     /**
@@ -242,7 +242,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     removeRole(roleID, reason) {
-        return this.guild.shard.client.removeGuildMemberRole.call(this.guild.shard.client, this.guild.id, this.id, roleID, reason);
+        return this.guild.shard._client.removeGuildMemberRole.call(this.guild.shard._client, this.guild.id, this.id, roleID, reason);
     }
 
     /**
@@ -251,7 +251,7 @@ class Member extends Base {
     * @returns {Promise}
     */
     unban(reason) {
-        return this.guild.shard.client.unbanGuildMember.call(this.guild.shard.client, this.guild.id, this.id, reason);
+        return this.guild.shard._client.unbanGuildMember.call(this.guild.shard._client, this.guild.id, this.id, reason);
     }
 
     toJSON(props = []) {

--- a/lib/structures/NewsChannel.js
+++ b/lib/structures/NewsChannel.js
@@ -18,7 +18,7 @@ class NewsChannel extends TextChannel {
      * @returns {Promise<Message>}
      */
     crosspostMessage(messageID) {
-        return this.client.crosspostMessage.call(this.client, this.id, messageID);
+        return this._client.crosspostMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -27,7 +27,7 @@ class NewsChannel extends TextChannel {
      * @returns {Object} An object containing this channel's ID and the new webhook's ID
      */
     follow(webhookChannelID) {
-        return this.client.followChannel.call(this.client, this.id, webhookChannelID);
+        return this._client.followChannel.call(this._client, this.id, webhookChannelID);
     }
 }
 

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -34,7 +34,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction, userID) {
-        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.addMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -79,7 +79,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return this.client.createMessage.call(this.client, this.id, content, file);
+        return this._client.createMessage.call(this._client, this.id, content, file);
     }
 
     /**
@@ -89,7 +89,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
+        return this._client.deleteMessage.call(this._client, this.id, messageID, reason);
     }
 
     /**
@@ -127,7 +127,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return this.client.editMessage.call(this.client, this.id, messageID, content);
+        return this._client.editMessage.call(this._client, this.id, messageID, content);
     }
 
     /**
@@ -136,7 +136,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return this.client.getMessage.call(this.client, this.id, messageID);
+        return this._client.getMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -151,7 +151,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Array<User>>}
     */
     getMessageReaction(messageID, reaction, options, before, after) {
-        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, options, before, after);
+        return this._client.getMessageReaction.call(this._client, this.id, messageID, reaction, options, before, after);
     }
 
     /**
@@ -167,7 +167,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Array<Message>>}
     */
     getMessages(options, before, after, around) {
-        return this.client.getMessages.call(this.client, this.id, options, before, after, around);
+        return this._client.getMessages.call(this._client, this.id, options, before, after, around);
     }
 
     /**
@@ -175,7 +175,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise<Array<Message>>}
     */
     getPins() {
-        return this.client.getPins.call(this.client, this.id);
+        return this._client.getPins.call(this._client, this.id);
     }
 
     /**
@@ -183,7 +183,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     leave() {
-        return this.client.deleteChannel.call(this.client, this.id);
+        return this._client.deleteChannel.call(this._client, this.id);
     }
 
     /**
@@ -192,7 +192,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     pinMessage(messageID) {
-        return this.client.pinMessage.call(this.client, this.id, messageID);
+        return this._client.pinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -206,7 +206,7 @@ class PrivateChannel extends Channel {
         if(userID !== undefined) {
             this.emit("warn", "[DEPRECATED] removeMessageReaction() was called on a PrivateChannel with a `userID` argument");
         }
-        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.removeMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
 
@@ -215,7 +215,7 @@ class PrivateChannel extends Channel {
     * @arg {Array<String>} recipients The IDs of the recipients to ring
     */
     ring(recipients) {
-        this.client.requestHandler.request("POST", Endpoints.CHANNEL_CALL_RING(this.id), true, {
+        this._client.requestHandler.request("POST", Endpoints.CHANNEL_CALL_RING(this.id), true, {
             recipients
         });
     }
@@ -225,14 +225,14 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     sendTyping() {
-        return this.client.sendChannelTyping.call(this.client, this.id);
+        return this._client.sendChannelTyping.call(this._client, this.id);
     }
 
     /**
     * Check if the channel has an existing call
     */
     syncCall() {
-        this.client.shards.values().next().value.sendWS(GatewayOPCodes.SYNC_CALL, {
+        this._client.shards.values().next().value.sendWS(GatewayOPCodes.SYNC_CALL, {
             channel_id: this.id
         });
     }
@@ -243,7 +243,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     unpinMessage(messageID) {
-        return this.client.unpinMessage.call(this.client, this.id, messageID);
+        return this._client.unpinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -252,7 +252,7 @@ class PrivateChannel extends Channel {
     * @returns {Promise}
     */
     unsendMessage(messageID) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID);
+        return this._client.deleteMessage.call(this._client, this.id, messageID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/Role.js
+++ b/lib/structures/Role.js
@@ -70,7 +70,7 @@ class Role extends Base {
     }
 
     get iconURL() {
-        return this.icon ? this.guild.shard.client._formatImage(Endpoints.ROLE_ICON(this.id, this.icon)) : null;
+        return this.icon ? this.guild.shard._client._formatImage(Endpoints.ROLE_ICON(this.id, this.icon)) : null;
     }
 
     get json() {
@@ -87,7 +87,7 @@ class Role extends Base {
     * @returns {Promise}
     */
     delete(reason) {
-        return this.guild.shard.client.deleteRole.call(this.guild.shard.client, this.guild.id, this.id, reason);
+        return this.guild.shard._client.deleteRole.call(this.guild.shard._client, this.guild.id, this.id, reason);
     }
 
     /**
@@ -104,7 +104,7 @@ class Role extends Base {
     * @returns {Promise<Role>}
     */
     edit(options, reason) {
-        return this.guild.shard.client.editRole.call(this.guild.shard.client, this.guild.id, this.id, options, reason);
+        return this.guild.shard._client.editRole.call(this.guild.shard._client, this.guild.id, this.id, options, reason);
     }
 
     /**
@@ -113,7 +113,7 @@ class Role extends Base {
     * @returns {Promise}
     */
     editPosition(position) {
-        return this.guild.shard.client.editRolePosition.call(this.guild.shard.client, this.guild.id, this.id, position);
+        return this.guild.shard._client.editRolePosition.call(this.guild.shard._client, this.guild.id, this.id, position);
     }
 
     toJSON(props = []) {

--- a/lib/structures/StageChannel.js
+++ b/lib/structures/StageChannel.js
@@ -23,7 +23,7 @@ class StageChannel extends VoiceChannel {
     * @returns {Promise<StageInstance>}
     */
     createInstance(options) {
-        return this.client.createStageInstance.call(this.client, this.id, options);
+        return this._client.createStageInstance.call(this._client, this.id, options);
     }
 
     /**
@@ -31,7 +31,7 @@ class StageChannel extends VoiceChannel {
     * @returns {Promise}
     */
     deleteInstance() {
-        return this.client.deleteStageInstance.call(this.client, this.id);
+        return this._client.deleteStageInstance.call(this._client, this.id);
     }
 
     /**
@@ -42,7 +42,7 @@ class StageChannel extends VoiceChannel {
     * @returns {Promise<StageInstance>}
     */
     editInstance(options) {
-        return this.client.editStageInstance.call(this.client, this.id, options);
+        return this._client.editStageInstance.call(this._client, this.id, options);
     }
 
     /**
@@ -50,7 +50,7 @@ class StageChannel extends VoiceChannel {
     * @returns {Promise<StageInstance>}
     */
     getInstance() {
-        return this.client.getStageInstance.call(this.client, this.id);
+        return this._client.getStageInstance.call(this._client, this.id);
     }
 
     toJSON(props = []) {

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -45,7 +45,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction, userID) {
-        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.addMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -59,7 +59,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Invite>}
     */
     createInvite(options, reason) {
-        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
+        return this._client.createChannelInvite.call(this._client, this.id, options, reason);
     }
 
     /**
@@ -104,7 +104,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return this.client.createMessage.call(this.client, this.id, content, file);
+        return this._client.createMessage.call(this._client, this.id, content, file);
     }
 
     /**
@@ -116,7 +116,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<NewsThreadChannel | PublicThreadChannel>}
     */
     createThreadWithMessage(messageID, options) {
-        return this.client.createThreadWithMessage.call(this.client, this.id, messageID, options);
+        return this._client.createThreadWithMessage.call(this._client, this.id, messageID, options);
     }
 
     /**
@@ -129,7 +129,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<PrivateThreadChannel>}
     */
     createThreadWithoutMessage(options) {
-        return this.client.createThreadWithoutMessage.call(this.client, this.id, options);
+        return this._client.createThreadWithoutMessage.call(this._client, this.id, options);
     }
 
     /**
@@ -141,7 +141,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object>} Resolves with a webhook object
     */
     createWebhook(options, reason) {
-        return this.client.createChannelWebhook.call(this.client, this.id, options, reason);
+        return this._client.createChannelWebhook.call(this._client, this.id, options, reason);
     }
 
     /**
@@ -151,7 +151,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
+        return this._client.deleteMessage.call(this._client, this.id, messageID, reason);
     }
 
     /**
@@ -161,7 +161,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessages(messageIDs, reason) {
-        return this.client.deleteMessages.call(this.client, this.id, messageIDs, reason);
+        return this._client.deleteMessages.call(this._client, this.id, messageIDs, reason);
     }
 
     /**
@@ -199,7 +199,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return this.client.editMessage.call(this.client, this.id, messageID, content);
+        return this._client.editMessage.call(this._client, this.id, messageID, content);
     }
 
     /**
@@ -207,7 +207,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object>} An object containing an array of `threads`, an array of `members` and whether the response `hasMore` threads that could be returned in a subsequent call
     */
     getActiveThreads() {
-        return this.client.getActiveThreads.call(this.client, this.id);
+        return this._client.getActiveThreads.call(this._client, this.id);
     }
 
     /**
@@ -219,7 +219,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object>} An object containing an array of `threads`, an array of `members` and whether the response `hasMore` threads that could be returned in a subsequent call
     */
     getArchivedThreads(type, options) {
-        return this.client.getArchivedThreads.call(this.client, this.id, type, options);
+        return this._client.getArchivedThreads.call(this._client, this.id, type, options);
     }
 
     /**
@@ -227,7 +227,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Array<Invite>>}
     */
     getInvites() {
-        return this.client.getChannelInvites.call(this.client, this.id);
+        return this._client.getChannelInvites.call(this._client, this.id);
     }
 
     /**
@@ -238,7 +238,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Object>} An object containing an array of `threads`, an array of `members` and whether the response `hasMore` threads that could be returned in a subsequent call
     */
     getJoinedPrivateArchivedThreads(options) {
-        return this.client.getJoinedPrivateArchivedThreads.call(this.client, this.id, options);
+        return this._client.getJoinedPrivateArchivedThreads.call(this._client, this.id, options);
     }
 
     /**
@@ -247,7 +247,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return this.client.getMessage.call(this.client, this.id, messageID);
+        return this._client.getMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -262,7 +262,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Array<User>>}
     */
     getMessageReaction(messageID, reaction, options, before, after) {
-        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, options, before, after);
+        return this._client.getMessageReaction.call(this._client, this.id, messageID, reaction, options, before, after);
     }
 
     /**
@@ -278,7 +278,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Array<Message>>}
     */
     getMessages(options, before, after, around) {
-        return this.client.getMessages.call(this.client, this.id, options, before, after, around);
+        return this._client.getMessages.call(this._client, this.id, options, before, after, around);
     }
 
     /**
@@ -286,7 +286,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Array<Message>>}
     */
     getPins() {
-        return this.client.getPins.call(this.client, this.id);
+        return this._client.getPins.call(this._client, this.id);
     }
 
     /**
@@ -294,7 +294,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Array<Object>>} Resolves with an array of webhook objects
     */
     getWebhooks() {
-        return this.client.getChannelWebhooks.call(this.client, this.id);
+        return this._client.getChannelWebhooks.call(this._client, this.id);
     }
 
     /**
@@ -303,7 +303,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     pinMessage(messageID) {
-        return this.client.pinMessage.call(this.client, this.id, messageID);
+        return this._client.pinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -321,7 +321,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
     purge(limit, filter, before, after, reason) {
-        return this.client.purgeChannel.call(this.client, this.id, limit, filter, before, after, reason);
+        return this._client.purgeChannel.call(this._client, this.id, limit, filter, before, after, reason);
     }
 
     /**
@@ -332,7 +332,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReaction(messageID, reaction, userID) {
-        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.removeMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -342,7 +342,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReactionEmoji(messageID, reaction) {
-        return this.client.removeMessageReactionEmoji.call(this.client, this.id, messageID, reaction);
+        return this._client.removeMessageReactionEmoji.call(this._client, this.id, messageID, reaction);
     }
 
     /**
@@ -351,7 +351,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReactions(messageID) {
-        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
+        return this._client.removeMessageReactions.call(this._client, this.id, messageID);
     }
 
     /**
@@ -359,7 +359,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     sendTyping() {
-        return this.client.sendChannelTyping.call(this.client, this.id);
+        return this._client.sendChannelTyping.call(this._client, this.id);
     }
 
     /**
@@ -368,7 +368,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     unpinMessage(messageID) {
-        return this.client.unpinMessage.call(this.client, this.id, messageID);
+        return this._client.unpinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -377,7 +377,7 @@ class TextChannel extends GuildChannel {
     * @returns {Promise}
     */
     unsendMessage(messageID) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID);
+        return this._client.deleteMessage.call(this._client, this.id, messageID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/TextVoiceChannel.js
+++ b/lib/structures/TextVoiceChannel.js
@@ -35,7 +35,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction, userID) {
-        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.addMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -49,7 +49,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Invite>}
     */
     createInvite(options, reason) {
-        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
+        return this._client.createChannelInvite.call(this._client, this.id, options, reason);
     }
 
     /**
@@ -95,7 +95,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return this.client.createMessage.call(this.client, this.id, content, file);
+        return this._client.createMessage.call(this._client, this.id, content, file);
     }
 
     /**
@@ -105,7 +105,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
+        return this._client.deleteMessage.call(this._client, this.id, messageID, reason);
     }
 
     /**
@@ -115,7 +115,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     deleteMessages(messageIDs, reason) {
-        return this.client.deleteMessages.call(this.client, this.id, messageIDs, reason);
+        return this._client.deleteMessages.call(this._client, this.id, messageIDs, reason);
     }
 
     /**
@@ -151,7 +151,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return this.client.editMessage.call(this.client, this.id, messageID, content);
+        return this._client.editMessage.call(this._client, this.id, messageID, content);
     }
 
     /**
@@ -159,7 +159,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Array<Invite>>}
     */
     getInvites() {
-        return this.client.getChannelInvites.call(this.client, this.id);
+        return this._client.getChannelInvites.call(this._client, this.id);
     }
 
     /**
@@ -168,7 +168,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return this.client.getMessage.call(this.client, this.id, messageID);
+        return this._client.getMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -183,7 +183,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Array<User>>}
     */
     getMessageReaction(messageID, reaction, options, before, after) {
-        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, options, before, after);
+        return this._client.getMessageReaction.call(this._client, this.id, messageID, reaction, options, before, after);
     }
 
     /**
@@ -199,7 +199,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Array<Message>>}
     */
     getMessages(options, before, after, around) {
-        return this.client.getMessages.call(this.client, this.id, options, before, after, around);
+        return this._client.getMessages.call(this._client, this.id, options, before, after, around);
     }
 
     /**
@@ -217,7 +217,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
     purge(limit, filter, before, after, reason) {
-        return this.client.purgeChannel.call(this.client, this.id, limit, filter, before, after, reason);
+        return this._client.purgeChannel.call(this._client, this.id, limit, filter, before, after, reason);
     }
 
     /**
@@ -228,7 +228,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     removeMessageReaction(messageID, reaction, userID) {
-        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.removeMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -238,7 +238,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     removeMessageReactionEmoji(messageID, reaction) {
-        return this.client.removeMessageReactionEmoji.call(this.client, this.id, messageID, reaction);
+        return this._client.removeMessageReactionEmoji.call(this._client, this.id, messageID, reaction);
     }
 
     /**
@@ -247,7 +247,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     removeMessageReactions(messageID) {
-        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
+        return this._client.removeMessageReactions.call(this._client, this.id, messageID);
     }
 
     /**
@@ -255,7 +255,7 @@ class TextVoiceChannel extends VoiceChannel {
     * @returns {Promise}
     */
     sendTyping() {
-        return this.client.sendChannelTyping.call(this.client, this.id);
+        return this._client.sendChannelTyping.call(this._client, this.id);
     }
 
     toJSON(props = []) {

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -56,7 +56,7 @@ class ThreadChannel extends GuildChannel {
             };
         }
         if(data.member !== undefined) {
-            this.member = new ThreadMember(data.member, this.client);
+            this.member = new ThreadMember(data.member, this._client);
         }
     }
 
@@ -67,7 +67,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     addMessageReaction(messageID, reaction) {
-        return this.client.addMessageReaction.call(this.client, this.id, messageID, reaction);
+        return this._client.addMessageReaction.call(this._client, this.id, messageID, reaction);
     }
 
     /**
@@ -112,7 +112,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     createMessage(content, file) {
-        return this.client.createMessage.call(this.client, this.id, content, file);
+        return this._client.createMessage.call(this._client, this.id, content, file);
     }
 
     /**
@@ -122,7 +122,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessage(messageID, reason) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID, reason);
+        return this._client.deleteMessage.call(this._client, this.id, messageID, reason);
     }
 
     /**
@@ -132,7 +132,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     deleteMessages(messageIDs, reason) {
-        return this.client.deleteMessages.call(this.client, this.id, messageIDs, reason);
+        return this._client.deleteMessages.call(this._client, this.id, messageIDs, reason);
     }
 
     /**
@@ -170,7 +170,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     editMessage(messageID, content) {
-        return this.client.editMessage.call(this.client, this.id, messageID, content);
+        return this._client.editMessage.call(this._client, this.id, messageID, content);
     }
 
     /**
@@ -178,7 +178,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Array<ThreadMember>>}
     */
     getMembers() {
-        return this.client.getThreadMembers.call(this.client, this.id);
+        return this._client.getThreadMembers.call(this._client, this.id);
     }
 
     /**
@@ -187,7 +187,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Message>}
     */
     getMessage(messageID) {
-        return this.client.getMessage.call(this.client, this.id, messageID);
+        return this._client.getMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -202,7 +202,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Array<User>>}
     */
     getMessageReaction(messageID, reaction, options, before, after) {
-        return this.client.getMessageReaction.call(this.client, this.id, messageID, reaction, options, before, after);
+        return this._client.getMessageReaction.call(this._client, this.id, messageID, reaction, options, before, after);
     }
 
     /**
@@ -218,7 +218,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Array<Message>>}
     */
     getMessages(options, before, after, around) {
-        return this.client.getMessages.call(this.client, this.id, options, before, after, around);
+        return this._client.getMessages.call(this._client, this.id, options, before, after, around);
     }
 
     /**
@@ -226,7 +226,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Array<Message>>}
     */
     getPins() {
-        return this.client.getPins.call(this.client, this.id);
+        return this._client.getPins.call(this._client, this.id);
     }
 
     /**
@@ -235,7 +235,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     join(userID) {
-        return this.client.joinThread.call(this.client, this.id, userID);
+        return this._client.joinThread.call(this._client, this.id, userID);
     }
 
     /**
@@ -244,7 +244,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     leave(userID) {
-        return this.client.leaveThread.call(this.client, this.id, userID);
+        return this._client.leaveThread.call(this._client, this.id, userID);
     }
 
     /**
@@ -253,7 +253,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     pinMessage(messageID) {
-        return this.client.pinMessage.call(this.client, this.id, messageID);
+        return this._client.pinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -267,7 +267,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise<Number>} Resolves with the number of messages deleted
     */
     purge(options) {
-        return this.client.purgeChannel.call(this.client, this.id, options);
+        return this._client.purgeChannel.call(this._client, this.id, options);
     }
 
     /**
@@ -278,7 +278,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReaction(messageID, reaction, userID) {
-        return this.client.removeMessageReaction.call(this.client, this.id, messageID, reaction, userID);
+        return this._client.removeMessageReaction.call(this._client, this.id, messageID, reaction, userID);
     }
 
     /**
@@ -288,7 +288,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReactionEmoji(messageID, reaction) {
-        return this.client.removeMessageReactionEmoji.call(this.client, this.id, messageID, reaction);
+        return this._client.removeMessageReactionEmoji.call(this._client, this.id, messageID, reaction);
     }
 
     /**
@@ -297,7 +297,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     removeMessageReactions(messageID) {
-        return this.client.removeMessageReactions.call(this.client, this.id, messageID);
+        return this._client.removeMessageReactions.call(this._client, this.id, messageID);
     }
 
     /**
@@ -305,7 +305,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     sendTyping() {
-        return this.client.sendChannelTyping.call(this.client, this.id);
+        return this._client.sendChannelTyping.call(this._client, this.id);
     }
 
     /**
@@ -314,7 +314,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     unpinMessage(messageID) {
-        return this.client.unpinMessage.call(this.client, this.id, messageID);
+        return this._client.unpinMessage.call(this._client, this.id, messageID);
     }
 
     /**
@@ -323,7 +323,7 @@ class ThreadChannel extends GuildChannel {
     * @returns {Promise}
     */
     unsendMessage(messageID) {
-        return this.client.deleteMessage.call(this.client, this.id, messageID);
+        return this._client.deleteMessage.call(this._client, this.id, messageID);
     }
 
     toJSON(props = []) {

--- a/lib/structures/VoiceChannel.js
+++ b/lib/structures/VoiceChannel.js
@@ -49,7 +49,7 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<Invite>}
     */
     createInvite(options, reason) {
-        return this.client.createChannelInvite.call(this.client, this.id, options, reason);
+        return this._client.createChannelInvite.call(this._client, this.id, options, reason);
     }
 
     /**
@@ -57,7 +57,7 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<Array<Invite>>}
     */
     getInvites() {
-        return this.client.getChannelInvites.call(this.client, this.id);
+        return this._client.getChannelInvites.call(this._client, this.id);
     }
 
     /**
@@ -70,14 +70,14 @@ class VoiceChannel extends GuildChannel {
     * @returns {Promise<VoiceConnection>} Resolves with a VoiceConnection
     */
     join(options) {
-        return this.client.joinVoiceChannel.call(this.client, this.id, options);
+        return this._client.joinVoiceChannel.call(this._client, this.id, options);
     }
 
     /**
     * Leaves the channel.
     */
     leave() {
-        return this.client.leaveVoiceChannel.call(this.client, this.id);
+        return this._client.leaveVoiceChannel.call(this._client, this.id);
     }
 
     toJSON(props = []) {

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -168,7 +168,7 @@ class VoiceConnection extends EventEmitter {
                 this.disconnect(new Error("Voice connection timeout"));
             }
             this.connectionTimeout = null;
-        }, this.shard.client ? this.shard.client.options.connectionTimeout : 30000).unref();
+        }, this.shard._client ? this.shard._client.options.connectionTimeout : 30000).unref();
         if(!data.endpoint) {
             return; // Endpoint null, wait next update.
         }


### PR DESCRIPTION
`Channel` & `Shard` are the only two classes that assign the Client as `client` instead of `_client`.

If not changed to be underscored, they should at least be changed to an `Object.defineProperty` call so they can be made non-enumerable.