### PR TITLE
fix(createGuild): use greater than or equal (>=)

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -612,7 +612,7 @@ class Client extends EventEmitter {
     * @returns {Promise<Guild>}
     */
     createGuild(name, options) {
-        if(this.guilds.size > 9) {
+        if(this.guilds.size >= 10) {
             throw new Error("This method can't be used when in 10 or more guilds.");
         }
 


### PR DESCRIPTION
If it supports only 10 guilds, then we can use >= 10 instead of > 9