### PR TITLE
Add application to client options in constructor

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -507,10 +507,10 @@ declare namespace Eris {
     type: ApplicationRoleConnectionMetadataTypes;
   }
   interface ClientOptions {
-    application?: { id: string; flags?: number };
     /** @deprecated */
     agent?: HTTPSAgent;
     allowedMentions?: AllowedMentions;
+    application?: { id: string; flags?: number };
     autoreconnect?: boolean;
     compress?: boolean;
     connectionTimeout?: number;

--- a/index.d.ts
+++ b/index.d.ts
@@ -507,6 +507,7 @@ declare namespace Eris {
     type: ApplicationRoleConnectionMetadataTypes;
   }
   interface ClientOptions {
+    application?: { id: string; flags?: number };
     /** @deprecated */
     agent?: HTTPSAgent;
     allowedMentions?: AllowedMentions;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -79,6 +79,7 @@ class Client extends EventEmitter {
    * Create a Client
    * @arg {String} token The auth token to use. Bot tokens should be prefixed with `Bot` (e.g. `Bot MTExIHlvdSAgdHJpZWQgMTEx.O5rKAA.dQw4w9WgXcQ_wpV-gGA4PSk_bm8`). Prefix-less bot tokens are [DEPRECATED]
    * @arg {Object} options Eris client options
+   * @arg {Object} [options.application] Object containing the bot application's ID and its public flags
    * @arg {Object} [options.agent] [DEPRECATED] A HTTPS Agent used to proxy requests. This option has been moved under `options.rest`
    * @arg {Object} [options.allowedMentions] A list of mentions to allow by default in createMessage/editMessage
    * @arg {Boolean} [options.allowedMentions.everyone] Whether or not to allow @everyone/@here

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -152,6 +152,13 @@ class Client extends EventEmitter {
       ws: {},
       reconnectDelay: (lastDelay, attempts) => Math.pow(attempts + 1, 0.7) * 20000,
     }, options);
+
+    if (options.application) {
+      this.application = {
+        id: options.application.id,
+        flags: options.application.flags ?? 0,
+      };
+    }
     this.options.allowedMentions = this._formatAllowedMentions(this.options.allowedMentions);
     if (this.options.lastShardID === undefined && this.options.maxShards !== "auto") {
       this.options.lastShardID = this.options.maxShards - 1;


### PR DESCRIPTION
`Client.application` should be configurable from the constructor. This pull request just adds application property to the options inside the Client constructor. 