### PR TITLE
fix(voice): OggOpusTransformer missing callback in _final

### DIFF
--- a/lib/voice/streams/OggOpusTransformer.js
+++ b/lib/voice/streams/OggOpusTransformer.js
@@ -73,10 +73,11 @@ class OggOpusTransformer extends BaseTransformer {
         }
     }
 
-    _final() {
+    _final(cb) {
         if(!this._bitstream) {
             this.emit("error", new Error("No Opus stream was found"));
         }
+        cb()
     }
 
     _transform(chunk, enc, cb) {


### PR DESCRIPTION
I discovered this when I tried to increase `voiceDataTimeout` and noticed the `end` event was later than expected.
Because the stream does not emit `end`, it will stop playing after waiting for timeout, not when the file ends.

ref: https://nodejs.org/docs/latest-v20.x/api/stream.html#writable_finalcallback