### PR TITLE
fix: export everything under the lib for new versions of node

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
       "./index.js"
     ],
     "./": "./",
+    "./*": "./*.js",
     "./esm": "./esm.mjs"
   },
   "typings": "./index.d.ts",


### PR DESCRIPTION
I don't know why but apparently this was changed in node 18+ (I'm guessing)