### PR TITLE
Makes channel_types an array of ChannelTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -230,7 +230,7 @@ declare namespace Eris {
     id?: string;
   }
   interface ApplicationCommandOption<T extends Constants["ApplicationCommandOptionTypes"][Exclude<keyof Constants["ApplicationCommandOptionTypes"], "SUB_COMMAND" | "SUB_COMMAND_GROUP">]> {
-    channel_types: T extends Constants["ApplicationCommandOptionTypes"]["CHANNEL"] ? ChannelTypes | undefined : never;
+    channel_types: T extends Constants["ApplicationCommandOptionTypes"]["CHANNEL"] ? ChannelTypes[] | undefined : never;
     description: string;
     descriptionLocalizations?:  Record<LocaleStrings, string> | null;
     name: string;


### PR DESCRIPTION
Fixed the channel_types property so it would not throw a type error when i try to use an array for channel_types (and to throw an error when not) as stated in the [Application Command Option Structure](https://discord.com/developers/docs/interactions/application-commands#application-command-object-application-command-option-structure)