### PR TITLE
feat(ThreadChannel): Thread member pagination

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1730,6 +1730,11 @@ declare namespace Eris {
     before?: Date;
     limit?: number;
   }
+  interface GetThreadMembersOptions {
+    after?: string;
+    limit?: number;
+    withMember?: boolean;
+  }
   interface ListedChannelThreads<T extends ThreadChannel = AnyThreadChannel> extends ListedGuildThreads<T> {
     hasMore: boolean;
   }
@@ -3021,7 +3026,8 @@ declare namespace Eris {
     }[]>;
     getSelfSettings(): Promise<UserSettings>;
     getStageInstance(channelID: string): Promise<StageInstance>;
-    getThreadMembers(channelID: string): Promise<ThreadMember[]>;
+    getThreadMember(channelID: string, userID: string, withMember?: boolean): Promise<ThreadMember>;
+    getThreadMembers(channelID: string, options?: GetThreadMembersOptions): Promise<ThreadMember[]>;
     getUserProfile(userID: string): Promise<UserProfile>;
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;
     getWebhook(webhookID: string, token?: string): Promise<Webhook>;
@@ -4107,7 +4113,7 @@ declare namespace Eris {
     constructor(data: BaseData, client: Client);
     edit(options: EditThreadChannelOptions, reason?: string): Promise<this>;
     getMember(userID: string, withMember?: boolean): Promise<ThreadMember>;
-    getMembers(): Promise<ThreadMember[]>;
+    getMembers(options?: GetThreadMembersOptions): Promise<ThreadMember[]>;
     getPins(): Promise<Message<this>[]>;
     join(userID?: string): Promise<void>;
     leave(userID?: string): Promise<void>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3505,7 +3505,7 @@ class Client extends EventEmitter {
      * @arg {Boolean} [options.withMember] Whether to include the guild member object for each member of the thread
      * @returns {Promise<Array<ThreadMember>>}
      */
-    getThreadMembers(channelID, options) {
+    getThreadMembers(channelID, options = {}) {
         return this.requestHandler.request("GET", Endpoints.THREAD_MEMBERS(channelID), true, {
             after: options.after,
             limit: options.limit,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3499,10 +3499,18 @@ class Client extends EventEmitter {
     /**
      * Get a list of members that are part of a thread channel
      * @arg {String} channelID The ID of the thread channel
+     * @arg {Object} [options] Options for the request
+     * @arg {String} [options.after] Get members after this user ID
+     * @arg {Number} [options.limit=100] The maximum number of thread members to fetch (1-100)
+     * @arg {Boolean} [options.withMember] Whether to include the guild member object for each member of the thread
      * @returns {Promise<Array<ThreadMember>>}
      */
-    getThreadMembers(channelID) {
-        return this.requestHandler.request("GET", Endpoints.THREAD_MEMBERS(channelID), true).then((members) => members.map((member) => new ThreadMember(member, this)));
+    getThreadMembers(channelID, options) {
+        return this.requestHandler.request("GET", Endpoints.THREAD_MEMBERS(channelID), true, {
+            after: options.after,
+            limit: options.limit,
+            with_member: options.withMember
+        }).then((members) => members.map((member) => new ThreadMember(member, this)));
     }
 
     /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3487,7 +3487,7 @@ class Client extends EventEmitter {
      * Get a member that is part of a thread channel
      * @arg {String} channelID The ID of the thread channel
      * @arg {String} userID The ID of the user
-     * @arg {Boolean} withMember Whether to include the guild member object within the response
+     * @arg {Boolean} [withMember] Whether to include the guild member object within the response
      * @returns {Promise<ThreadMember>}
      */
     getThreadMember(channelID, userID, withMember) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3491,7 +3491,7 @@ class Client extends EventEmitter {
      * @returns {Promise<ThreadMember>}
      */
     getThreadMember(channelID, userID, withMember) {
-        return this.requestHandler.request("GET", Endpoints.THREAD_MEMBER(channelID, userID), {
+        return this.requestHandler.request("GET", Endpoints.THREAD_MEMBER(channelID, userID), true, {
             with_member: withMember
         }).then((threadMember) => new ThreadMember(threadMember, this));
     }

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -69,10 +69,14 @@ class ThreadChannel extends GuildTextableChannel {
 
     /**
      * Get a list of members that are part of this thread channel
+     * @arg {Object} [options] Options for the request
+     * @arg {String} [options.after] Get members after this user ID
+     * @arg {Number} [options.limit=100] The maximum number of thread members to fetch (1-100)
+     * @arg {Boolean} [options.withMember] Whether to include the guild member object for each member of the thread
      * @returns {Promise<Array<ThreadMember>>}
      */
-    getMembers() {
-        return this._client.getThreadMembers.call(this._client, this.id);
+    getMembers(options) {
+        return this._client.getThreadMembers.call(this._client, this.id, options);
     }
 
     /**

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -60,7 +60,7 @@ class ThreadChannel extends GuildTextableChannel {
     /**
      * Get a member that is part of the thread channel
      * @arg {String} userID The ID of the user
-     * @arg {Boolean} withMember Whether to include the guild member object within the response
+     * @arg {Boolean} [withMember] Whether to include the guild member object within the response
      * @returns {Promise<ThreadMember>}
      */
     getMember(userID, withMember) {

--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -19,6 +19,9 @@ class ThreadMember extends Base {
 
         if(data.member !== undefined) {
             const guild = this._client.guilds.get(this._client.threadGuildMap[this.threadID]);
+            if(data.user_id) {
+                data.member.id = data.user_id;
+            }
             this.guildMember = guild.members.update(data.member, guild);
             if(data.presence !== undefined) {
                 this.guildMember.update(data.presence);


### PR DESCRIPTION
## Add thread member pagination options

Ref:
- discord/discord-api-docs#5834

## Additions/Changes
- Added `after`, `limit` & `withMember` options to `Client#getThreadMembers()` and `ThreadChannel#getMembers()`
- Typed `Client#getThreadMember()`
- Fixed `Client#getThreadMember()` function not sending the `with_member` option properly
- Fixed `Client#getThreadMember()` & `ThreadChannel#getMember()` js doc