### PR TITLE
feat: New pins endpoints & options

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -457,6 +457,10 @@ declare namespace Eris {
     before?: string;
     limit?: number;
   }
+  interface GetPinsOptions {
+    before?: Date;
+    limit?: number;
+  }
   interface GroupRecipientOptions {
     accessToken: string;
     nick?: string;
@@ -481,9 +485,19 @@ declare namespace Eris {
   }
   interface Pinnable {
     lastPinTimestamp: number | null;
+    /** @deprecated */
     getPins(): Promise<Message[]>;
+    getPins(options?: GetPinsOptions): Promise<GetPinsResponse>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
+  }
+  interface GetPinsResponse {
+    hasMore: boolean;
+    items: GetPinsResponseItem;
+  }
+  interface GetPinsResponseItem {
+    pinnedAt: number;
+    message: Message;
   }
   interface PurgeChannelOptions {
     after?: string;
@@ -2365,7 +2379,9 @@ declare namespace Eris {
     getMessages(channelID: string, limit?: number, before?: string, after?: string, around?: string): Promise<Message[]>;
     getNitroStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getOAuthApplication(): Promise<OAuthApplicationInfo>;
+    /** @deprecated */
     getPins(channelID: string): Promise<Message[]>;
+    getPins(channelID: string, options?: GetPinsOptions): Promise<GetPinsResponse>;
     getPollAnswerVoters(channelID: string, messageID: string, answerID: string, options?: GetPollAnswerVotersOptions): Promise<User[]>;
     getPruneCount(guildID: string, options?: GetPruneOptions): Promise<number>;
     getRESTChannel(channelID: string): Promise<AnyChannel>;
@@ -2557,7 +2573,9 @@ declare namespace Eris {
     getMessages(options: GetMessagesOptions): Promise<Message<this>[]>;
     /** @deprecated */
     getMessages(limit?: number, before?: string, after?: string, around?: string): Promise<Message<this>[]>;
+    /** @deprecated */
     getPins(): Promise<Message<this>[]>;
+    getPins(options?: GetPinsOptions): Promise<GetPinsResponse>;
     pinMessage(messageID: string): Promise<void>;
     removeMessageReaction(messageID: string, reaction: string): Promise<void>;
     /** @deprecated */
@@ -3461,7 +3479,9 @@ declare namespace Eris {
     getArchivedThreads(type: "public", options?: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PublicThreadChannel>>;
     getInvites(): Promise<Invite<"withMetadata", this>[]>;
     getJoinedPrivateArchivedThreads(options: GetArchivedThreadsOptions): Promise<ListedChannelThreads<PrivateThreadChannel>>;
+    /** @deprecated */
     getPins(): Promise<Message<this>[]>;
+    getPins(options?: GetPinsOptions): Promise<GetPinsResponse>;
     getWebhooks(): Promise<Webhook[]>;
     pinMessage(messageID: string): Promise<void>;
     unpinMessage(messageID: string): Promise<void>;
@@ -3481,7 +3501,9 @@ declare namespace Eris {
     edit(options: EditThreadChannelOptions, reason?: string): Promise<this>;
     getMember(userID: string, withMember?: boolean): Promise<ThreadMember>;
     getMembers(options?: GetThreadMembersOptions): Promise<ThreadMember[]>;
+    /** @deprecated */
     getPins(): Promise<Message<this>[]>;
+    getPins(options?: GetPinsOptions): Promise<GetPinsResponse>;
     join(userID?: string): Promise<void>;
     leave(userID?: string): Promise<void>;
     pinMessage(messageID: string): Promise<void>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3186,19 +3186,19 @@ class Client extends EventEmitter {
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} // NEEDS FEEDBACK - this func will return something different if dev does not pass `options`, want 2 separate @return arguments??
    */
   getPins(channelID, options) {
-    const request = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options);
-    if (!options) {
-      emitDeprecation("GET_CHANNEL_PINS");
-      return request.then((pinned) => pinned.items.map((pin) => new Message(pin.message, this)));
-    } else {
-      return request.then((pinned) => ({
+    return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options).then((pinned) => {
+      if (!options) {
+        emitDeprecation("GET_CHANNEL_PINS");
+        return pinned.items.map((pin) => new Message(pin.message, this));
+      }
+      return {
         hasMore: pinned.has_more,
         items: pinned.items.map((pin) => ({
           pinnedAt: pin.pinned_at,
           message: new Message(pin.message, this),
         })),
-      }));
-    }
+      };
+    });
   }
 
   /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3186,7 +3186,7 @@ class Client extends EventEmitter {
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} // NEEDS FEEDBACK - this func will return something different if dev does not pass `options`, want 2 separate @return arguments??
    */
   getPins(channelID, options) {
-    const request = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true);
+    const request = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options);
     if (!options) {
       emitDeprecation("GET_CHANNEL_PINS");
       return request.then((pinned) => pinned.items.map((pin) => new Message(pin.message, this)));

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3186,9 +3186,11 @@ class Client extends EventEmitter {
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} An object containing `hasMore` (Boolean, `true` if there are more pins available), and `items` which is an array of objects containing `pinnedAt` (Date of when the message was pinned) and `message` (the pinned message)
    */
   getPins(channelID, options) {
+    if (!options) {
+      emitDeprecation("GET_CHANNEL_PINS");
+    }
     return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options).then((pinned) => {
       if (!options) {
-        emitDeprecation("GET_CHANNEL_PINS");
         return pinned.items.map((pin) => new Message(pin.message, this));
       }
       return {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3186,11 +3186,11 @@ class Client extends EventEmitter {
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} An object containing `hasMore` (Boolean, `true` if there are more pins available), and `items` which is an array of objects containing `pinnedAt` (Date of when the message was pinned) and `message` (the pinned message)
    */
   getPins(channelID, options) {
-    if (!options) {
+    if (options === undefined) {
       emitDeprecation("GET_CHANNEL_PINS");
     }
     return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options).then((pinned) => {
-      if (!options) {
+      if (options === undefined) {
         return pinned.items.map((pin) => new Message(pin.message, this));
       }
       return {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3127,7 +3127,7 @@ class Client extends EventEmitter {
       return {
         hasMore: pinned.has_more,
         items: pinned.items.map((pin) => ({
-          pinnedAt: pin.pinned_at,
+          pinnedAt: Date.parse(pin.pinned_at),
           message: new Message(pin.message, this),
         })),
       };

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3183,7 +3183,7 @@ class Client extends EventEmitter {
    * @arg {Object} [options] The options to use to get pinned messages
    * @arg {Date} [options.before] Get pinned messages before this date
    * @arg {Number} [options.limit=50] The max number of pinned messages to get (1-50, default 50)
-   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} // NEEDS FEEDBACK - this func will return something different if dev does not pass `options`, want 2 separate @return arguments??
+   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} An object containing `hasMore` (Boolean, `true` if there are more pins available), and `items` which is an array of objects containing `pinnedAt` (Date of when the message was pinned) and `message` (the pinned message)
    */
   getPins(channelID, options) {
     return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true, options).then((pinned) => {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3182,7 +3182,7 @@ class Client extends EventEmitter {
    * @arg {String} channelID The ID of the channel
    * @arg {Object} [options] The options to use to get pinned messages
    * @arg {Date} [options.before] Get pinned messages before this date
-   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get (1-50, default 50)
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} // NEEDS FEEDBACK - this func will return something different if dev does not pass `options`, want 2 separate @return arguments??
    */
   getPins(channelID, options) {

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3178,12 +3178,27 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Get all the pins in a channel
+   * Get pinned messages in a channel
    * @arg {String} channelID The ID of the channel
-   * @returns {Promise<Array<Message>>}
+   * @arg {Object} [options] The options to use to get pinned messages
+   * @arg {Date} [options.before] Get pinned messages before this date
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>} // NEEDS FEEDBACK - this func will return something different if dev does not pass `options`, want 2 separate @return arguments??
    */
-  getPins(channelID) {
-    return this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true).then((messages) => messages.map((message) => new Message(message, this)));
+  getPins(channelID, options) {
+    const request = this.requestHandler.request("GET", Endpoints.CHANNEL_PINS(channelID), true);
+    if (!options) {
+      emitDeprecation("GET_CHANNEL_PINS");
+      return request.then((pinned) => pinned.items.map((pin) => new Message(pin.message, this)));
+    } else {
+      return request.then((pinned) => ({
+        hasMore: pinned.has_more,
+        items: pinned.items.map((pin) => ({
+          pinnedAt: pin.pinned_at,
+          message: new Message(pin.message, this),
+        })),
+      }));
+    }
   }
 
   /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -25,8 +25,8 @@ module.exports.CHANNEL_MESSAGE =                                 (chanID, msgID)
 module.exports.CHANNEL_MESSAGES =                                       (chanID) => `/channels/${chanID}/messages`;
 module.exports.CHANNEL_PERMISSION =                             (chanID, overID) => `/channels/${chanID}/permissions/${overID}`;
 module.exports.CHANNEL_PERMISSIONS =                                    (chanID) => `/channels/${chanID}/permissions`;
-module.exports.CHANNEL_PIN =                                     (chanID, msgID) => `/channels/${chanID}/pins/${msgID}`;
-module.exports.CHANNEL_PINS =                                           (chanID) => `/channels/${chanID}/pins`;
+module.exports.CHANNEL_PIN =                                     (chanID, msgID) => `/channels/${chanID}/messages/pins/${msgID}`;
+module.exports.CHANNEL_PINS =                                           (chanID) => `/channels/${chanID}/messages/pins`;
 module.exports.CHANNEL_RECIPIENT =                             (groupID, userID) => `/channels/${groupID}/recipients/${userID}`;
 module.exports.CHANNEL_TYPING =                                         (chanID) => `/channels/${chanID}/typing`;
 module.exports.CHANNEL_VOICE_STATUS =                                   (chanID) => `/channels/${chanID}/voice-status`;

--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -140,6 +140,8 @@ class RequestHandler {
                     body[key].forEach(function (val) {
                       qs += `&${encodeURIComponent(key)}=${encodeURIComponent(val)}`;
                     });
+                  } else if (body[key] instanceof Date) {
+                    qs += `&${encodeURIComponent(key)}=${body[key].toISOString()}`;
                   } else {
                     qs += `&${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`;
                   }

--- a/lib/structures/DMChannel.js
+++ b/lib/structures/DMChannel.js
@@ -205,7 +205,7 @@ class DMChannel extends Channel {
    * Get pinned messages in the channel
    * @arg {Object} [options] The options to use to get pinned messages
    * @arg {Date} [options.before] Get pinned messages before this date
-   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get (1-50, default 50)
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
   getPins(options) {

--- a/lib/structures/DMChannel.js
+++ b/lib/structures/DMChannel.js
@@ -202,11 +202,14 @@ class DMChannel extends Channel {
   }
 
   /**
-   * Get all the pins in the channel
-   * @returns {Promise<Array<Message>>}
+   * Get pinned messages in the channel
+   * @arg {Object} [options] The options to use to get pinned messages
+   * @arg {Date} [options.before] Get pinned messages before this date
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
-  getPins() {
-    return this._client.getPins.call(this._client, this.id);
+  getPins(options) {
+    return this._client.getPins.call(this._client, this.id, options);
   }
 
   /**

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -159,11 +159,14 @@ class TextChannel extends GuildTextableChannel {
   }
 
   /**
-   * Get all the pins in the channel
-   * @returns {Promise<Array<Message>>}
+   * Get pinned messages in the channel
+   * @arg {Object} [options] The options to use to get pinned messages
+   * @arg {Date} [options.before] Get pinned messages before this date
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
-  getPins() {
-    return this._client.getPins.call(this._client, this.id);
+  getPins(options) {
+    return this._client.getPins.call(this._client, this.id, options);
   }
 
   /**

--- a/lib/structures/TextChannel.js
+++ b/lib/structures/TextChannel.js
@@ -162,7 +162,7 @@ class TextChannel extends GuildTextableChannel {
    * Get pinned messages in the channel
    * @arg {Object} [options] The options to use to get pinned messages
    * @arg {Date} [options.before] Get pinned messages before this date
-   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get (1-50, default 50)
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
   getPins(options) {

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -83,7 +83,7 @@ class ThreadChannel extends GuildTextableChannel {
    * Get pinned messages in the thread channel
    * @arg {Object} [options] The options to use to get pinned messages
    * @arg {Date} [options.before] Get pinned messages before this date
-   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get (1-50, default 50)
    * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
   getPins(options) {

--- a/lib/structures/ThreadChannel.js
+++ b/lib/structures/ThreadChannel.js
@@ -80,11 +80,14 @@ class ThreadChannel extends GuildTextableChannel {
   }
 
   /**
-   * Get all the pins in the channel
-   * @returns {Promise<Array<Message>>}
+   * Get pinned messages in the thread channel
+   * @arg {Object} [options] The options to use to get pinned messages
+   * @arg {Date} [options.before] Get pinned messages before this date
+   * @arg {Number} [options.limit=50] The max number of pinned messages to get
+   * @returns {Promise<{hasMore: Boolean, items: Array<{pinnedAt: Number, message: Message}>}>}
    */
-  getPins() {
-    return this._client.getPins.call(this._client, this.id);
+  getPins(options) {
+    return this._client.getPins.call(this._client, this.id, options);
   }
 
   /**

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -4,6 +4,7 @@ const warningMessages = {
   DEFAULT_PERMISSION: "Passing a defaultPermission for application commands is deprecated. Use defaultMemberPermissions instead.",
   DELETE_MESSAGE_DAYS: "Passing the deleteMessageDays parameter to banGuildMember is deprecated. Use an options object with deleteMessageSeconds instead.",
   DM_REACTION_REMOVE: "Passing a userID when using removeMessageReaction() in a DMChannel is deprecated. This behavior is no longer supported by Discord.",
+  GET_CHANNEL_PINS: "getPins() returning an array of messages is deprecated and will be removed in future versions. Use an options object instead.",
   GET_REACTION_BEFORE: "Passing the before parameter to getMessageReaction() is deprecated. Discord no longer supports this parameter.",
   MEMBER_PERMISSION: "Member#permission is deprecated. Use Member#permissions instead.",
   MESSAGE_REFERENCE: "Passing the content.messageReferenceID option to createMessage() is deprecated. Use the content.messageReference option instead.",


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/7585

Ignore the `after` options in that PR ^ they were incorrectly added (removed with [this PR](https://github.com/discord/discord-api-docs/pull/7630))