### PR TITLE
Added missing createdAt prop from Interaction's docs

### DIFF
--- a/lib/structures/Interaction.js
+++ b/lib/structures/Interaction.js
@@ -7,6 +7,7 @@ const {InteractionTypes} = require("../Constants");
  * Represents an interaction. You also probably want to look at PingInteraction, CommandInteraction, ComponentInteraction, AutocompleteInteraction, ModalSubmitInteraction, and UnknownInteraction.
  * @prop {Boolean} acknowledged Whether or not the interaction has been acknowledged
  * @prop {String} applicationID The ID of the interaction's application
+ * @prop {Number} createdAt Timestamp of the interaction's creation
  * @prop {String} id The ID of the interaction
  * @prop {String} token The interaction token (Interaction tokens are valid for 15 minutes after initial response and can be used to send followup messages but you must send an initial response within 3 seconds of receiving the event. If the 3 second deadline is exceeded, the token will be invalidated.)
  * @prop {Number} type 1 is a Ping, 2 is an Application Command, 3 is a Message Component, 4 is a Modal Submit


### PR DESCRIPTION
I noticed that the `createdAt` property is missing from the Interaction's documentation page, so I added it like it's added in e.g. the Channel's docs.