### PR TITLE
Fix(Scheduled Events): editGuildScheduledEvent return class

### DIFF
--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1871,7 +1871,7 @@ class Client extends EventEmitter {
       scheduled_start_time: event.scheduledStartTime,
       status: event.status,
       reason: reason,
-    });
+    }).then((data) => new GuildScheduledEvent(data, this));
   }
 
   /**

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -206,6 +206,12 @@ class Guild extends Base {
         }
       }
     }
+
+    if (data.guild_scheduled_events) {
+      for (const eventData of data.guild_scheduled_events) {
+        this.events.add(eventData, client);
+      }
+    }
     this.update(data);
   }
 


### PR DESCRIPTION
Ref:

- https://github.com/abalabahaha/eris/issues/1549

---

- Return GuildScheduledEvent class in `Client#editGuildScheduledEvent()`
- Add scheduled events to events collection on `GUILD_CREATE`

Fixes #1549