### PR TITLE
Fix slash commands: Add support for `description_localizations`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2255,8 +2255,9 @@ declare namespace Eris {
     editChannelPosition(channelID: string, position: number, options?: EditChannelPositionOptions): Promise<void>;
     editChannelPositions(guildID: string, channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandTypes>(commandID: string, command: ApplicationCommandEditOptions<false, T>): Promise<ApplicationCommand<false, T>>;
-    editEmoji(emojiID: string, options: EditApplicationEmojiOptions): Promise<Emoji>;
     editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[], reason?: string): Promise<GuildApplicationCommandPermissions>;
+    editEmoji(emojiID: string, options: EditApplicationEmojiOptions): Promise<Emoji>;
+
     editGuild(guildID: string, options: GuildOptions, reason?: string): Promise<Guild>;
     editGuildCommand<T extends ApplicationCommandTypes>(guildID: string, commandID: string, command: ApplicationCommandEditOptions<true, T>): Promise<ApplicationCommand<true, T>>;
     editGuildDiscovery(guildID: string, options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
@@ -2322,8 +2323,9 @@ declare namespace Eris {
     getDiscoveryCategories(): Promise<DiscoveryCategory[]>;
     getDMChannel(userID: string): Promise<DMChannel>;
     getEmoji(emojiID: string): Promise<Emoji>;
-    getEmojis(): Promise<ApplicationEmojis>;
     getEmojiGuild(emojiID: string): Promise<Guild>;
+    getEmojis(): Promise<ApplicationEmojis>;
+
     getGateway(): Promise<{ url: string }>;
     getGuildAuditLog(guildID: string, options?: GetGuildAuditLogOptions): Promise<GuildAuditLog>;
     /** @deprecated */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -406,6 +406,9 @@ class Client extends EventEmitter {
         command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
       }
       command.dm_permission = command.dmPermission;
+      if (command.descriptionLocalizations !== undefined) {
+        command.description_localizations = command.descriptionLocalizations;
+      }
     }
     return this.requestHandler.request("PUT", Endpoints.COMMANDS(this.application.id), true, commands).then((commands) => commands.map((command) => new ApplicationCommand(command, this)));
   }
@@ -443,6 +446,9 @@ class Client extends EventEmitter {
         emitDeprecation("DEFAULT_PERMISSION");
         this.emit("warn", "[DEPRECATED] bulkEditGuildCommands() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
         command.default_permission = command.defaultPermission;
+      }
+      if (command.descriptionLocalizations !== undefined) {
+        command.description_localizations = command.descriptionLocalizations;
       }
     }
     return this.requestHandler.request("PUT", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, commands).then((commands) => commands.map((command) => new ApplicationCommand(command, this)));
@@ -680,6 +686,9 @@ class Client extends EventEmitter {
       command.default_permission = command.defaultPermission;
     }
     command.dm_permission = command.dmPermission;
+    if (command.descriptionLocalizations !== undefined) {
+      command.description_localizations = command.descriptionLocalizations;
+    }
     return this.requestHandler.request("POST", Endpoints.COMMANDS(this.application.id), true, command).then((command) => new ApplicationCommand(command, this));
   }
 
@@ -773,6 +782,9 @@ class Client extends EventEmitter {
       emitDeprecation("DEFAULT_PERMISSION");
       this.emit("warn", "[DEPRECATED] createGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
       command.default_permission = command.defaultPermission;
+    }
+    if (command.descriptionLocalizations !== undefined) {
+      command.description_localizations = command.descriptionLocalizations;
     }
     return this.requestHandler.request("POST", Endpoints.GUILD_COMMANDS(this.application.id, guildID), true, command).then((command) => new ApplicationCommand(command, this));
   }
@@ -1698,17 +1710,10 @@ class Client extends EventEmitter {
       command.default_member_permissions = command.defaultMemberPermissions === null ? null : String(command.defaultMemberPermissions.allow || command.defaultMemberPermissions);
     }
     command.dm_permission = command.dmPermission;
+    if (command.descriptionLocalizations !== undefined) {
+      command.description_localizations = command.descriptionLocalizations;
+    }
     return this.requestHandler.request("PATCH", Endpoints.COMMAND(this.application.id, commandID), true, command).then((command) => new ApplicationCommand(command, this));
