### PR TITLE
feat(Presence): Allow bots to set custom status

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1520,6 +1520,7 @@ declare namespace Eris {
   }
   interface ActivityPartial<T extends ActivityType> {
     name: string;
+    state?: string;
     type?: T;
     url?: string;
   }

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,7 +155,7 @@ declare namespace Eris {
 
   // Presence/Relationship
   type ActivityFlags = Constants["ActivityFlags"][keyof Constants["ActivityFlags"]];
-  type ActivityType = Constants["ActivityTypes"];
+  type ActivityType = Constants["ActivityTypes"][keyof Constants["ActivityTypes"]];
   type FriendSuggestionReasons = { name: string; platform_type: string; type: number }[];
   type SelfStatus = Status | "invisible";
   type Status = "online" | "idle" | "dnd";

--- a/index.d.ts
+++ b/index.d.ts
@@ -155,8 +155,7 @@ declare namespace Eris {
 
   // Presence/Relationship
   type ActivityFlags = Constants["ActivityFlags"][keyof Constants["ActivityFlags"]];
-  type ActivityType = BotActivityType | Constants["ActivityTypes"]["CUSTOM"];
-  type BotActivityType = Constants["ActivityTypes"][Exclude<keyof Constants["ActivityTypes"], "CUSTOM">];
+  type ActivityType = Constants["ActivityTypes"];
   type FriendSuggestionReasons = { name: string; platform_type: string; type: number }[];
   type SelfStatus = Status | "invisible";
   type Status = "online" | "idle" | "dnd";
@@ -1516,7 +1515,7 @@ declare namespace Eris {
     // the stuff attached to this object apparently varies even more than documented, so...
     [key: string]: unknown;
   }
-  interface ActivityPartial<T extends ActivityType = BotActivityType> {
+  interface ActivityPartial<T extends ActivityType> {
     name: string;
     type?: T;
     url?: string;
@@ -2661,8 +2660,8 @@ declare namespace Eris {
     ): Promise<Connection>;
     editSelfSettings(data: UserSettings): Promise<UserSettings>;
     editStageInstance(channelID: string, options: StageInstanceOptions): Promise<StageInstance>;
-    editStatus(status: SelfStatus, activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
-    editStatus(activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
+    editStatus(status: SelfStatus, activities?: ActivityPartial<ActivityType>[] | ActivityPartial<ActivityType>): void;
+    editStatus(activities?: ActivityPartial<ActivityType>[] | ActivityPartial<ActivityType>): void;
     editUserNote(userID: string, note: string): Promise<void>;
     editWebhook(
       webhookID: string,
@@ -3703,8 +3702,8 @@ declare namespace Eris {
     createGuild(_guild: Guild): Guild;
     disconnect(options?: { reconnect?: boolean | "auto" }, error?: Error): void;
     editAFK(afk: boolean): void;
-    editStatus(status: SelfStatus, activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
-    editStatus(activities?: ActivityPartial<BotActivityType>[] | ActivityPartial<BotActivityType>): void;
+    editStatus(status: SelfStatus, activities?: ActivityPartial<ActivityType>[] | ActivityPartial<ActivityType>): void;
+    editStatus(activities?: ActivityPartial<ActivityType>[] | ActivityPartial<ActivityType>): void;
     // @ts-ignore: Method override
     emit(event: string, ...args: any[]): void;
     emit<K extends keyof ShardEvents>(event: K, ...args: ShardEvents[K]): boolean;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2169,9 +2169,10 @@ class Client extends EventEmitter {
      * Update the bot's status on all guilds
      * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
      * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
-     * @arg {String} activities[].name The name of the activity
+     * @arg {String} [activities[].name] The name of the activity. Note: When setting a custom status, use `state` instead
      * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 4 is custom status, 5 is competing in
      * @arg {String} [activities[].url] The URL of the activity
+     * @arg {String} [activities[].state] The state of the activity. This is the text to be displayed as the bots custom status
      */
     editStatus(status, activities) {
         if(activities === undefined && typeof status === "object") {
@@ -2191,8 +2192,6 @@ class Client extends EventEmitter {
                 activities = activities.map((a) => {
                     if(!a.hasOwnProperty("type")) {
                         a.type = a.url ? 1 : 0;
-                    } else if(a.type === 4) {
-                        a.state = a.name;
                     }
                     return a;
                 });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2182,10 +2182,15 @@ class Client extends EventEmitter {
         if(status) {
             this.presence.status = status;
         }
-        if(activities && !Array.isArray(activities)) {
+        if(activities === null) {
+            activities = [];
+        } else if(activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        this.presence.activities = activities || [];
+        if(activities !== undefined) {
+            this.presence.activities = activities;
+        }
+
         this.shards.forEach((shard) => {
             shard.editStatus(status, activities);
         });

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2173,6 +2173,16 @@ class Client extends EventEmitter {
             activities = [activities];
         }
         if(activities !== undefined) {
+            if(activities.length > 0) {
+                activities = activities.map((a) => {
+                    if(a.hasOwnProperty("type")) {
+                        a.type = a.url ? 1 : 0;
+                    } else if(a.type === 4) {
+                        a.state = a.name;
+                    }
+                    return a;
+                });
+            }
             this.presence.activities = activities;
         }
 

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2189,7 +2189,7 @@ class Client extends EventEmitter {
         if(activities !== undefined) {
             if(activities.length > 0) {
                 activities = activities.map((a) => {
-                    if(a.hasOwnProperty("type")) {
+                    if(!a.hasOwnProperty("type")) {
                         a.type = a.url ? 1 : 0;
                     } else if(a.type === 4) {
                         a.state = a.name;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2156,7 +2156,7 @@ class Client extends EventEmitter {
      * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
      * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
      * @arg {String} activities[].name The name of the activity
-     * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
+     * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 4 is custom status, 5 is competing in
      * @arg {String} [activities[].url] The URL of the activity
      */
     editStatus(status, activities) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2182,23 +2182,10 @@ class Client extends EventEmitter {
         if(status) {
             this.presence.status = status;
         }
-        if(activities === null) {
-            activities = [];
-        } else if(activities && !Array.isArray(activities)) {
+        if(activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        if(activities !== undefined) {
-            if(activities.length > 0) {
-                activities = activities.map((a) => {
-                    if(!a.hasOwnProperty("type")) {
-                        a.type = a.url ? 1 : 0;
-                    }
-                    return a;
-                });
-            }
-            this.presence.activities = activities;
-        }
-
+        this.presence.activities = activities || [];
         this.shards.forEach((shard) => {
             shard.editStatus(status, activities);
         });

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -229,10 +229,15 @@ class Shard extends EventEmitter {
         if(status) {
             this.presence.status = status;
         }
-        if(activities && !Array.isArray(activities)) {
+        if(activities === null) {
+            activities = [];
+        } else if(activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        this.presence.activities = activities || [];
+        if(activities !== undefined) {
+            this.presence.activities = activities;
+        }
+
         this.sendStatusUpdate();
     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -229,23 +229,10 @@ class Shard extends EventEmitter {
         if(status) {
             this.presence.status = status;
         }
-        if(activities === null) {
-            activities = [];
-        } else if(activities && !Array.isArray(activities)) {
+        if(activities && !Array.isArray(activities)) {
             activities = [activities];
         }
-        if(activities !== undefined) {
-            if(activities.length > 0) {
-                activities = activities.map((a) => {
-                    if(!a.hasOwnProperty("type")) {
-                        a.type = a.url ? 1 : 0;
-                    }
-                    return a;
-                });
-            }
-            this.presence.activities = activities;
-        }
-
+        this.presence.activities = activities || [];
         this.sendStatusUpdate();
     }
 

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -217,7 +217,7 @@ class Shard extends EventEmitter {
      * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
      * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
      * @arg {String} activities[].name The name of the activity
-     * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 5 is competing in
+     * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 4 is custom status, 5 is competing in
      * @arg {String} [activities[].url] The URL of the activity
      */
     editStatus(status, activities) {
@@ -234,8 +234,15 @@ class Shard extends EventEmitter {
             activities = [activities];
         }
         if(activities !== undefined) {
-            if(activities.length > 0 && !activities[0].hasOwnProperty("type")) {
-                activities[0].type = activities[0].url ? 1 : 0;
+            if(activities.length > 0) {
+                activities = activities.map((a) => {
+                    if(a.hasOwnProperty("type")) {
+                        a.type = a.url ? 1 : 0;
+                    } else if(a.type === 4) {
+                        a.state = a.name;
+                    }
+                    return a;
+                });
             }
             this.presence.activities = activities;
         }

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -236,7 +236,7 @@ class Shard extends EventEmitter {
         if(activities !== undefined) {
             if(activities.length > 0) {
                 activities = activities.map((a) => {
-                    if(a.hasOwnProperty("type")) {
+                    if(!a.hasOwnProperty("type")) {
                         a.type = a.url ? 1 : 0;
                     } else if(a.type === 4) {
                         a.state = a.name;

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -216,9 +216,10 @@ class Shard extends EventEmitter {
      * Updates the bot's status on all guilds the shard is in
      * @arg {String} [status] Sets the bot's status, either "online", "idle", "dnd", or "invisible"
      * @arg {Array | Object} [activities] Sets the bot's activities. A single activity object is also accepted for backwards compatibility
-     * @arg {String} activities[].name The name of the activity
+     * @arg {String} [activities[].name] The name of the activity. Note: When setting a custom status, use `state` instead
      * @arg {Number} activities[].type The type of the activity. 0 is playing, 1 is streaming (Twitch only), 2 is listening, 3 is watching, 4 is custom status, 5 is competing in
      * @arg {String} [activities[].url] The URL of the activity
+     * @arg {String} [activities[].state] The state of the activity. This is the text to be displayed as the bots custom status
      */
     editStatus(status, activities) {
         if(activities === undefined && typeof status === "object") {

--- a/lib/gateway/Shard.js
+++ b/lib/gateway/Shard.js
@@ -238,8 +238,6 @@ class Shard extends EventEmitter {
                 activities = activities.map((a) => {
                     if(!a.hasOwnProperty("type")) {
                         a.type = a.url ? 1 : 0;
-                    } else if(a.type === 4) {
-                        a.state = a.name;
                     }
                     return a;
                 });


### PR DESCRIPTION
[Docs reference](https://github.com/discord/discord-api-docs/pull/6345)

~~WIP. Needs reviewing by a collab to tell me whether they prefer Eris handling it this way, or whether they want me to add an `activities[].state` prop that users specifically need to use to set custom statuses.~~

## Changes
 - Added `activities[].state` prop to use when setting a custom status
 - Removed `BotActivityType` type from TSdocs, since it is now the same as `ActivityType`
 - ~~Validate the `type` prop on all activity objects, rather than just the first one~~