### PR TITLE
fix(Member): fix voice state not updated when `member` field is missing.

### DIFF
--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -96,7 +96,7 @@ class Member extends Base {
             this.status = data.status;
         }
         if(data.joined_at !== undefined) {
-            this.joinedAt = data.joined_at ?  Date.parse(data.joined_at) : null;
+            this.joinedAt = data.joined_at ? Date.parse(data.joined_at) : null;
         }
         if(data.client_status !== undefined) {
             this.clientStatus = Object.assign({web: "offline", desktop: "offline", mobile: "offline"}, data.client_status);

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -79,7 +79,7 @@ class Member extends Base {
 
     update(data) {
         // Handle updates from voice states
-        if(data.hasOwnProperty("member") && data.hasOwnProperty("channel_id") && this.guild) {
+        if(data.hasOwnProperty("channel_id") && this.guild) {
             const state = this.guild.voiceStates.get(this.id);
             if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
                 this.guild.voiceStates.delete(this.id);
@@ -88,7 +88,9 @@ class Member extends Base {
             } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
                 this.guild.voiceStates.update(data);
             }
-            data = data.member;
+            if(data.hasOwnProperty("member")){
+                data = data.member;
+            }
         }
         if(data.status !== undefined) {
             this.status = data.status;

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -88,7 +88,7 @@ class Member extends Base {
             } else if(data.channel_id || data.mute || data.deaf || data.suppress) {
                 this.guild.voiceStates.update(data);
             }
-            if(data.hasOwnProperty("member")){
+            if(data.hasOwnProperty("member")) {
                 data = data.member;
             }
         }

--- a/lib/structures/Member.js
+++ b/lib/structures/Member.js
@@ -81,7 +81,7 @@ class Member extends Base {
         // Handle updates from voice states
         if(data.hasOwnProperty("channel_id") && this.guild) {
             const state = this.guild.voiceStates.get(this.id);
-            if(data.channel_id === null && !data.mute && !data.deaf && !data.suppress) {
+            if(data.channel_id === null && !data.mute && !data.deaf) {
                 this.guild.voiceStates.delete(this.id);
             } else if(state) {
                 state.update(data);


### PR DESCRIPTION
Fix: #1522

Currently, the voice state is only updated if the data has `member` field. However, the `member` field is optional in [Voice State object](https://discord.com/developers/docs/resources/voice#voice-state-object-voice-state-structure), leading to incorrect update handling. This PR ensures that the voice state is updated even when the `member` field is not present.