### PR TITLE
fix(Member): fix updating from voice state updates

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -78,6 +78,18 @@ class Member extends Base {
     }
 
     update(data) {
+        // Handle updates from voice states
+        if(data.hasOwnProperty("member") && data.hasOwnProperty("channel_id") && this.guild) {
+            const state = this.guild.voiceStates.get(this.id);
+            if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
+                this.guild.voiceStates.delete(this.id);
+            } else if(state) {
+                state.update(data);
+            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
+                this.guild.voiceStates.update(data);
+            }
+            data = data.member;
+        }
         if(data.status !== undefined) {
             this.status = data.status;
         }
@@ -92,16 +104,6 @@ class Member extends Base {
         }
         if(data.premium_since !== undefined) {
             this.premiumSince = data.premium_since === null ? null : Date.parse(data.premium_since);
-        }
-        if(data.hasOwnProperty("mute") && this.guild) {
-            const state = this.guild.voiceStates.get(this.id);
-            if(data.channel_id === null && !data.mute && !data.deaf) {
-                this.guild.voiceStates.delete(this.id);
-            } else if(state) {
-                state.update(data);
-            } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
-                this.guild.voiceStates.update(data);
-            }
         }
         if(data.nick !== undefined) {
             this.nick = data.nick;
@@ -124,6 +126,9 @@ class Member extends Base {
         }
         if(data.flags !== undefined) {
             this.flags = data.flags;
+        }
+        if(data.user !== undefined) {
+            this.user.update(data.user);
         }
     }
 


### PR DESCRIPTION
Since this is kinda active again, this is a mirror of this PR: https://github.com/projectdysnomia/dysnomia/pull/131
> Noticed that voice updates don't also update member's roles, so this should update that stuff (and also update user stuff)
> 
> This is really only useful for use cases where you aren't receiving member/user updates already.