### PR TITLE
Sticker Packs: Rename & deprecate getNitroStickerPacks()

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2363,6 +2363,7 @@ declare namespace Eris {
     getMessages(channelID: string, options?: GetMessagesOptions): Promise<Message[]>;
     /** @deprecated */
     getMessages(channelID: string, limit?: number, before?: string, after?: string, around?: string): Promise<Message[]>;
+    /** @deprecated */
     getNitroStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getOAuthApplication(): Promise<OAuthApplicationInfo>;
     getPins(channelID: string): Promise<Message[]>;
@@ -2392,6 +2393,7 @@ declare namespace Eris {
     getSoundboardSounds(): Promise<SoundboardSound<false>[]>;
     getStageInstance(channelID: string): Promise<StageInstance>;
     getStickerPack(packID: string): Promise<StickerPack>;
+    getStickerPacks(): Promise<{ sticker_packs: StickerPack[] }>;
     getThreadMember(channelID: string, userID: string, withMember?: boolean): Promise<ThreadMember>;
     getThreadMembers(channelID: string, options?: GetThreadMembersOptions): Promise<ThreadMember[]>;
     getVoiceRegions(guildID?: string): Promise<VoiceRegion[]>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3162,11 +3162,12 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Get the list of sticker packs available to Nitro subscribers
-   * @returns {Promise<Object>} An object whichs contains a value which contains an array of sticker packs
+   * [DEPRECATED] Get the list of available sticker packs
+   * @returns {Promise<{sticker_packs: Array<Object>}>} An object containing a `sticker_packs` value which contains an array of sticker packs
    */
   getNitroStickerPacks() {
-    return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);
+    emitDeprecation("GET_NITRO_STICKER_PACKS");
+    return this.getStickerPacks();
   }
 
   /**
@@ -3483,6 +3484,14 @@ class Client extends EventEmitter {
    */
   getStickerPack(packID) {
     return this.requestHandler.request("GET", Endpoints.STICKER_PACK(packID), true);
+  }
+
+  /**
+   * Get the list of available sticker packs
+   * @returns {Promise<{sticker_packs: Array<Object>}>} An object containing a `sticker_packs` value which contains an array of sticker packs
+   */
+  getStickerPacks() {
+    return this.requestHandler.request("GET", Endpoints.STICKER_PACKS, true);
   }
 
   /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -3166,7 +3166,7 @@ class Client extends EventEmitter {
   }
 
   /**
-   * [DEPRECATED] Get the list of available sticker packs
+   * [DEPRECATED] Get the list of available sticker packs. This function is deprecated, use `getStickerPacks()` instead.
    * @returns {Promise<{sticker_packs: Array<Object>}>} An object containing a `sticker_packs` value which contains an array of sticker packs
    */
   getNitroStickerPacks() {

--- a/lib/util/emitDeprecation.js
+++ b/lib/util/emitDeprecation.js
@@ -5,6 +5,7 @@ const warningMessages = {
   DELETE_MESSAGE_DAYS: "Passing the deleteMessageDays parameter to banGuildMember is deprecated. Use an options object with deleteMessageSeconds instead.",
   DM_REACTION_REMOVE: "Passing a userID when using removeMessageReaction() in a DMChannel is deprecated. This behavior is no longer supported by Discord.",
   GET_REACTION_BEFORE: "Passing the before parameter to getMessageReaction() is deprecated. Discord no longer supports this parameter.",
+  GET_NITRO_STICKER_PACKS: "getNitroStickerPacks() is deprecated because standard sticker packs are no longer Nitro locked. Use getStickerPacks() instead.",
   MEMBER_PERMISSION: "Member#permission is deprecated. Use Member#permissions instead.",
   MESSAGE_REFERENCE: "Passing the content.messageReferenceID option to createMessage() is deprecated. Use the content.messageReference option instead.",
   REACTION_USER: "Passing a userID other than \"@me\" to addMessageReaction() is deprecated. Discord no longer supports this parameter.",


### PR DESCRIPTION
Changed because #1464 

Standard stickers aren't locked to Nitro now. Deprecated `Client#getNitroStickerPacks()` and added `Client#getStickerPacks()`.

Ref:
- https://github.com/discord/discord-api-docs/pull/6265