### PR TITLE
Acceptance of all alphabetic characters in slash commands.

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -402,7 +402,7 @@ class Client extends EventEmitter {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                        throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                     }
                 }
             }
@@ -422,7 +422,7 @@ class Client extends EventEmitter {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                        throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                     }
                 }
             }
@@ -601,7 +601,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                 }
             }
         }
@@ -671,7 +671,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                 }
             }
         }
@@ -1456,7 +1456,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                 }
             }
         }
@@ -1549,7 +1549,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
                 }
             }
         }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -401,7 +401,7 @@ class Client extends EventEmitter {
             if(command.name !== undefined){
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
-                    if(!command.name.match(/^[\w-]{1,32}$/)) {
+                    if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                         throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                     }
                 }
@@ -421,7 +421,7 @@ class Client extends EventEmitter {
             if(command.name !== undefined){
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
-                    if(!command.name.match(/^[\w-]{1,32}$/)) {
+                    if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                         throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                     }
                 }
@@ -600,7 +600,7 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\w-]{1,32}$/)) {
+                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
@@ -670,7 +670,7 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\w-]{1,32}$/)) {
+                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
@@ -1455,7 +1455,7 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\w-]{1,32}$/)) {
+                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }
@@ -1548,7 +1548,7 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\w-]{1,32}$/)) {
+                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
                     throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
                 }
             }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -402,7 +402,7 @@ class Client extends EventEmitter {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                        throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                     }
                 }
             }
@@ -422,7 +422,7 @@ class Client extends EventEmitter {
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
                     if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                        throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                     }
                 }
             }
@@ -601,7 +601,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                 }
             }
         }
@@ -671,7 +671,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                 }
             }
         }
@@ -1456,7 +1456,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                 }
             }
         }
@@ -1549,7 +1549,7 @@ class Client extends EventEmitter {
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
                 if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\w-]{1,32}$\"");
+                    throw new Error("Slash Command names must match the regular expression \"^[\p{L}\w-]{1,32}$\"");
                 }
             }
         }

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -401,8 +401,8 @@ class Client extends EventEmitter {
             if(command.name !== undefined){
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
-                    if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                    if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                        throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                     }
                 }
             }
@@ -421,8 +421,8 @@ class Client extends EventEmitter {
             if(command.name !== undefined){
                 if(command.type === 1 || command.type === undefined) {
                     command.name = command.name.toLowerCase();
-                    if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                        throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                    if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                        throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                     }
                 }
             }
@@ -600,8 +600,8 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                    throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                 }
             }
         }
@@ -670,8 +670,8 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                    throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                 }
             }
         }
@@ -1455,8 +1455,8 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                    throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                 }
             }
         }
@@ -1548,8 +1548,8 @@ class Client extends EventEmitter {
         if(command.name !== undefined){
             if(command.type === 1 || command.type === undefined) {
                 command.name = command.name.toLowerCase();
-                if(!command.name.match(/^[\p{L}\w-]{1,32}$/u)) {
-                    throw new Error("Slash Command names must match the regular expression \"^[\\p{L}\\w-]{1,32}$\"");
+                if(!command.name.match(/^[-_\p{L}\p{N}\p{sc=Deva}\p{sc=Thai}]{1,32}$/u)) {
+                    throw new Error("Slash Command names must match the regular expression \"^[-_\\p{L}\\p{N}\\p{sc=Deva}\\p{sc=Thai}]{1,32}$\"");
                 }
             }
         }


### PR DESCRIPTION
In the names of slash commands, only the letters of the English alphabet were accepted. However, Discord actually supports all alphabets, but this was being blocked by Eris. For example, in Turkish, the command "/zamanaşımı" (timeout) was being prevented from being added due to the letters "ı" and "ş". Similarly, when creating a Russian command like "/таймаут" (timeout), it was being blocked in the same way. However, Discord actually allows the creation of all these commands.