### PR TITLE
chore(gitignore): Ignore lock files for yarn,pnpm,bun

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ node_modules
 test
 npm-debug.log
 package-lock.json
+yarn.lock
+pnpm-lock.yaml
+bun.lockb
+bun.lock


### PR DESCRIPTION
### Lock Files
This pull request updates the ".gitignore" file to include 4 more lock files used by package managers other then npm's.

### New
- yarn.lock (for yarn's package manager)
- pnpm-lock.yaml (for pnpm's package manager)
- bun.lockb, bun.lock (for bun's package manager)