### PR TITLE
fix(getMessages): Emit Error object in "error" event

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2673,7 +2673,7 @@ class Client extends EventEmitter {
             try {
                 return new Message(message, this);
             } catch(err) {
-                this.emit("error", `Error creating message from channel messages\n${err.stack}\n${JSON.stringify(messages)}`);
+                this.emit("error", new Error(`Error creating message from channel messages\n${err.stack}\n${JSON.stringify(messages)}`));
                 return null;
             }
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2673,7 +2673,8 @@ class Client extends EventEmitter {
             try {
                 return new Message(message, this);
             } catch(err) {
-                this.emit("error", new Error(`Error creating message from channel messages\n${JSON.stringify(message)}`, {cause: err}));
+                err.message = `Error creating message from channel messages\n${JSON.stringify(message)}`;
+                this.emit("error", err);
                 return null;
             }
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2673,7 +2673,7 @@ class Client extends EventEmitter {
             try {
                 return new Message(message, this);
             } catch(err) {
-                this.emit("error", new Error(`Error creating message from channel messages\n${err.stack}\n${JSON.stringify(messages)}`));
+                this.emit("error", new Error(`Error creating message from channel messages\n${JSON.stringify(message)}`, {cause: err}));
                 return null;
             }
         });


### PR DESCRIPTION
Didn't really know how to title this, apologies if I got it wrong.

Error event `err` param should be type `Error` - https://github.com/abalabahaha/eris/blob/dev/index.d.ts#L711