### PR TITLE
fix(DMChannel, GroupChannel): Missing client in constructor

### DIFF
--- a/lib/structures/DMChannel.js
+++ b/lib/structures/DMChannel.js
@@ -22,7 +22,7 @@ class DMChannel extends Channel {
     this.lastMessageID = data.last_message_id;
     this.recipients = new Collection(User);
     data.recipients.forEach((recipient) => {
-      this.recipients.add(client.users.add(recipient));
+      this.recipients.add(client.users.add(recipient, client));
     });
     this.messages = new Collection(Message, client.options.messageLimit);
 

--- a/lib/structures/GroupChannel.js
+++ b/lib/structures/GroupChannel.js
@@ -30,7 +30,7 @@ class GroupChannel extends Channel {
     this.icon = data.icon;
     this.recipients = new Collection(User);
     data.recipients.forEach((recipient) => {
-      this.recipients.add(client.users.add(recipient));
+      this.recipients.add(client.users.add(recipient, client));
     });
   }
 


### PR DESCRIPTION
Fix 'Missing client in constructor' error in DM and group channels