### PR TITLE
Turn `routefy` more easy to read and efficient.

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -403,28 +403,34 @@ class RequestHandler {
     }
 
     routefy(url, method) {
-        let route = url.replace(/\/([a-z-]+)\/(?:[0-9]{17,19})/g, function(match, p) {
-            return p === "channels" || p === "guilds" || p === "webhooks" ? match : `/${p}/:id`;
-        }).replace(/\/reactions\/[^/]+/g, "/reactions/:id").replace(/\/reactions\/:id\/[^/]+/g, "/reactions/:id/:userID").replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
-        if(method === "DELETE" && route.endsWith("/messages/:id")) {
-            const messageID = url.slice(url.lastIndexOf("/") + 1);
-            const createdAt = Base.getCreatedAt(messageID);
-            if(Date.now() - this.latencyRef.latency - createdAt >= 1000 * 60 * 60 * 24 * 14) {
-                method += "_OLD";
-            } else if(Date.now() - this.latencyRef.latency - createdAt <= 1000 * 10) {
-                method += "_NEW";
-            }
-            route = method + route;
-        } else if(method === "GET" && /\/guilds\/[0-9]+\/channels$/.test(route)) {
-            route = "/guilds/:id/channels";
+    let route = url
+        .replace(/\/(channels|guilds|webhooks)\/\d{17,19}/g, "/$1/:id")
+        .replace(/\/reactions\/[^/]+/g, "/reactions/:id")
+        .replace(/\/reactions\/:id\/[^/]+/g, "/reactions/:id/:userID")
+        .replace(/^\/webhooks\/(\d+)\/[A-Za-z0-9-_]{64,}/, "/webhooks/$1/:token");
+
+    if (method === "DELETE" && route.endsWith("/messages/:id")) {
+        const messageID = url.slice(url.lastIndexOf("/") + 1);
+        const createdAt = Base.getCreatedAt(messageID);
+        const diff = Date.now() - this.latencyRef.latency - createdAt;
+
+        if (diff >= 1000 * 60 * 60 * 24 * 14) {
+            method += "_OLD";
+        } else if (diff <= 10000) {
+            method += "_NEW";
         }
-        if(method === "PUT" || method === "DELETE") {
-            const index = route.indexOf("/reactions");
-            if(index !== -1) {
-                route = "MODIFY" + route.slice(0, index + 10);
-            }
-        }
-        return route;
+
+        route = method + route;
+    } else if (method === "GET" && route.endsWith("/guilds/:id/channels")) {
+        route = "/guilds/:id/channels";
+    }
+
+    if (["PUT", "DELETE"].includes(method) && route.includes("/reactions")) {
+        const index = route.indexOf("/reactions");
+        route = `MODIFY${route.slice(0, index + 10)}`;
+    }
+
+    return route;
     }
 
     [util.inspect.custom]() {


### PR DESCRIPTION
1. In the first regular expression, i used a capture group with the words "channels", "guilds", and "webhooks" to simplify the code and make it more readable. I used the \d{17,19} quantifier to match only numeric IDs with 17 to 19 characters.

2. I replaced the second regular expression with a replace function call with the string "/reactions/:id", which performs the same substitution.

3. I used the endsWith function to check if the route ends with "/messages/:id" instead of using a regular expression.

4. I used the slice function instead of a regular expression to extract the message ID.

5. I replaced the regular expressions in lines 18-19 with an includes function call to check if the route contains "/reactions".

6. I used route.includes("/reactions") instead of route.indexOf("/reactions") !== -1 to make the code more readable.

7. I used template strings instead of string concatenation to make the code more readable.