### PR TITLE
fix(Voice): IP Discovery packets should not have additional random content

### DIFF
--- a/lib/voice/VoiceConnection.js
+++ b/lib/voice/VoiceConnection.js
@@ -272,7 +272,7 @@ class VoiceConnection extends EventEmitter {
               this.disconnect(err);
             }
           });
-          const udpMessage = Buffer.allocUnsafe(74);
+          const udpMessage = Buffer.alloc(74);
           udpMessage.writeUInt16BE(0x1, 0);
           udpMessage.writeUInt16BE(70, 2);
           udpMessage.writeUInt32BE(this.ssrc, 4);


### PR DESCRIPTION
This fixes the problem that the new version of voice gateway does not respond to IP Discovery