-  }
-
-  /**
-   * Edit an existing emoji for this application
-   * @arg {Object} options Emoji options
-   * @arg {String} options.name The name of emoji
-   * @returns {Promise<Object>} An emoji object
-   */
-  editEmoji(emojiID, options) {
-    return this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true, options);
   }
 
   /**
@@ -1728,6 +1733,16 @@ class Client extends EventEmitter {
       throw new Error("You must provide an id of the command whose permissions you want to edit.");
     }
     return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, { permissions, reason });
+  }
+
+  /**
+   * Edit an existing emoji for this application
+   * @arg {Object} options Emoji options
+   * @arg {String} options.name The name of emoji
+   * @returns {Promise<Object>} An emoji object
+   */
+  editEmoji(emojiID, options) {
+    return this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true, options);
   }
 
   /**
@@ -1815,6 +1830,9 @@ class Client extends EventEmitter {
       emitDeprecation("DEFAULT_PERMISSION");
       this.emit("warn", "[DEPRECATED] editGuildCommand() was called with a `defaultPermission` parameter. This has been replaced with `defaultMemberPermissions`");
       command.default_permission = command.defaultPermission;
+    }
+    if (command.descriptionLocalizations !== undefined) {
+      command.description_localizations = command.descriptionLocalizations;
     }
     return this.requestHandler.request("PATCH", Endpoints.GUILD_COMMAND(this.application.id, guildID, commandID), true, command).then((command) => new ApplicationCommand(command, this));
   }
@@ -2649,6 +2667,15 @@ class Client extends EventEmitter {
   }
 
   /**
+   * Get a guild from the guild's emoji ID
+   * @arg {String} emojiID The ID of the emoji
+   * @returns {Promise<Guild>}
+   */
+  getEmojiGuild(emojiID) {
+    return this.requestHandler.request("GET", Endpoints.CUSTOM_EMOJI_GUILD(emojiID), true).then((result) => new Guild(result, this));
+  }
+
+  /**
    * Get the emojis for this application
    * @returns {Promise<Object>} Resolves with an object that contains a property "items" which is an array of emoji objects
    */
@@ -2664,15 +2691,6 @@ class Client extends EventEmitter {
 
       return data;
     });
-  }
-
-  /**
-   * Get a guild from the guild's emoji ID
-   * @arg {String} emojiID The ID of the emoji
-   * @returns {Promise<Guild>}
-   */
-  getEmojiGuild(emojiID) {
-    return this.requestHandler.request("GET", Endpoints.CUSTOM_EMOJI_GUILD(emojiID), true).then((result) => new Guild(result, this));
   }
 
   /**

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -128,30 +128,30 @@ class Command {
     this.errorMessage = options.errorMessage || "";
     this.reactionButtons = options.reactionButtons
       ? options.reactionButtons.map((button, index) => {
-        if (typeof button.response === "string") {
-          button.execute = () => button.response;
-          return button;
-        } else if (Array.isArray(button.response)) {
-          button.responses = button.response.map((item, otherIndex) => {
-            if (typeof item === "string") {
-              return () => item;
-            } else if (typeof item === "function") {
-              return item;
-            } else {
-              throw new Error(`Invalid reaction button response generator (index ${index}:${otherIndex})`);
-            }
-          });
-          button.execute = () => button.responses[Math.floor(Math.random() * button.responses.length)]();
-          return button;
-        } else if (typeof button.response === "function") {
-          button.execute = button.response;
-          return button;
-        } else if (button.type === "cancel") {
-          return button;
-        } else {
-          throw new Error(`Invalid reaction button response generator (index ${index})`);
-        }
-      })
+          if (typeof button.response === "string") {
+            button.execute = () => button.response;
+            return button;
+          } else if (Array.isArray(button.response)) {
+            button.responses = button.response.map((item, otherIndex) => {
+              if (typeof item === "string") {
+                return () => item;
+              } else if (typeof item === "function") {
+                return item;
+              } else {
+                throw new Error(`Invalid reaction button response generator (index ${index}:${otherIndex})`);
+              }
+            });
+            button.execute = () => button.responses[Math.floor(Math.random() * button.responses.length)]();
+            return button;
+          } else if (typeof button.response === "function") {
+            button.execute = button.response;
+            return button;
+          } else if (button.type === "cancel") {
+            return button;
+          } else {
+            throw new Error(`Invalid reaction button response generator (index ${index})`);
+          }
+        })
       : null;
     this.reactionButtonTimeout = options.reactionButtonTimeout || 60000;
     if (this.cooldown !== 0) {


### PR DESCRIPTION
This pull request adds support for `description_localizations` when handling slash commands in the following methods:  
- `createCommand`  
- `createGuildCommand`  
- `editCommand`  
- `editGuildCommand`  
- `bulkEditCommands`  
- `bulkEditGuildCommands`  

Currently, these methods do not properly handle the `description_localizations` field, which is crucial for providing localized descriptions for slash commands. To resolve this, the following code snippet is added to each affected method:

```javascript
if (command.descriptionLocalizations !== undefined) {
    command.description_localizations = command.descriptionLocalizations;
}
```

This ensures that `descriptionLocalizations` is properly passed to the API, allowing for multilingual support in slash command descriptions.

### Changes
- Updated all relevant methods to handle the `description_localizations` field.
- Improved the support for localized descriptions in slash commands.