### PR TITLE
fix(ThreadMember): data.presence can be null

### DIFF
--- a/lib/structures/ThreadMember.js
+++ b/lib/structures/ThreadMember.js
@@ -23,7 +23,7 @@ class ThreadMember extends Base {
         data.member.id = data.user_id;
       }
       this.guildMember = guild.members.update(data.member, guild);
-      if (data.presence !== undefined) {
+      if (data.presence) {
         this.guildMember.update(data.presence);
       }
     }


### PR DESCRIPTION
Resolves **TypeError: Cannot read properties of null (reading 'hasOwnProperty')** when `data.presence` is null. This occurs when mentioning a member in a thread where they are not a participant.