### PR TITLE
Added missing createdAt prop from Interaction's docs

### DIFF
--- a/lib/structures/AutocompleteInteraction.js
+++ b/lib/structures/AutocompleteInteraction.js
@@ -9,6 +9,7 @@ const {InteractionResponseTypes} = require("../Constants");
  * @extends Interaction
  * @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
  * @prop {DMChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id if the channel is not cached
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Object} data The data attached to the interaction
  * @prop {String} data.id The ID of the Application Command
  * @prop {String} data.name The command name

--- a/lib/structures/CommandInteraction.js
+++ b/lib/structures/CommandInteraction.js
@@ -16,6 +16,7 @@ const {InteractionResponseTypes} = require("../Constants");
  * @extends Interaction
  * @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
  * @prop {DMChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id if the channel is not cached
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Object} data The data attached to the interaction
  * @prop {String} data.id The ID of the Application Command
  * @prop {String} data.name The command name

--- a/lib/structures/ComponentInteraction.js
+++ b/lib/structures/ComponentInteraction.js
@@ -10,6 +10,7 @@ const {InteractionResponseTypes} = require("../Constants");
  * @extends Interaction
  * @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
  * @prop {DMChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id if the channel is not cached
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Object} data The data attached to the interaction
  * @prop {Number} data.component_type The type of Message Component
  * @prop {String} data.custom_id The ID of the Message Component

--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -5,9 +5,9 @@ const {InteractionTypes} = require("../Constants");
 
 /**
  * Represents an interaction. You also probably want to look at PingInteraction, CommandInteraction, ComponentInteraction, AutocompleteInteraction, ModalSubmitInteraction, and UnknownInteraction.
- * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Boolean} acknowledged Whether or not the interaction has been acknowledged
  * @prop {String} applicationID The ID of the interaction's application
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {String} id The ID of the interaction
  * @prop {String} token The interaction token (Interaction tokens are valid for 15 minutes after initial response and can be used to send followup messages but you must send an initial response within 3 seconds of receiving the event. If the 3 second deadline is exceeded, the token will be invalidated.)
  * @prop {Number} type 1 is a Ping, 2 is an Application Command, 3 is a Message Component, 4 is a Modal Submit

--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -5,6 +5,7 @@ const {InteractionTypes} = require("../Constants");
 
 /**
  * Represents an interaction. You also probably want to look at PingInteraction, CommandInteraction, ComponentInteraction, AutocompleteInteraction, ModalSubmitInteraction, and UnknownInteraction.
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Boolean} acknowledged Whether or not the interaction has been acknowledged
  * @prop {String} applicationID The ID of the interaction's application
  * @prop {String} id The ID of the interaction

--- a/lib/structures/ModalSubmitInteraction.js
+++ b/lib/structures/ModalSubmitInteraction.js
@@ -7,6 +7,7 @@ const {InteractionResponseTypes} = require("../Constants");
  * Represents a modal submit interaction. See Interaction for more properties
  * @extends Interaction
  * @prop {DMChannel | TextChannel | NewsChannel} channel The channel the interaction was created in. Can be partial with only the id if the channel is not cached
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Object} data The data attached to the interaction
  * @prop {String} data.custom_id The ID of the Modal
  * @prop {Array<Object>} data.components The values submitted by the user

--- a/lib/structures/PingInteraction.js
+++ b/lib/structures/PingInteraction.js
@@ -6,6 +6,7 @@ const {InteractionResponseTypes} = require("../Constants");
 /**
  * Represents a ping interaction. See Interaction for more properties.
  * @extends Interaction
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  */
 class PingInteraction extends Interaction {
     constructor(info, client) {

--- a/lib/structures/UnknownInteraction.js
+++ b/lib/structures/UnknownInteraction.js
@@ -12,6 +12,7 @@ const {InteractionResponseTypes} = require("../Constants");
  * @extends Interaction
  * @prop {Permission?} appPermissions The permissions the app or bot has within the channel the interaction was sent from
  * @prop {(DMChannel | TextChannel | NewsChannel)?} channel The channel the interaction was created in. Can be partial with only the id if the channel is not cached.
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {Object?} data The data attached to the interaction
  * @prop {String?} guildID The ID of the guild in which the interaction was created
  * @prop {Member?} member The member who triggered the interaction (This is only sent when the interaction is invoked within a guild)


### PR DESCRIPTION
I noticed that the createdAt property is missing from the Interaction's documentation page, so I added it like it's added in the Channel's docs, but I have a suggestion for better readability of the documentation. Wouldn't it be better to show that the Interaction, Channel, Message etc are extending Base, and don't show the properties from the parent class? I think that the way it is done currently slightly hurts the readability because it doesn't tell the whole exact story, for example, GuildChannel extends Channel, and it is shown in the GuildChannel's docs, but the GuildChannel's docs duplicate properties that are in the Channel's docs, but not always all of them like in the Interaction's case. If this suggestion looks good for y'all, I can close this pull request and create another one with this suggestion. Maybe properties from the parent classes can be shown in a separate section "Inherited from ..." on the docs website, but I don't know if jsdoc supports something like that.