### PR TITLE
typings(Message): Update snapshot message fields

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1612,7 +1612,7 @@ declare namespace Eris {
   }
   interface MessageSnapshot {
     guildID?: string;
-    message: Pick<Message, "attachments" | "content" | "components" | "editedTimestamp" | "embeds" | "flags" | "id" | "mentions" | "roleMentions" | "timestamp" | "stickers" | "stickerItems" | "type">;
+    message: Pick<Message, "attachments" | "components" | "content" | "editedTimestamp" | "embeds" | "flags" | "id" | "mentions" | "roleMentions" | "stickerItems" | "stickers" | "timestamp" | "type">;
   }
   interface PartialAttachment {
     description?: string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1612,7 +1612,7 @@ declare namespace Eris {
   }
   interface MessageSnapshot {
     guildID?: string;
-    message: Pick<Message, "attachments" | "content" | "editedTimestamp" | "embeds" | "flags" | "id" | "mentions" | "roleMentions" | "timestamp" | "type">;
+    message: Pick<Message, "attachments" | "content" | "components" | "editedTimestamp" | "embeds" | "flags" | "id" | "mentions" | "roleMentions" | "timestamp" | "stickers" | "stickerItems" | "type">;
   }
   interface PartialAttachment {
     description?: string;


### PR DESCRIPTION
### Changes
- Added "stickers", "sticker_items" and "components" to message in "MessageSnapshot" interface
### Reference
- https://github.com/discord/discord-api-docs/pull/7116