### PR TITLE
refactor(GroupChannels): Properly Support Group Channels

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -257,8 +257,8 @@ declare namespace Eris {
 
   // Channel
   export interface AddGroupRecipientOptions {
-    userID: string;
     accessToken: string;
+    userID: string;
     nick?: string;
   }
   interface ChannelFollow {

--- a/index.d.ts
+++ b/index.d.ts
@@ -256,6 +256,11 @@ declare namespace Eris {
   }
 
   // Channel
+  export interface AddGroupRecipientOptions {
+    userID: string;
+    accessToken: string;
+    nick?: string;
+  }
   interface ChannelFollow {
     channel_id: string;
     webhook_id: string;
@@ -276,6 +281,10 @@ declare namespace Eris {
     reason?: string;
     topic?: string;
     userLimit?: number;
+  }
+  export interface CreateGroupChannelOptions {
+    accessTokens: string[];
+    nicks?: Record<string, string>;
   }
   interface EditChannelOptions extends Omit<CreateChannelOptions, "reason"> {
     archived?: boolean;
@@ -2132,7 +2141,7 @@ declare namespace Eris {
     voiceConnections: VoiceConnectionManager;
     constructor(token: string, options?: ClientOptions);
     acceptInvite(inviteID: string): Promise<Invite<"withoutCount">>;
-    addGroupRecipient(groupID: string, userID: string): Promise<void>;
+    addGroupRecipient(groupID: string, options: AddGroupRecipientOptions): Promise<void>;
     addGuildDiscoverySubcategory(guildID: string, categoryID: string, reason?: string): Promise<DiscoverySubcategoryResponse>;
     addGuildMemberRole(guildID: string, memberID: string, roleID: string, reason?: string): Promise<void>;
     addMessageReaction(channelID: string, messageID: string, reaction: string): Promise<void>;
@@ -2256,7 +2265,7 @@ declare namespace Eris {
       reason?: string
     ): Promise<Webhook>;
     createCommand(command: ApplicationCommandStructure): Promise<ApplicationCommand>;
-    createGroupChannel(userIDs: string[]): Promise<GroupChannel>;
+    createGroupChannel(options: CreateGroupChannelOptions): Promise<GroupChannel>;
     createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
     createGuildCommand(guildID: string, command: ApplicationCommandStructure): Promise<ApplicationCommand>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
@@ -2625,9 +2634,13 @@ declare namespace Eris {
     verified: boolean;
   }
 
-  export class GroupChannel extends PrivateChannel {
+  export class GroupChannel extends Channel {
+    applicationID: string;
     icon: string | null;
     iconURL: string | null;
+    lastMessageID: string;
+    managed: true;
+    messages: Collection<Message<this>>;
     name: string;
     ownerID: string;
     recipients: Collection<User>;
@@ -3240,7 +3253,7 @@ declare namespace Eris {
     lastMessageID: string;
     messages: Collection<Message<this>>;
     recipient: User;
-    type: PrivateChannelTypes;
+    type: Constants["ChannelTypes"]["DM"];
     addMessageReaction(messageID: string, reaction: string): Promise<void>;
     /** @deprecated */
     addMessageReaction(messageID: string, reaction: string, userID: string): Promise<void>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -258,8 +258,8 @@ declare namespace Eris {
   // Channel
   export interface AddGroupRecipientOptions {
     accessToken: string;
-    userID: string;
     nick?: string;
+    userID: string;
   }
   interface ChannelFollow {
     channel_id: string;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -256,13 +256,19 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [USER ACCOUNT] Add a user to a group
+    * Add a user to a group
     * @arg {String} groupID The ID of the target group
-    * @arg {String} userID The ID of the target user
+    * @arg {Object} options The options for adding the user
+    * @arg {String} options.userID The id of the user to add
+    * @arg {String} options.accessToken The access token of the user to add. Requires having been authorized with the `gdm.join` scope
+    * @arg {String} [options.nick] The nickname to give the user
     * @returns {Promise}
     */
-    addGroupRecipient(groupID, userID) {
-        return this.requestHandler.request("PUT", Endpoints.CHANNEL_RECIPIENT(groupID, userID), true);
+    addGroupRecipient(groupID, options) {
+        return this.requestHandler.request("PUT", Endpoints.CHANNEL_RECIPIENT(groupID, options.userID), true, {
+            access_token: options.accessToken,
+            nick: options.nick
+        });
     }
 
     /**
@@ -587,15 +593,17 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [USER ACCOUNT] Create a group channel with other users
-    * @arg {Array<String>} userIDs The IDs of the other users
-    * @returns {Promise<PrivateChannel>}
+    * Create a group channel with other users
+    * @arg  {Object} options The options for the group channel
+    * @arg {Array<String>} options.acessTokens The OAuth2 access tokens of the users to add to the group. Requires them to have been authorized with the `gdm.join` scope
+    * @arg {Object} [options.nicks] A dictionary of id to nickname for the group members
+    * @returns {Promise<GroupChannel>}
     */
-    createGroupChannel(userIDs) {
+    createGroupChannel(options) {
         return this.requestHandler.request("POST", Endpoints.USER_CHANNELS("@me"), true, {
-            recipients: userIDs,
-            type: 3
-        }).then((privateChannel) => new GroupChannel(privateChannel, this));
+            access_tokens: options.accessTokens,
+            nicks: options.nicks
+        }).then((groupChannel) => new GroupChannel(groupChannel, this));
     }
 
     /**
@@ -3237,7 +3245,7 @@ class Client extends EventEmitter {
     }
 
     /**
-    * [USER ACCOUNT] Remove a user from a group
+    * Remove a user from a group
     * @arg {String} groupID The ID of the target group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -259,9 +259,9 @@ class Client extends EventEmitter {
     * Add a user to a group
     * @arg {String} groupID The ID of the target group
     * @arg {Object} options The options for adding the user
-    * @arg {String} options.userID The id of the user to add
     * @arg {String} options.accessToken The access token of the user to add. Requires having been authorized with the `gdm.join` scope
     * @arg {String} [options.nick] The nickname to give the user
+    * @arg {String} options.userID The id of the user to add
     * @returns {Promise}
     */
     addGroupRecipient(groupID, options) {

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -66,7 +66,7 @@ class GroupChannel extends Channel {
     * @returns {String?}
     */
     dynamicIconURL(format, size) {
-        return this.icon ? this.client._formatImage(Endpoints.CHANNEL_ICON(this.id, this.icon), format, size) : null;
+        return this.icon ? this.client._formatImage(Endpoints.APPLICATION_ICON(this.applicationID, this.icon), format, size) : null;
     }
 
     /**

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -2,24 +2,29 @@
 
 const Collection = require("../util/Collection");
 const Endpoints = require("../rest/Endpoints");
-const PrivateChannel = require("./PrivateChannel");
 const User = require("./User");
+const Channel = require("./Channel");
+const Message = require("./Message");
 
 /**
-* [USER ACCOUNT] Represents a group channel. See PrivateChannel docs for additional properties.
-* @extends PrivateChannel
+* Represents a group channel. See Channel for additional properties.
+* @extends Channel
 * @prop {Call?} call The current group call, if any
 * @prop {String?} icon The hash of the group channel icon
 * @prop {String?} iconURL The URL of the group channel icon
 * @prop {Call?} lastCall The previous group call, if any
+* @prop {String} lastMessageID The ID of the last message in this channel
 * @prop {String} mention A string that mentions the channel
+* @prop {Collection<Message>} messages Collection of Messages in this channel
 * @prop {String} name The name of the group channel
 * @prop {String} ownerID The ID of the user that is the group owner
 * @prop {Collection<User>} recipients The recipients in this private channel
 */
-class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
+class GroupChannel extends Channel {
     constructor(data, client) {
         super(data, client);
+        this.lastMessageID = data.last_message_id;
+        this.messages = new Collection(Message, client.options.messageLimit);
         this.recipients = new Collection(User);
         data.recipients.forEach((recipient) => {
             this.recipients.add(client.options.restMode ? new User(recipient, client) : client.users.add(recipient, client));
@@ -44,12 +49,14 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * [USER ACCOUNT] Add a user to the group
-    * @arg {String} userID The ID of the target user
+    * Add a user to the group
+    * @arg {Object} options The options for adding the user
+    * @arg {String} options.accessToken The access token of the user to add. Requires having been authorized with the `gdm.join` scope
+    * @arg {String} [options.nick] The nickname to give the user
     * @returns {Promise}
     */
-    addRecipient(userID) {
-        return this.client.addGroupRecipient.call(this.client, this.id, userID);
+    addRecipient(options) {
+        return this.client.addGroupRecipient.call(this.client, this.id, options);
     }
 
     /**
@@ -63,7 +70,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * [USER ACCOUNT] Edit the channel's properties
+    * Edit the channel's properties
     * @arg {Object} options The properties to edit
     * @arg {String} [options.name] The name of the channel
     * @arg {String} [options.icon] The icon of the channel as a base64 data URI (group channels only). Note: base64 strings alone are not base64 data URI strings
@@ -75,7 +82,7 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
     }
 
     /**
-    * [USER ACCOUNT] Remove a user from the group
+    * Remove a user from the group
     * @arg {String} userID The ID of the target user
     * @returns {Promise}
     */
@@ -85,7 +92,11 @@ class GroupChannel extends PrivateChannel { // (╯°□°）╯︵ ┻━┻
 
     toJSON(props = []) {
         return super.toJSON([
+            "call",
             "icon",
+            "lastCall",
+            "lastMessageID",
+            "messages",
             "name",
             "ownerID",
             "recipients",

--- a/lib/structures/PrivateChannel.js
+++ b/lib/structures/PrivateChannel.js
@@ -4,8 +4,7 @@ const Channel = require("./Channel");
 const Collection = require("../util/Collection");
 const Endpoints = require("../rest/Endpoints");
 const Message = require("./Message");
-const {GatewayOPCodes, ChannelTypes} = require("../Constants");
-const User = require("./User");
+const {GatewayOPCodes} = require("../Constants");
 
 /**
 * Represents a private channel. See Channel for more properties and methods.
@@ -20,9 +19,7 @@ class PrivateChannel extends Channel {
         this.lastMessageID = data.last_message_id;
         this.rateLimitPerUser = data.rate_limit_per_user;
         this.call = this.lastCall = null;
-        if(this.type === ChannelTypes.DM || this.type === undefined) {
-            this.recipient = new User(data.recipients[0], client);
-        }
+        this.recipient = client.users.add(data.recipients[0]);
         this.messages = new Collection(Message, client.options.messageLimit);
     }
 


### PR DESCRIPTION
Despite what our functions say, group channels are not purely userbot. They still have some in api functionality.
[Create](https://discord.com/developers/docs/resources/user#create-group-dm)
[Add Recipient](https://discord.com/developers/docs/resources/channel#group-dm-add-recipient)
[Remove Recipient](https://discord.com/developers/docs/resources/channel#group-dm-remove-recipient)

And despite what Discord's docs might say:
> DMs created with this endpoint will not be shown in the Discord client

![image](https://user-images.githubusercontent.com/17226394/183344743-a5614e34-b08a-41eb-bd8f-7a0ace507e7f.png)

They do, and they function just fine.
![image](https://user-images.githubusercontent.com/17226394/183344828-2138f2d6-428b-48e5-b0ca-c26331b879d7.png)

