### PR TITLE
chore(Guild): Remove user account only features

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1194,7 +1194,6 @@ declare namespace Eris {
     features?: GuildFeatures[]; // Though only some are editable?
     icon?: string | null;
     name?: string;
-    ownerID?: string;
     preferredLocale?: LocaleStrings | null;
     publicUpdatesChannelID?: string | null;
     rulesChannelID?: string | null;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1078,17 +1078,6 @@ declare namespace Eris {
     banned_users: string[];
     failed_users: string[];
   }
-  interface CreateGuildOptions {
-    afkChannelID?: string;
-    afkTimeout?: number;
-    channels?: PartialChannel[];
-    defaultNotifications?: DefaultNotifications;
-    explicitContentFilter?: ExplicitContentFilter;
-    icon?: string;
-    roles?: PartialRole[];
-    systemChannelID: string;
-    verificationLevel?: VerificationLevel;
-  }
   interface DiscoveryCategory {
     id: number;
     is_primary: boolean;
@@ -2197,10 +2186,8 @@ declare namespace Eris {
     createCommand<T extends ApplicationCommandTypes>(command: ApplicationCommandCreateOptions<false, T>): Promise<ApplicationCommand<false, T>>;
     createEmoji(options: ApplicationEmojiOptions): Promise<Emoji>;
     createGroupChannel(userIDs: string[]): Promise<GroupChannel>;
-    createGuild(name: string, options?: CreateGuildOptions): Promise<Guild>;
     createGuildCommand<T extends ApplicationCommandTypes>(guildID: string, command: ApplicationCommandCreateOptions<true, T>): Promise<ApplicationCommand<true, T>>;
     createGuildEmoji(guildID: string, options: EmojiOptions, reason?: string): Promise<Emoji>;
-    createGuildFromTemplate(code: string, name: string, icon?: string): Promise<Guild>;
     createGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, event: GuildScheduledEventOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     createGuildSoundboardSound(guildID: string, sound: GuildSoundboardSoundCreate, reason?: string): Promise<SoundboardSound>;
     createGuildSticker(guildID: string, options: CreateStickerOptions, reason?: string): Promise<Sticker>;
@@ -2220,7 +2207,6 @@ declare namespace Eris {
     deleteChannelPermission(channelID: string, overwriteID: string, reason?: string): Promise<void>;
     deleteCommand(commandID: string): Promise<void>;
     deleteEmoji(emojiID: string): Promise<void>;
-    deleteGuild(guildID: string): Promise<void>;
     deleteGuildCommand(guildID: string, commandID: string): Promise<void>;
     deleteGuildDiscoverySubcategory(guildID: string, categoryID: string, reason?: string): Promise<void>;
     deleteGuildEmoji(guildID: string, emojiID: string, reason?: string): Promise<void>;
@@ -2681,7 +2667,6 @@ declare namespace Eris {
     createSoundboardSound(sound: GuildSoundboardSoundCreate, reason?: string): Promise<SoundboardSound>;
     createSticker(options: CreateStickerOptions, reason?: string): Promise<Sticker>;
     createTemplate(name: string, description?: string | null): Promise<GuildTemplate>;
-    delete(): Promise<void>;
     deleteAutoModerationRule(ruleID: string, reason?: string): Promise<void>;
     deleteCommand(commandID: string): Promise<void>;
     deleteDiscoverySubcategory(categoryID: string, reason?: string): Promise<void>;
@@ -2881,7 +2866,6 @@ declare namespace Eris {
     updatedAt: number;
     usageCount: number;
     constructor(data: BaseData, client: Client);
-    createGuild(name: string, icon?: string): Promise<Guild>;
     delete(): Promise<GuildTemplate>;
     edit(options: GuildTemplateOptions): Promise<GuildTemplate>;
     sync(): Promise<GuildTemplate>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1287,9 +1287,6 @@ declare namespace Eris {
     expireBehavior?: string;
     expireGracePeriod?: string;
   }
-  interface MFALevelResponse {
-    level: MFALevel;
-  }
   interface PruneMemberOptions extends GetPruneOptions {
     computePruneCount?: boolean;
     reason?: string;
@@ -2253,7 +2250,6 @@ declare namespace Eris {
       reason?: string
     ): Promise<Emoji>;
     editGuildMember(guildID: string, memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
-    editGuildMFALevel(guildID: string, level: MFALevel, reason?: string): Promise<MFALevelResponse>;
     editGuildOnboarding(guildID: string, options: GuildOnboardingOptions, reason?: string): Promise<GuildOnboarding>;
     editGuildScheduledEvent<T extends GuildScheduledEventEntityTypes>(guildID: string, eventID: string, event: GuildScheduledEventEditOptions<T>, reason?: string): Promise<GuildScheduledEvent<T>>;
     editGuildSoundboardSound(guildID: string, soundID: string, options: GuildSoundboardSoundEdit): Promise<SoundboardSound>;
@@ -2689,7 +2685,6 @@ declare namespace Eris {
     editDiscovery(options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
     editEmoji(emojiID: string, options: { name: string; roles?: string[] }, reason?: string): Promise<Emoji>;
     editMember(memberID: string, options: MemberOptions, reason?: string): Promise<Member>;
-    editMFALevel(level: MFALevel, reason?: string): Promise<MFALevelResponse>;
     /** @deprecated */
     editNickname(nick: string): Promise<void>;
     editOnboarding(options: GuildOnboardingOptions, reason?: string): Promise<GuildOnboarding>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1687,7 +1687,6 @@ class Client extends EventEmitter {
    * @arg {Array<String>} [options.features] The enabled features for the guild. Note that only certain features can be toggled with the API
    * @arg {String?} [options.icon] The guild icon as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
    * @arg {String} [options.name] The name of the guild
-   * @arg {String} [options.ownerID] The ID of the user to transfer server ownership to (bot user must be owner)
    * @arg {String?} [options.preferredLocale] Preferred "COMMUNITY" guild language used in server discovery and notices from Discord
    * @arg {String?} [options.publicUpdatesChannelID] The ID of the channel where admins and moderators of "COMMUNITY" guilds receive notices from Discord
    * @arg {String?} [options.rulesChannelID] The ID of the channel where "COMMUNITY" guilds display rules and/or guidelines
@@ -1713,7 +1712,6 @@ class Client extends EventEmitter {
       preferred_locale: options.preferredLocale,
       afk_channel_id: options.afkChannelID,
       afk_timeout: options.afkTimeout,
-      owner_id: options.ownerID,
       splash: options.splash,
       banner: options.banner,
       description: options.description,

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1825,20 +1825,6 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Edit a guild's MFA level (multi-factor authentication). Note: The bot account must be the owner of the guild to be able to edit the MFA status.
-   * @arg {String} guildID The ID of the guild
-   * @arg {Number} level The new MFA level, `0` to disable MFA, `1` to enable it
-   * @arg {String} [reason] The reason to be displayed in audit logs
-   * @returns {Promise<Object>} An object containing a `level` (Number) key, indicating the new MFA level
-   */
-  editGuildMFALevel(guildID, level, reason) {
-    return this.requestHandler.request("POST", Endpoints.GUILD_MFA_LEVEL(guildID), true, {
-      level,
-      reason,
-    });
-  }
-
-  /**
    * Edit a guild's onboarding settings
    * @arg {String} guildID The ID of the guild
    * @arg {Object} options The properties to edit

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -709,40 +709,6 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Create a guild
-   * @arg {String} name The name of the guild
-   * @arg {Object} [options] The properties of the guild
-   * @arg {String} [options.afkChannelID] The ID of the AFK voice channel
-   * @arg {Number} [options.afkTimeout] The AFK timeout in seconds
-   * @arg {Array<Object>} [options.channels] The new channels of the guild. IDs are placeholders which allow use of category channels.
-   * @arg {Number} [options.defaultNotifications] The default notification settings for the guild. 0 is "All Messages", 1 is "Only @mentions".
-   * @arg {Number} [options.explicitContentFilter] The level of the explicit content filter for messages/images in the guild. 0 disables message scanning, 1 enables scanning the messages of members without roles, 2 enables scanning for all messages.
-   * @arg {String} [options.icon] The guild icon as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
-   * @arg {Array<Object>} [options.roles] The new roles of the guild, the first one is the @everyone role. IDs are placeholders which allow channel overwrites.
-   * @arg {String} [options.systemChannelID] The ID of the system channel
-   * @arg {Number} [options.verificationLevel] The guild verification level
-   * @returns {Promise<Guild>}
-   */
-  createGuild(name, options = {}) {
-    if (this.guilds.size > 9) {
-      throw new Error("This method can't be used when in 10 or more guilds.");
-    }
-
-    return this.requestHandler.request("POST", Endpoints.GUILDS, true, {
-      name: name,
-      icon: options.icon,
-      verification_level: options.verificationLevel,
-      default_message_notifications: options.defaultNotifications,
-      explicit_content_filter: options.explicitContentFilter,
-      system_channel_id: options.systemChannelID,
-      afk_channel_id: options.afkChannelID,
-      afk_timeout: options.afkTimeout,
-      roles: options.roles,
-      channels: options.channels,
-    }).then((guild) => new Guild(guild, this));
-  }
-
-  /**
    * Create a guild application command
    * @arg {String} guildID The ID of the guild
    * @arg {Object} command A command object
@@ -790,20 +756,6 @@ class Client extends EventEmitter {
   createGuildEmoji(guildID, options, reason) {
     options.reason = reason;
     return this.requestHandler.request("POST", Endpoints.GUILD_EMOJIS(guildID), true, options);
-  }
-
-  /**
-   * Create a guild based on a template. This can only be used with bots in less than 10 guilds
-   * @arg {String} code The template code
-   * @arg {String} name The name of the guild
-   * @arg {String} [icon] The 128x128 icon as a base64 data URI
-   * @returns {Promise<Guild>}
-   */
-  createGuildFromTemplate(code, name, icon) {
-    return this.requestHandler.request("POST", Endpoints.GUILD_TEMPLATE(code), true, {
-      name,
-      icon,
-    }).then((guild) => new Guild(guild, this));
   }
 
   /**
@@ -1255,15 +1207,6 @@ class Client extends EventEmitter {
    */
   deleteEmoji(emojiID) {
     return this.requestHandler.request("DELETE", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true);
-  }
-
-  /**
-   * Delete a guild (bot user must be owner)
-   * @arg {String} guildID The ID of the guild
-   * @returns {Promise}
-   */
-  deleteGuild(guildID) {
-    return this.requestHandler.request("DELETE", Endpoints.GUILD(guildID), true);
   }
 
   /**

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -80,7 +80,6 @@ module.exports.GUILD_WIDGET =                                          (guildID)
 module.exports.GUILD_WIDGET_IMAGE =                                    (guildID) => `/guilds/${guildID}/widget.png`;
 module.exports.GUILD_WIDGET_SETTINGS =                                 (guildID) => `/guilds/${guildID}/widget`;
 module.exports.GUILD_VOICE_STATE =                               (guildID, user) => `/guilds/${guildID}/voice-states/${user}`;
-module.exports.GUILDS =                                                             "/guilds";
 module.exports.INTERACTION_RESPOND =                 (interactID, interactToken) => `/interactions/${interactID}/${interactToken}/callback`;
 module.exports.INVITE =                                               (inviteID) => `/invites/${inviteID}`;
 module.exports.OAUTH2_APPLICATION =                                                 "/oauth2/applications/@me";

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -59,7 +59,6 @@ module.exports.GUILD_MEMBER_NICK =                           (guildID, memberID)
 module.exports.GUILD_MEMBER_ROLE =                   (guildID, memberID, roleID) => `/guilds/${guildID}/members/${memberID}/roles/${roleID}`;
 module.exports.GUILD_MEMBERS =                                         (guildID) => `/guilds/${guildID}/members`;
 module.exports.GUILD_MEMBERS_SEARCH =                                  (guildID) => `/guilds/${guildID}/members/search`;
-module.exports.GUILD_MFA_LEVEL =                                       (guildID) => `/guilds/${guildID}/mfa`;
 module.exports.GUILD_ONBOARDING =                                      (guildID) => `/guilds/${guildID}/onboarding`;
 module.exports.GUILD_PREVIEW =                                         (guildID) => `/guilds/${guildID}/preview`;
 module.exports.GUILD_PRUNE =                                           (guildID) => `/guilds/${guildID}/prune`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -595,14 +595,6 @@ class Guild extends Base {
   }
 
   /**
-   * Delete the guild (bot user must be owner)
-   * @returns {Promise}
-   */
-  delete() {
-    return this._client.deleteGuild.call(this._client, this.id);
-  }
-
-  /**
    * Delete an auto moderation rule
    * @arg {String} ruleID The ID of the rule to delete
    * @arg {String} [reason] The reason to be displayed in audit logs

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -743,7 +743,6 @@ class Guild extends Base {
    * @arg {Array<String>} [options.features] The enabled features for the guild. Note that only certain features can be toggled with the API
    * @arg {String?} [options.icon] The guild icon as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
    * @arg {String} [options.name] The name of the guild
-   * @arg {String} [options.ownerID] The ID of the member to transfer guild ownership to (bot user must be owner)
    * @arg {String?} [options.preferredLocale] Preferred "COMMUNITY" guild language used in server discovery and notices from Discord
    * @arg {String?} [options.publicUpdatesChannelID] The ID of the channel where admins and moderators of "COMMUNITY" guilds receive notices from Discord
    * @arg {String?} [options.rulesChannelID] The ID of the channel where "COMMUNITY" guilds display rules and/or guidelines

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -866,16 +866,6 @@ class Guild extends Base {
   }
 
   /**
-   * Edit the guild's MFA level (multi-factor authentication). Note: The bot account must be the owner of the guild to be able to edit the MFA status.
-   * @arg {Number} level The new MFA level, `0` to disable MFA, `1` to enable it
-   * @arg {String} [reason] The reason to be displayed in audit logs
-   * @returns {Promise<Object>} An object containing a `level` (Number) key, indicating the new MFA level
-   */
-  editMFALevel(level, reason) {
-    return this._client.editGuildMFALevel.call(this._client, this.id, level, reason);
-  }
-
-  /**
    * [DEPRECATED] Edit the bot's nickname in the guild
    * @arg {String} nick The nickname
    * @returns {Promise}

--- a/lib/structures/GuildTemplate.js
+++ b/lib/structures/GuildTemplate.js
@@ -30,16 +30,6 @@ class GuildTemplate {
   }
 
   /**
-   * Create a guild based on this template. This can only be used with bots in less than 10 guilds
-   * @arg {String} name The name of the guild
-   * @arg {String} [icon] The 128x128 icon as a base64 data URI
-   * @returns {Promise<Guild>}
-   */
-  createGuild(name, icon) {
-    return this._client.createGuildFromTemplate.call(this._client, this.code, name, icon);
-  }
-
-  /**
    * Delete this template
    * @returns {Promise<GuildTemplate>}
    */


### PR DESCRIPTION
Bots can't own guilds anymore. Rather than deprecate all of this, I've just removed it all cuz no bots own guilds anymore since last month (see screenshot of changelog). Also #1338 did the same thing when removing features that bots couldn't use.

Refs:
Removed `Client#createGuild()`, `Client#createGuildFromTemplate()`, and `GuildTemplate#createGuild()`:
- https://github.com/discord/discord-api-docs/pull/7715
- https://github.com/discord/discord-api-docs/pull/7718

Removed `Client#editGuildMFALevel()` and `Guild#editMFALevel()`:
- https://github.com/discord/discord-api-docs/pull/7722

Removed `ownerID` option from `Client#editGuild()` and `Guild#edit()`. Also removed `Client#deleteGuild()` and `Guild#delete()` functions:
- https://github.com/discord/discord-api-docs/pull/7720

<img width="1359" height="801" alt="image" src="https://github.com/user-attachments/assets/af9dbd80-4ab3-4d6c-b6c5-48cc5d9404e4" />