### PR TITLE
refactor: Properly support many new Discord properties

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1045,7 +1045,7 @@ declare namespace Eris {
     after?: string;
     before?: string;
     limit?: number;
-    withCounts: boolean;
+    withCounts?: boolean;
   }
   interface GuildAuditLog {
     entries: GuildAuditLogEntry[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -1368,6 +1368,7 @@ declare namespace Eris {
     duration_secs?: number;
     ephemeral?: boolean;
     filename: string;
+    flags?: number;
     height?: number;
     id: string;
     proxy_url: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1365,6 +1365,7 @@ declare namespace Eris {
   }
   interface Attachment extends PartialAttachment {
     content_type?: string;
+    duration_secs?: number;
     ephemeral?: boolean;
     filename: string;
     height?: number;
@@ -1372,6 +1373,7 @@ declare namespace Eris {
     proxy_url: string;
     size: number;
     url: string;
+    waveform?: string;
     width?: number;
   }
   interface ButtonBase {
@@ -1761,6 +1763,9 @@ declare namespace Eris {
       CHAT_INPUT: 1;
       USER:       2;
       MESSAGE:    3;
+    };
+    AttachmentFlags: {
+      IS_REMIX: 4;
     };
     AuditLogActions: {
       GUILD_UPDATE: 1;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1045,6 +1045,7 @@ declare namespace Eris {
     after?: string;
     before?: string;
     limit?: number;
+    withCounts: boolean;
   }
   interface GuildAuditLog {
     entries: GuildAuditLogEntry[];

--- a/index.d.ts
+++ b/index.d.ts
@@ -82,7 +82,7 @@ declare namespace Eris {
 
   // Client
   type MembershipStates = Constants["MembershipState"][keyof Constants["MembershipState"]];
-  type OAuthTeamMemberRoleTypes = Constants["OAuthTeamMemberRoleTypes"][keyof Constants["OAuthTeamMemberRoleTypes"]]
+  type OAuthTeamMemberRoleTypes = Constants["OAuthTeamMemberRoleTypes"][keyof Constants["OAuthTeamMemberRoleTypes"]];
 
   // Command
   type CommandGenerator = CommandGeneratorFunction | MessageContent | MessageContent[] | CommandGeneratorFunction[];
@@ -2007,11 +2007,11 @@ declare namespace Eris {
     GuildOnboardingModes: {
       ONBOARDING_DEFAULT:  0;
       ONBOARDING_ADVANCED: 1;
-    }
+    };
     GuildOnboardingPromptTypes: {
       MULTIPLE_CHOICE: 0;
       DROPDOWN:        1;
-    }
+    };
     GuildScheduledEventEntityTypes: {
       STAGE_INSTANCE: 1;
       VOICE: 2;
@@ -2096,7 +2096,7 @@ declare namespace Eris {
       COMPLETED_ONBOARDING:  2;
       BYPASSES_VERIFICATION: 4;
       STARTED_ONBOARDING:    8;
-    }
+    };
     MessageActivityTypes: {
       JOIN:         1;
       SPECTATE:     2;
@@ -2165,7 +2165,7 @@ declare namespace Eris {
       DEVELOPER: "developer";
       OWNER:     "";
       READ_ONLY: "read_only";
-    }
+    };
     PermissionOverwriteTypes: {
       ROLE: 0;
       USER: 1;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3211,7 +3211,7 @@ class Client extends EventEmitter {
      * @arg {Object} [options] Options for the request. If this is a number ([DEPRECATED] behavior), it is treated as `options.limit`
      * @arg {String} [options.after] The highest guild ID of the previous page
      * @arg {String} [options.before] The lowest guild ID of the next page
-     * @arg {Number} [options.limit=100] The max number of guilds to get (1 to 1000)
+     * @arg {Number} [options.limit=100] The max number of guilds to get (1 to 200)
      * @arg {Boolean} [options.withCounts=false] Whether to include approximate member and presence counts
      * @arg {String} [before] [DEPRECATED] The lowest guild ID of the next page
      * @arg {String} [after] [DEPRECATED] The highest guild ID of the previous page

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3212,6 +3212,7 @@ class Client extends EventEmitter {
      * @arg {String} [options.after] The highest guild ID of the previous page
      * @arg {String} [options.before] The lowest guild ID of the next page
      * @arg {Number} [options.limit=100] The max number of guilds to get (1 to 1000)
+     * @arg {Boolean} [options.withCounts=false] Whether to include approximate member and presence counts
      * @arg {String} [before] [DEPRECATED] The lowest guild ID of the next page
      * @arg {String} [after] [DEPRECATED] The highest guild ID of the previous page
      * @returns {Promise<Array<Guild>>}
@@ -3232,6 +3233,7 @@ class Client extends EventEmitter {
         if(before !== undefined) {
             options.before = before;
         }
+        options.with_counts = options.withCounts;
         return this.requestHandler.request("GET", Endpoints.USER_GUILDS("@me"), true, options).then((guilds) => guilds.map((guild) => new Guild(guild, this)));
     }
 

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -50,6 +50,10 @@ module.exports.ApplicationCommandTypes = {
     MESSAGE:    3
 };
 
+module.exports.AttachmentFlags = {
+    IS_REMIX: 1 << 2
+};
+
 module.exports.AuditLogActions = {
     GUILD_UPDATE: 1,
 


### PR DESCRIPTION
- Support `with_counts` option in Client#getRESTGuilds(): [Docs reference](https://discord.com/developers/docs/resources/user#get-current-user-guilds-query-string-params)
- Add attachment flags: [Docs reference](https://discord.com/developers/docs/resources/channel#attachment-object)
- Document voice message properties within attachments: [Docs reference](https://discord.com/developers/docs/resources/channel#attachment-object)