### PR TITLE
feat(bans): Seconds Support

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -836,6 +836,12 @@ declare namespace Eris {
   }
 
   // Guild
+  export interface BanMemberOptions {
+    /** @deprecated */
+    deleteMessageDays?: number;
+    deleteMessageSeconds?: number;
+    reason?: string;
+  }
   interface CreateGuildOptions {
     afkChannelID?: string;
     afkTimeout?: number;
@@ -2140,6 +2146,8 @@ declare namespace Eris {
     addMessageReaction(channelID: string, messageID: string, reaction: string, userID: string): Promise<void>;
     addRelationship(userID: string, block?: boolean): Promise<void>;
     addSelfPremiumSubscription(token: string, plan: string): Promise<void>;
+    banGuildMember(guildID: string, userID: string, options?: BanMemberOptions): Promise<void>;
+    /** @deprecated */
     banGuildMember(guildID: string, userID: string, deleteMessageDays?: number, reason?: string): Promise<void>;
     bulkEditCommandPermissions(guildID: string, permissions: { id: string; permissions: ApplicationCommandPermissions[] }[]): Promise<GuildApplicationCommandPermissions[]>;
     bulkEditCommands(commands: ApplicationCommandStructure[]): Promise<ApplicationCommand[]>;
@@ -2700,6 +2708,8 @@ declare namespace Eris {
     constructor(data: BaseData, client: Client);
     addDiscoverySubcategory(categoryID: string, reason?: string): Promise<DiscoverySubcategoryResponse>;
     addMemberRole(memberID: string, roleID: string, reason?: string): Promise<void>;
+    banMember(userID: string, options?: BanMemberOptions): Promise<void>;
+    /** @deprecated */
     banMember(userID: string, deleteMessageDays?: number, reason?: string): Promise<void>;
     bulkEditCommands(commands: ApplicationCommandStructure[]): Promise<ApplicationCommand[]>;
     createChannel(name: string): Promise<TextChannel>;
@@ -3118,6 +3128,8 @@ declare namespace Eris {
     voiceState: VoiceState;
     constructor(data: BaseData, guild?: Guild, client?: Client);
     addRole(roleID: string, reason?: string): Promise<void>;
+    ban(options?: BanMemberOptions): Promise<void>;
+    /** @deprecated */
     ban(deleteMessageDays?: number, reason?: string): Promise<void>;
     edit(options: MemberOptions, reason?: string): Promise<void>;
     kick(reason?: string): Promise<void>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -354,8 +354,10 @@ class Client extends EventEmitter {
         if(reason !== undefined) {
             options.reason = reason;
         }
+        if(options.deleteMessageDays && !isNaN(options.deleteMessageDays) && !Object.hasOwn(options, "deleteMessageSeconds")) {
+            options.deleteMessageSeconds = options.deleteMessageDays * 24 * 60 * 60;
+        }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
-            delete_message_days: options.deleteMessageDays || 0,
             delete_message_seconds: options.deleteMessageSeconds || 0,
             reason: options.reason
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -339,17 +339,25 @@ class Client extends EventEmitter {
     * Ban a user from a guild
     * @arg {String} guildID The ID of the guild
     * @arg {String} userID The ID of the user
-    * @arg {Number} [deleteMessageDays=0] Number of days to delete messages for, between 0-7 inclusive
-    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @arg {Number} [options.deleteMessageDays=0] [DEPRECATED] Number of days to delete messages for, between 0-7 inclusive
+    * @arg {Number} [options.deleteMessageSeconds=0] Number of seconds to delete messages for, between 0 and 604800 inclusive
+    * @arg {String} [options.reason] The reason to be displayed in audit logs
+    * @arg {String} [reason] [DEPRECATED] The reason to be displayed in audit logs
     * @returns {Promise}
     */
-    banGuildMember(guildID, userID, deleteMessageDays, reason) {
-        if(!isNaN(deleteMessageDays) && (deleteMessageDays < 0 || deleteMessageDays > 7)) {
-            return Promise.reject(new Error(`Invalid deleteMessageDays value (${deleteMessageDays}), should be a number between 0-7 inclusive`));
+    banGuildMember(guildID, userID, options, reason) {
+        if(!options || typeof options !== "object") {
+            options = {
+                deleteMessageDays: options
+            };
+        }
+        if(reason !== undefined) {
+            options.reason = reason;
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {
-            delete_message_days: deleteMessageDays || 0,
-            reason: reason
+            delete_message_days: options.deleteMessageDays || 0,
+            delete_message_seconds: options.deleteMessageSeconds || 0,
+            reason: options.reason
         });
     }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -354,7 +354,7 @@ class Client extends EventEmitter {
         if(reason !== undefined) {
             options.reason = reason;
         }
-        if(options.deleteMessageDays && !isNaN(options.deleteMessageDays) && !Object.hasOwn(options, "deleteMessageSeconds")) {
+        if(options.deleteMessageDays && !isNaN(options.deleteMessageDays) && !Object.hasOwnProperty.call(options, "deleteMessageSeconds")) {
             options.deleteMessageSeconds = options.deleteMessageDays * 24 * 60 * 60;
         }
         return this.requestHandler.request("PUT", Endpoints.GUILD_BAN(guildID, userID), true, {

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -357,12 +357,14 @@ class Guild extends Base {
     /**
     * Ban a user from the guild
     * @arg {String} userID The ID of the member
-    * @arg {Number} [deleteMessageDays=0] Number of days to delete messages for, between 0-7 inclusive
-    * @arg {String} [reason] Reason for the ban
+    * @arg {Number} [options.deleteMessageDays=0] [DEPRECATED] Number of days to delete messages for, between 0-7 inclusive
+    * @arg {Number} [options.deleteMessageSeconds=0] Number of seconds to delete messages for, between 0 and 604,800 inclusive
+    * @arg {String} [options.reason] The reason to be displayed in audit logs
+    * @arg {String} [reason] [DEPRECATED] The reason to be displayed in audit logs
     * @returns {Promise}
     */
-    banMember(userID, deleteMessageDays, reason) {
-        return this._client.banGuildMember.call(this._client, this.id, userID, deleteMessageDays, reason);
+    banMember(userID, options, reason) {
+        return this._client.banGuildMember.call(this._client, this.id, userID, options, reason);
     }
 
     /**

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -202,12 +202,14 @@ class Member extends Base {
 
     /**
     * Ban the user from the guild
-    * @arg {Number} [deleteMessageDays=0] Number of days to delete messages for, between 0-7 inclusive
-    * @arg {String} [reason] The reason to be displayed in audit logs
+    * @arg {Number} [options.deleteMessageDays=0] [DEPRECATED] Number of days to delete messages for, between 0-7 inclusive
+    * @arg {Number} [options.deleteMessageSeconds=0] Number of seconds to delete messages for, between 0 and 604,800 inclusive
+    * @arg {String} [options.reason] The reason to be displayed in audit logs
+    * @arg {String} [reason] [DEPRECATED] The reason to be displayed in audit logs
     * @returns {Promise}
     */
-    ban(deleteMessageDays, reason) {
-        return this.guild.shard.client.banGuildMember.call(this.guild.shard.client, this.guild.id, this.id, deleteMessageDays, reason);
+    ban(options, reason) {
+        return this.guild.shard.client.banGuildMember.call(this.guild.shard.client, this.guild.id, this.id, options, reason);
     }
 
     /**


### PR DESCRIPTION
discord/discord-api-docs#5219

This adds support for `delete_message_seconds`, and removes the range check, as we've moved away from checking things like that for end users.