### PR TITLE
Update Channel Types to match Discord API documentation

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -109,18 +109,20 @@ module.exports.ButtonStyles = {
 };
 
 module.exports.ChannelTypes = {
-    GUILD_TEXT:           0,
-    DM:                   1,
-    GUILD_VOICE:          2,
-    GROUP_DM:             3,
-    GUILD_CATEGORY:       4,
-    GUILD_NEWS:           5,
-    GUILD_STORE:          6,
-
-    GUILD_NEWS_THREAD:    10,
-    GUILD_PUBLIC_THREAD:  11,
-    GUILD_PRIVATE_THREAD: 12,
-    GUILD_STAGE_VOICE:    13, GUILD_STAGE: 13 // [DEPRECATED]
+    GUILD_TEXT:                 0,
+    DM:                         1,
+    GUILD_VOICE:                2,
+    GROUP_DM:                   3,
+    GUILD_CATEGORY:             4,
+    GUILD_ANNOUNCEMENT:         5, GUILD_NEWS: 5, // [DEPRECATED]
+    GUILD_STORE:                6,
+    // Type 10, 11 and 12 are only available in API v9 and above.
+    GUILD_ANNOUNCEMENT_THREAD:  10, GUILD_NEWS_THREAD: 10, // [DEPRECATED]
+    GUILD_PUBLIC_THREAD:        11,
+    GUILD_PRIVATE_THREAD:       12,
+    GUILD_STAGE_VOICE:          13, GUILD_STAGE: 13, // [DEPRECATED]
+    GUILD_DIRECTORY:            14,
+    GUILD_FORUM:                15
 };
 
 module.exports.ComponentTypes = {


### PR DESCRIPTION
Updates Channel Types in [Constants.js](https://github.com/abalabahaha/eris/blob/dev/lib/Constants.js) to match Discord API documentation.

Additions:\
`GUILD_DIRECTORY`\
`GUILD_FORUM`

Replacements:\
`GUILD_ANNOUNCEMENT` with `GUILD_NEWS`\
`GUILD_ANNOUNCEMENT_THREAD` with `GUILD_NEWS_THREAD`.

[Discord Documentation Reference](https://discord.com/developers/docs/resources/channel#channel-object-channel-types)