### PR TITLE
Fix incorrect channel_types type for ApplicationCommandOptionTypes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -231,7 +231,7 @@ declare namespace Eris {
     id?: string;
   }
   interface ApplicationCommandOption<T extends Constants["ApplicationCommandOptionTypes"][Exclude<keyof Constants["ApplicationCommandOptionTypes"], "SUB_COMMAND" | "SUB_COMMAND_GROUP">]> {
-    channel_types: T extends Constants["ApplicationCommandOptionTypes"]["CHANNEL"] ? ChannelTypes | undefined : never;
+    channel_types: T extends Constants["ApplicationCommandOptionTypes"]["CHANNEL"] ? ChannelTypes[] | undefined : never;
     description: string;
     descriptionLocalizations?: Record<LocaleStrings, string> | null;
     name: string;


### PR DESCRIPTION
The Discord API expects the `channel_types` field for a command option to be provided as an array of `ChannelTypes` instead of a singular `ChannelTypes` value.

This fixes the following error when creating a command with a command option specifying a channel.
![image](https://github.com/user-attachments/assets/8fc080ea-f0f6-4733-8860-1db6ba336510)
