### PR TITLE
feat(User): Support avatar decorations

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -678,6 +678,7 @@ declare namespace Eris {
   }
   interface OldMember {
     avatar: string | null;
+    avatarDecorationData?: AvatarDecorationData | null;
     communicationDisabledUntil?: number | null;
     nick: string | null;
     pending?: boolean;
@@ -1216,6 +1217,10 @@ declare namespace Eris {
   }
 
   // Member/User
+  interface AvatarDecorationData {
+    asset: string;
+    sku_id: string;
+  }
   interface FetchMembersOptions {
     limit?: number;
     presences?: boolean;
@@ -1241,6 +1246,7 @@ declare namespace Eris {
   interface PartialUser {
     accentColor?: number | null;
     avatar: string | null;
+    avatarDecorationData?: AvatarDecorationData | null;
     banner?: string | null;
     discriminator: string;
     id: string;
@@ -3253,6 +3259,8 @@ declare namespace Eris {
     accentColor?: number | null;
     activities?: Activity[];
     avatar: string | null;
+    avatarDecorationData?: AvatarDecorationData | null;
+    avatarDecorationURL: string | null;
     avatarURL: string;
     banner?: string | null;
     bannerURL: string | null;
@@ -3790,6 +3798,8 @@ declare namespace Eris {
   export class User extends Base {
     accentColor?: number | null;
     avatar: string | null;
+    avatarDecorationData?: AvatarDecorationData | null;
+    avatarDecorationURL: string | null;
     avatarURL: string;
     banner?: string | null;
     bannerURL: string | null;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -765,16 +765,16 @@ class Shard extends EventEmitter {
                     if(!user || oldUser) {
                         user = this.client.users.update(packet.d.user, this.client);
                         /**
-                        * Fired when a user's avatar, avatar decoration, discriminator, display name or username changes
-                        * @event Client#userUpdate
-                        * @prop {User} user The updated user
-                        * @prop {Object?} oldUser The old user data. If the user was uncached, this will be null
-                        * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
-                        * @prop {Object?} oldUser.avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
-                        * @prop {String} oldUser.discriminator The discriminator of the user
-                        * @prop {String?} oldUser.globalName The user's display name, if it is set. For bots, this is the application name
-                        * @prop {String} oldUser.username The username of the user
-                        */
+                         * Fired when a user's avatar, avatar decoration, discriminator, display name or username changes
+                         * @event Client#userUpdate
+                         * @prop {User} user The updated user
+                         * @prop {Object?} oldUser The old user data. If the user was uncached, this will be null
+                         * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
+                         * @prop {Object?} oldUser.avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
+                         * @prop {String} oldUser.discriminator The discriminator of the user
+                         * @prop {String?} oldUser.globalName The user's display name, if it is set. For bots, this is the application name
+                         * @prop {String} oldUser.username The username of the user
+                         */
                         this.emit("userUpdate", user, oldUser);
                     }
                 }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -621,22 +621,24 @@ class Shard extends EventEmitter {
                 if(packet.d.user.username !== undefined) {
                     let user = this.client.users.get(packet.d.user.id);
                     let oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.globalName !== packet.d.user.global_name || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
+                    if(user && (user.username !== packet.d.user.username || user.globalName !== packet.d.user.global_name || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar || (packet.d.user.avatar_decoration_data && user.avatarDecorationData && user.avatarDecorationData.asset !== packet.d.user.avatar_decoration_data.asset))) {
                         oldUser = {
                             username: user.username,
                             globalName: user.globalName,
                             discriminator: user.discriminator,
-                            avatar: user.avatar
+                            avatar: user.avatar,
+                            avatarDecorationData: user.avatarDecorationData
                         };
                     }
                     if(!user || oldUser) {
                         user = this.client.users.update(packet.d.user, this.client);
                         /**
-                        * Fired when a user's avatar, discriminator, display name or username changes
+                        * Fired when a user's avatar, avatar decoration, discriminator, display name or username changes
                         * @event Client#userUpdate
                         * @prop {User} user The updated user
                         * @prop {Object?} oldUser The old user data. If the user was uncached, this will be null
                         * @prop {String?} oldUser.avatar The hash of the user's avatar, or null if no avatar
+                        * @prop {Object?} oldUser.avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
                         * @prop {String} oldUser.discriminator The discriminator of the user
                         * @prop {String?} oldUser.globalName The user's display name, if it is set. For bots, this is the application name
                         * @prop {String} oldUser.username The username of the user
@@ -1138,12 +1140,13 @@ class Shard extends EventEmitter {
                 if(!(this.client.options.intents & Constants.Intents.guildPresences) && packet.d.user.username !== undefined) {
                     let user = this.client.users.get(packet.d.user.id);
                     let oldUser = null;
-                    if(user && (user.username !== packet.d.user.username || user.globalName !== packet.d.user.global_name || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar)) {
+                    if(user && (user.username !== packet.d.user.username || user.globalName !== packet.d.user.global_name || user.discriminator !== packet.d.user.discriminator || user.avatar !== packet.d.user.avatar || (packet.d.user.avatar_decoration_data && user.avatarDecorationData && user.avatarDecorationData.asset !== packet.d.user.avatar_decoration_data.asset))) {
                         oldUser = {
                             username: user.username,
                             globalName: user.globalName,
                             discriminator: user.discriminator,
-                            avatar: user.avatar
+                            avatar: user.avatar,
+                            avatarDecorationData: user.avatarDecorationData
                         };
                     }
                     if(!user || oldUser) {
@@ -2006,7 +2009,8 @@ class Shard extends EventEmitter {
                     oldUser = {
                         username: user.username,
                         discriminator: user.discriminator,
-                        avatar: user.avatar
+                        avatar: user.avatar,
+                        avatarDecorationData: user.avatarDecorationData
                     };
                 }
                 user = this.client.users.update(packet.d, this.client);

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -132,6 +132,7 @@ module.exports.GUILD_SPLASH =                             (guildID, guildSplash)
 module.exports.ROLE_ICON =                                    (roleID, roleIcon) => `/role-icons/${roleID}/${roleIcon}`;
 module.exports.TEAM_ICON =                                    (teamID, teamIcon) => `/team-icons/${teamID}/${teamIcon}`;
 module.exports.USER_AVATAR =                                (userID, userAvatar) => `/avatars/${userID}/${userAvatar}`;
+module.exports.USER_AVATAR_DECORATION =                         (userDecoration) => `/avatar-decoration-presets/${userDecoration}`;
 
 // Client Endpoints
 module.exports.MESSAGE_LINK =                    (guildID, channelID, messageID) => `/channels/${guildID}/${channelID}/${messageID}`;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -7,46 +7,46 @@ const User = require("./User");
 const VoiceState = require("./VoiceState");
 
 /**
-* Represents a server member
-* @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
-* @prop {Array<Object>?} activities The member's current activities
-* @prop {String?} avatar The hash of the member's guild avatar, or null if no guild avatar
-* @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
-* @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
-* @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
-* @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
-* @prop {String?} bannerURL The URL of the user's banner
-* @prop {Boolean} bot Whether the user is an OAuth bot or not
-* @prop {Object?} clientStatus The member's per-client status
-* @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
-* @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
-* @prop {String} clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
-* @prop {Number?} communicationDisabledUntil Timestamp of timeout expiry. If `null`, the member is not timed out
-* @prop {Number} createdAt Timestamp of user creation
-* @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
-* @prop {String} defaultAvatarURL The URL of the user's default avatar
-* @prop {String} discriminator The discriminator of the user. If they've migrated to the new username system, this will be "0"
-* @prop {Object?} game The active game the member is playing
-* @prop {String} game.name The name of the active game
-* @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
-* @prop {String?} game.url The url of the active game
-* @prop {String?} globalName The user's display name, if it is set. For bots, this is the application name
-* @prop {Guild} guild The guild the member is in
-* @prop {String} id The ID of the member
-* @prop {Number?} joinedAt Timestamp of when the member joined the guild
-* @prop {String} mention A string that mentions the member
-* @prop {String?} nick The server nickname of the member
-* @prop {Boolean?} pending Whether the member has passed the guild's Membership Screening requirements
-* @prop {Permission} permission [DEPRECATED] The guild-wide permissions of the member. Use Member#permissions instead
-* @prop {Permission} permissions The guild-wide permissions of the member
-* @prop {Number?} premiumSince Timestamp of when the member boosted the guild
-* @prop {Array<String>} roles An array of role IDs this member is a part of
-* @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
-* @prop {String} status The member's status. Either "online", "idle", "dnd", or "offline"
-* @prop {User} user The user object of the member
-* @prop {String} username The username of the user
-* @prop {VoiceState} voiceState The voice state of the member
-*/
+ * Represents a server member
+ * @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
+ * @prop {Array<Object>?} activities The member's current activities
+ * @prop {String?} avatar The hash of the member's guild avatar, or null if no guild avatar
+ * @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
+ * @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
+ * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
+ * @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
+ * @prop {String?} bannerURL The URL of the user's banner
+ * @prop {Boolean} bot Whether the user is an OAuth bot or not
+ * @prop {Object?} clientStatus The member's per-client status
+ * @prop {String} clientStatus.desktop The member's status on desktop. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+ * @prop {String} clientStatus.mobile The member's status on mobile. Either "online", "idle", "dnd", or "offline". Will be "offline" for bots
+ * @prop {String} clientStatus.web The member's status on web. Either "online", "idle", "dnd", or "offline". Will be "online" for bots
+ * @prop {Number?} communicationDisabledUntil Timestamp of timeout expiry. If `null`, the member is not timed out
+ * @prop {Number} createdAt Timestamp of user creation
+ * @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
+ * @prop {String} defaultAvatarURL The URL of the user's default avatar
+ * @prop {String} discriminator The discriminator of the user. If they've migrated to the new username system, this will be "0"
+ * @prop {Object?} game The active game the member is playing
+ * @prop {String} game.name The name of the active game
+ * @prop {Number} game.type The type of the active game (0 is default, 1 is Twitch, 2 is YouTube)
+ * @prop {String?} game.url The url of the active game
+ * @prop {String?} globalName The user's display name, if it is set. For bots, this is the application name
+ * @prop {Guild} guild The guild the member is in
+ * @prop {String} id The ID of the member
+ * @prop {Number?} joinedAt Timestamp of when the member joined the guild
+ * @prop {String} mention A string that mentions the member
+ * @prop {String?} nick The server nickname of the member
+ * @prop {Boolean?} pending Whether the member has passed the guild's Membership Screening requirements
+ * @prop {Permission} permission [DEPRECATED] The guild-wide permissions of the member. Use Member#permissions instead
+ * @prop {Permission} permissions The guild-wide permissions of the member
+ * @prop {Number?} premiumSince Timestamp of when the member boosted the guild
+ * @prop {Array<String>} roles An array of role IDs this member is a part of
+ * @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
+ * @prop {String} status The member's status. Either "online", "idle", "dnd", or "offline"
+ * @prop {User} user The user object of the member
+ * @prop {String} username The username of the user
+ * @prop {VoiceState} voiceState The voice state of the member
+ */
 class Member extends Base {
     constructor(data, guild, client) {
         super(data.id || data.user.id);

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -11,6 +11,8 @@ const VoiceState = require("./VoiceState");
 * @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
 * @prop {Array<Object>?} activities The member's current activities
 * @prop {String?} avatar The hash of the member's guild avatar, or null if no guild avatar
+* @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
+* @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
 * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
 * @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
 * @prop {String?} bannerURL The URL of the user's banner
@@ -123,6 +125,14 @@ class Member extends Base {
 
     get accentColor() {
         return this.user.accentColor;
+    }
+
+    get avatarDecorationData() {
+        return this.user.avatarDecorationData;
+    }
+
+    get avatarDecorationURL() {
+        return this.user.avatarDecorationURL;
     }
 
     get avatarURL() {

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -195,6 +195,7 @@ class User extends Base {
         return super.toJSON([
             "accentColor",
             "avatar",
+            "avatarDecorationData",
             "banner",
             "bot",
             "discriminator",

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -4,27 +4,27 @@ const Base = require("./Base");
 const Endpoints = require("../rest/Endpoints");
 
 /**
-* Represents a user
-* @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
-* @prop {String?} avatar The hash of the user's avatar, or null if no avatar
-* @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
-* @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
-* @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
-* @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
-* @prop {String?} bannerURL The URL of the user's banner
-* @prop {Boolean} bot Whether the user is an OAuth bot or not
-* @prop {Number} createdAt Timestamp of the user's creation
-* @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
-* @prop {String} defaultAvatarURL The URL of the user's default avatar
-* @prop {String} discriminator The discriminator of the user. If they've migrated to the new username system, this will be "0"
-* @prop {String?} globalName The user's display name, if it is set. For bots, this is the application name
-* @prop {String} id The ID of the user
-* @prop {String} mention A string that mentions the user
-* @prop {Number?} publicFlags Publicly visible flags for this user
-* @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
-* @prop {Boolean} system Whether the user is an official Discord system user (e.g. urgent messages)
-* @prop {String} username The username of the user
-*/
+ * Represents a user
+ * @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
+ * @prop {String?} avatar The hash of the user's avatar, or null if no avatar
+ * @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
+ * @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
+ * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
+ * @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
+ * @prop {String?} bannerURL The URL of the user's banner
+ * @prop {Boolean} bot Whether the user is an OAuth bot or not
+ * @prop {Number} createdAt Timestamp of the user's creation
+ * @prop {String} defaultAvatar The hash for the default avatar of a user if there is no avatar set
+ * @prop {String} defaultAvatarURL The URL of the user's default avatar
+ * @prop {String} discriminator The discriminator of the user. If they've migrated to the new username system, this will be "0"
+ * @prop {String?} globalName The user's display name, if it is set. For bots, this is the application name
+ * @prop {String} id The ID of the user
+ * @prop {String} mention A string that mentions the user
+ * @prop {Number?} publicFlags Publicly visible flags for this user
+ * @prop {String} staticAvatarURL The URL of the user's avatar (always a JPG)
+ * @prop {Boolean} system Whether the user is an official Discord system user (e.g. urgent messages)
+ * @prop {String} username The username of the user
+ */
 class User extends Base {
     constructor(data, client) {
         super(data.id);

--- a/lib/structures/User.js
+++ b/lib/structures/User.js
@@ -7,6 +7,8 @@ const Endpoints = require("../rest/Endpoints");
 * Represents a user
 * @prop {Number?} accentColor The user's banner color, or null if no banner color (REST only)
 * @prop {String?} avatar The hash of the user's avatar, or null if no avatar
+* @prop {Object?} avatarDecorationData The data of the user's avatar decoration, including the asset and sku ID, or null if no avatar decoration
+* @prop {String?} avatarDecorationURL The URL of the user's avatar decoration
 * @prop {String} avatarURL The URL of the user's avatar which can be either a JPG or GIF
 * @prop {String?} banner The hash of the user's banner, or null if no banner (REST only)
 * @prop {String?} bannerURL The URL of the user's banner
@@ -57,6 +59,19 @@ class User extends Base {
         if(data.accent_color !== undefined) {
             this.accentColor = data.accent_color;
         }
+        if(data.avatar_decoration_data !== undefined) {
+            this.avatarDecorationData = data.avatar_decoration_data;
+        }
+    }
+
+    get avatarDecorationURL() {
+        if(!this.avatarDecorationData) {
+            return null;
+        }
+        if(this._missingClientError) {
+            throw this._missingClientError;
+        }
+        return this._client._formatImage(Endpoints.USER_AVATAR_DECORATION(this.avatarDecorationData.asset));
     }
 
     get avatarURL() {


### PR DESCRIPTION
Adds support for user avatar decorations. Avatar decoration properties will also exist within members, to be consistent with other user properties that do the same.

You may notice that some of the properties aren't the same as what's shown on the Discord docs rn. Discord have changed the field names and CDN endpoint for avatar decorations apparently so I used discord/discord-api-docs#6464 to make this PR so I wouldnt have to potentially go back and make changes lol

I'm sure I probably made a mistake in TS docs so any help would be great if you happen to spot any