### PR TITLE
feat(shards): Support Non-Sequential Shard IDs

### DIFF
--- a/examples/sharding.js
+++ b/examples/sharding.js
@@ -4,6 +4,7 @@ const Eris = require("eris");
 const bot = new Eris("Bot TOKEN", {
     firstShardID: 0,
     lastShardID: 15,
+    shardIDs: [5, 9, 1, 4], // Overrides firstShardID and lastShardID above
     maxShards: 16,
     getAllUsers: false,
     intents: ["guilds", "guildMembers", "guildPresences"]

--- a/index.d.ts
+++ b/index.d.ts
@@ -404,6 +404,7 @@ declare namespace Eris {
     restMode?: boolean;
     seedVoiceConnections?: boolean;
     shardConcurrency?: number | "auto";
+    shardIDs?: number[];
     ws?: unknown;
   }
   interface CommandClientOptions {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -120,6 +120,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. Even with this option enabled, it is recommended that you check the cache first before using REST
     * @arg {Boolean} [options.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
     * @arg {Number | String} [options.shardConcurrency="auto"] The number of shards that can start simultaneously. If "auto" Eris will use Discord's recommended shard concurrency.
+    * @arg {Array<Number>} [options.shardIDs=null] An array of shard IDs to run for this client. If this is specified, the firstShardID and lastShardID options are ignored.
     * @arg {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
     */
     constructor(token, options) {
@@ -151,6 +152,7 @@ class Client extends EventEmitter {
             restMode: false,
             seedVoiceConnections: false,
             shardConcurrency: "auto",
+            shardIDs: null,
             ws: {},
             reconnectDelay: (lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000
         }, options);
@@ -458,8 +460,22 @@ class Client extends EventEmitter {
                 this.shards.setConcurrency(data.session_start_limit.max_concurrency);
             }
 
-            for(let i = this.options.firstShardID; i <= this.options.lastShardID; ++i) {
-                this.shards.spawn(i);
+            // ensure we have a valid shard ID array
+            let shardIDs = this.options.shardIDs;
+            if(!Array.isArray(shardIDs)) {
+                shardIDs = [];
+            }
+
+            // populate array via first/last shard IDs if no elements are present
+            if(shardIDs.length === 0) {
+                for(let i = this.options.firstShardID; i <= this.options.lastShardID; i++) {
+                    shardIDs.push(i);
+                }
+            }
+
+            // spawn the shards
+            for(const id of shardIDs) {
+                this.shards.spawn(id);
             }
         } catch(err) {
             if(!this.options.autoreconnect) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -120,7 +120,7 @@ class Client extends EventEmitter {
     * @arg {Boolean} [options.restMode=false] Whether to enable getting objects over REST. Even with this option enabled, it is recommended that you check the cache first before using REST
     * @arg {Boolean} [options.seedVoiceConnections=false] Whether to populate bot.voiceConnections with existing connections the bot account has during startup. Note that this will disconnect connections from other bot sessions
     * @arg {Number | String} [options.shardConcurrency="auto"] The number of shards that can start simultaneously. If "auto" Eris will use Discord's recommended shard concurrency.
-    * @arg {Array<Number>} [options.shardIDs=null] An array of shard IDs to run for this client. If this is specified, the firstShardID and lastShardID options are ignored.
+    * @arg {Array<Number>} [options.shardIDs] An array of shard IDs to run for this client. If this is specified, the firstShardID and lastShardID options are ignored.
     * @arg {Object} [options.ws] An object of WebSocket options to pass to the shard WebSocket constructors
     */
     constructor(token, options) {
@@ -152,7 +152,7 @@ class Client extends EventEmitter {
             restMode: false,
             seedVoiceConnections: false,
             shardConcurrency: "auto",
-            shardIDs: null,
+            shardIDs: [],
             ws: {},
             reconnectDelay: (lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000
         }, options);
@@ -460,13 +460,13 @@ class Client extends EventEmitter {
                 this.shards.setConcurrency(data.session_start_limit.max_concurrency);
             }
 
-            // ensure we have a valid shard ID array
+            // ensure we have a valid shardIDs array
             let shardIDs = this.options.shardIDs;
             if(!Array.isArray(shardIDs)) {
                 shardIDs = [];
             }
 
-            // populate array via first/last shard IDs if no elements are present
+            // populate array via first/last shardID if no elements are present
             if(shardIDs.length === 0) {
                 for(let i = this.options.firstShardID; i <= this.options.lastShardID; i++) {
                     shardIDs.push(i);


### PR DESCRIPTION
This PR adds support for non-sequential shardsIDs to be used in eris. Currently I wrote it to override firstShardID and lastShardID if any numbers exist in the array. But I can see valid cases for the following as well:
- Throw an error if both firstShardID/lastShardID and shardIDs are defined
- firstShardID/lastShardID take priority and must be set to null for shardIDs to be used

Please let me know if I should change the logic to reflect one of these other states or to something entirely different if someone has a better idea.

I have performed basic testing of this and seems fine, but I want to test it more thoroughly before we merge.

Closes #1385