### PR TITLE
feat(Member): Add dynamicAvatarURL

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3120,6 +3120,7 @@ declare namespace Eris {
     addRole(roleID: string, reason?: string): Promise<void>;
     ban(deleteMessageDays?: number, reason?: string): Promise<void>;
     edit(options: MemberOptions, reason?: string): Promise<void>;
+    dynamicAvatarURL(format?: ImageFormat, size?: number): string;
     kick(reason?: string): Promise<void>;
     removeRole(roleID: string, reason?: string): Promise<void>;
     unban(reason?: string): Promise<void>;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -227,6 +227,19 @@ class Member extends Base {
     }
 
     /**
+    * Get the member's avatar with the given format and size
+    * @arg {String} [format] The filetype of the avatar ("jpg", "jpeg", "png", "gif", or "webp")
+    * @arg {Number} [size] The size of the avatar (any power of two between 16 and 4096)
+    * @returns {String}
+    */
+    dynamicAvatarURL(format, size) {
+        if(!this.avatar) {
+            return this.user.dynamicAvatarURL(format, size);
+        }
+        return this.guild.shard.client._formatImage(Endpoints.GUILD_AVATAR(this.guild.id, this.id, this.avatar), format, size);
+    }
+
+    /**
     * Kick the member from the guild
     * @arg {String} [reason] The reason to be displayed in audit logs
     * @returns {Promise}


### PR DESCRIPTION
Adds `Member#dynamicAvatarURL`, mirroring `User#dynamicAvatarURL` and falling back to it if the member has no guild-specific avatar.