### PR TITLE
feat(Client): allow custom numbers in intents option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -386,7 +386,7 @@ declare namespace Eris {
     firstShardID?: number;
     getAllUsers?: boolean;
     guildCreateTimeout?: number;
-    intents: number | IntentStrings[];
+    intents: number | (IntentStrings | number)[];
     largeThreshold?: number;
     lastShardID?: number;
     /** @deprecated */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -96,7 +96,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String>} [options.intents] A list of [intent names](https://abal.moe/Eris/docs/reference) or numbers, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
+    * @arg {Number | Array<String|Number>} [options.intents] A list of [intent names](https://abal.moe/Eris/docs/reference), pre-shifted intent numbers to add, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -96,7 +96,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String>} [options.intents] A list of intents, or raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
+    * @arg {Number | Array<String>} [options.intents] A list of intent strings or numbers, or raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -179,7 +179,9 @@ class Client extends EventEmitter {
             if(Array.isArray(this.options.intents)) {
                 let bitmask = 0;
                 for(const intent of this.options.intents) {
-                    if(Constants.Intents[intent]) {
+                    if(typeof intent === "number") {
+                        bitmask |= (1 << intent);
+                    } else if(Constants.Intents[intent]) {
                         bitmask |= Constants.Intents[intent];
                     } else {
                         this.emit("warn", `Unknown intent: ${intent}`);

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -180,7 +180,7 @@ class Client extends EventEmitter {
                 let bitmask = 0;
                 for(const intent of this.options.intents) {
                     if(typeof intent === "number") {
-                        bitmask |= (1 << intent);
+                        bitmask |= intent;
                     } else if(Constants.Intents[intent]) {
                         bitmask |= Constants.Intents[intent];
                     } else {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -96,7 +96,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String|Number>} [options.intents] A list of [intent names](https://abal.moe/Eris/docs/reference), pre-shifted intent numbers to add, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
+    * @arg {Number | Array<String|Number>} [options.intents] A list of [intent names](/Eris/docs/reference), pre-shifted intent numbers to add, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -96,7 +96,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String>} [options.intents] A list of intent strings or numbers, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
+    * @arg {Number | Array<String>} [options.intents] A list of [intent names](https://abal.moe/Eris/docs/reference) or numbers, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -96,7 +96,7 @@ class Client extends EventEmitter {
     * @arg {Number} [options.firstShardID=0] The ID of the first shard to run for this client
     * @arg {Boolean} [options.getAllUsers=false] Get all the users in every guild. Ready time will be severely delayed
     * @arg {Number} [options.guildCreateTimeout=2000] How long in milliseconds to wait for a GUILD_CREATE before "ready" is fired. Increase this value if you notice missing guilds
-    * @arg {Number | Array<String>} [options.intents] A list of intent strings or numbers, or raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
+    * @arg {Number | Array<String>} [options.intents] A list of intent strings or numbers, or a raw bitmask value describing the intents to subscribe to. Some intents, like `guildPresences` and `guildMembers`, must be enabled on your application's page to be used. By default, all non-privileged intents are enabled.
     * @arg {Number} [options.largeThreshold=250] The maximum number of offline users per guild during initial guild data transmission
     * @arg {Number} [options.lastShardID=options.maxShards - 1] The ID of the last shard to run for this client
     * @arg {Number} [options.latencyThreshold=30000] [DEPRECATED] The average request latency at which Eris will start emitting latency errors. This option has been moved under `options.rest`


### PR DESCRIPTION
See above, smol change to allow for custom intent numbers to be specified in the array without needed to maintain the bitmask logic yourself