### PR TITLE
fix(VoiceConnection): do not reconnect if close code is 4014 (Disconnected)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -876,7 +876,7 @@ declare namespace Eris {
     channelDelete: [channel: Exclude<AnyChannel, GroupChannel>];
     channelPinUpdate: [channel: TextableChannel, timestamp: number, oldTimestamp: number];
     channelUpdate: [channel: AnyGuildChannel, oldChannel: OldGuildChannel | OldForumChannel | OldGuildTextChannel | OldVoiceChannel]
-    | [channel: GroupChannel, oldChannel: OldGroupChannel];
+      | [channel: GroupChannel, oldChannel: OldGroupChannel];
     connect: [id: number];
     debug: [message: string, id?: number];
     disconnect: [];
@@ -933,7 +933,7 @@ declare namespace Eris {
     threadMemberUpdate: [channel: AnyThreadChannel, member: ThreadMember, oldMember: OldThreadMember];
     threadUpdate: [channel: AnyThreadChannel, oldChannel: OldThread | null];
     typingStart: [channel: AnyGuildTextableChannel | Uncached, user: User | Uncached, member: Member]
-    | [channel: DMChannel | Uncached, user: User | Uncached, member: null];
+      | [channel: DMChannel | Uncached, user: User | Uncached, member: null];
     unavailableGuildCreate: [guild: UnavailableGuild];
     unknown: [packet: RawPacket, id?: number];
     userUpdate: [user: User, oldUser: PartialUser | null];

--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -366,28 +366,18 @@ class VoiceConnection extends EventEmitter {
       this.emit("error", err);
     });
     this.ws.on("close", (code, reason) => {
-      let err = !code || code === 1000 ? null : new Error(code + ": " + reason);
+      const err = !code || code === 1000 ? null : new Error(code + ": " + reason);
       this.emit("warn", `Voice WS close ${code}: ${reason}`);
       if (this.connecting || this.ready) {
         let reconnecting = true;
-        if (code < 4000 || code === 4015) {
+        if ((code !== 1000 && code < 4000) || code === 4015) {
           this.resuming = true;
           setTimeout(() => {
             this.connect(data);
           }, 500).unref();
           return;
         }
-        if (code === 4006) {
-          reconnecting = false;
-        } else if (code === 4014) {
-          if (this.channelID) {
-            data.endpoint = null;
-            reconnecting = true;
-            err = null;
-          } else {
-            reconnecting = false;
-          }
-        } else if (code === 1000) {
+        if (code === 1000 || code === 4006 || code === 4014) {
           reconnecting = false;
         }
         this.disconnect(err, reconnecting);


### PR DESCRIPTION
Fixes: #1437

[As described in the docs](https://discord.com/developers/docs/topics/opcodes-and-status-codes#voice-voice-close-event-codes), voice should not reconnect if close code is 4014 (Disconnected).

