### PR TITLE
feat: add support for editing bot guild profile and IS_COMPONENTS_V2 message flag

### DIFF
--- a/examples/editSelf.js
+++ b/examples/editSelf.js
@@ -1,0 +1,18 @@
+const Eris = require("eris");
+
+const bot = new Eris("BOT TOKEN", {
+  intents: [
+    "guilds",
+  ],
+});
+
+bot.on("ready", async () => { // When the bot is ready
+  console.log("Ready!"); // Log "Ready!"
+  await bot.editSelf({ nick: "Really cool dude" }, "12345678012345678"); // Edits bot nickname to Really cool dude
+});
+
+bot.on("error", (err) => {
+  console.error(err); // or your preferred logger
+});
+
+bot.connect(); // Get the bot to connect to Discord

--- a/index.d.ts
+++ b/index.d.ts
@@ -2273,8 +2273,9 @@ declare namespace Eris {
     editChannelPosition(channelID: string, position: number, options?: EditChannelPositionOptions): Promise<void>;
     editChannelPositions(guildID: string, channelPositions: ChannelPosition[]): Promise<void>;
     editCommand<T extends ApplicationCommandTypes>(commandID: string, command: ApplicationCommandEditOptions<false, T>): Promise<ApplicationCommand<false, T>>;
-    editEmoji(emojiID: string, options: EditApplicationEmojiOptions): Promise<Emoji>;
     editCommandPermissions(guildID: string, commandID: string, permissions: ApplicationCommandPermissions[], reason?: string): Promise<GuildApplicationCommandPermissions>;
+    editEmoji(emojiID: string, options: EditApplicationEmojiOptions): Promise<Emoji>;
+
     editGuild(guildID: string, options: GuildOptions, reason?: string): Promise<Guild>;
     editGuildCommand<T extends ApplicationCommandTypes>(guildID: string, commandID: string, command: ApplicationCommandEditOptions<true, T>): Promise<ApplicationCommand<true, T>>;
     editGuildDiscovery(guildID: string, options?: DiscoveryOptions): Promise<DiscoveryMetadata>;
@@ -2339,8 +2340,9 @@ declare namespace Eris {
     getDiscoveryCategories(): Promise<DiscoveryCategory[]>;
     getDMChannel(userID: string): Promise<DMChannel>;
     getEmoji(emojiID: string): Promise<Emoji>;
-    getEmojis(): Promise<ApplicationEmojis>;
     getEmojiGuild(emojiID: string): Promise<Guild>;
+    getEmojis(): Promise<ApplicationEmojis>;
+
     getGateway(): Promise<{ url: string }>;
     getGuildAuditLog(guildID: string, options?: GetGuildAuditLogOptions): Promise<GuildAuditLog>;
     /** @deprecated */

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2151,15 +2151,51 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Edit properties of the bot user
-   * @arg {Object} options The properties to edit
-   * @arg {String?} [options.avatar] The new avatar as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
-   * @arg {String?} [options.banner] The new banner as a base64 data URI. Note: base64 strings alone are not base64 data URI strings
-   * @arg {String} [options.username] The new username
+   * Edit properties of the bot user.
+   *
+   * If a `guildID` is provided, edits the bot’s member profile *within that guild*.
+   * Otherwise, edits the bot’s *global user* profile.
+   *
+   * @arg {Object} options The properties to edit.
+   *
+   * @arg {String} [options.username] The new global username.
+   *   Only valid when **no guildID** is provided.
+   *
+   * @arg {String} [options.avatar] The new avatar as a base64 data URI.
+   *   Note: base64 strings alone are not valid base64 data URI strings.
+   *   Can be set globally or per guild.
+   *
+   * @arg {String} [options.banner] The new banner as a base64 data URI.
+   *   Note: base64 strings alone are not valid base64 data URI strings.
+   *   Can be set globally or per guild.
+   *
+   * @arg {String} [options.nick] The new nickname.
+   *   Only valid when a **guildID** is provided.
+   *
+   * @arg {String} [options.bio] The new bio (member profile description).
+   *   Only valid when a **guildID** is provided.
+   *
+   * @arg {String} [guildID] The guild ID.
+   *   If provided, applies the edits to the bot’s member data in that guild.
+   *
    * @returns {Promise<ExtendedUser>}
+   *
+   * @example
+   * // Edit global username and avatar
+   * client.editSelf({
+   *   username: "Eris",
+   *   avatar: "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA..."
+   * });
+   *
+   * @example
+   * // Edit nickname and bio inside a guild
+   * client.editSelf({
+   *   nick: "Eris",
+   *   bio: "Wangle bazangle"
+   * }, "123456789012345678");
    */
-  editSelf(options) {
-    return this.requestHandler.request("PATCH", Endpoints.USER("@me"), true, options).then((data) => new ExtendedUser(data, this));
+  editSelf(options, guildID) {
+    return this.requestHandler.request("PATCH", guildID ? Endpoints.GUILD_MEMBER(guildID, "@me") : Endpoints.USER("@me"), true, options).then((data) => new ExtendedUser(data, this));
   }
 
   /**

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -1647,16 +1647,6 @@ class Client extends EventEmitter {
   }
 
   /**
-   * Edit an existing emoji for this application
-   * @arg {Object} options Emoji options
-   * @arg {String} options.name The name of emoji
-   * @returns {Promise<Object>} An emoji object
-   */
-  editEmoji(emojiID, options) {
-    return this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true, options);
-  }
-
-  /**
    * Edits command permissions for a specific command in a guild.
    * Note: You can only add up to 10 permission overwrites for a command.
    * @arg {String} guildID The guild ID
@@ -1673,6 +1663,16 @@ class Client extends EventEmitter {
       throw new Error("You must provide an id of the command whose permissions you want to edit.");
     }
     return this.requestHandler.request("PUT", Endpoints.COMMAND_PERMISSIONS(this.application.id, guildID, commandID), true, { permissions, reason });
+  }
+
+  /**
+   * Edit an existing emoji for this application
+   * @arg {Object} options Emoji options
+   * @arg {String} options.name The name of emoji
+   * @returns {Promise<Object>} An emoji object
+   */
+  editEmoji(emojiID, options) {
+    return this.requestHandler.request("PATCH", Endpoints.APPLICATION_EMOJI(this.application.id, emojiID), true, options);
   }
 
   /**
@@ -2580,6 +2580,15 @@ class Client extends EventEmitter {
   }
 
   /**
+   * Get a guild from the guild's emoji ID
+   * @arg {String} emojiID The ID of the emoji
+   * @returns {Promise<Guild>}
+   */
+  getEmojiGuild(emojiID) {
+    return this.requestHandler.request("GET", Endpoints.CUSTOM_EMOJI_GUILD(emojiID), true).then((result) => new Guild(result, this));
+  }
+
+  /**
    * Get the emojis for this application
    * @returns {Promise<Object>} Resolves with an object that contains a property "items" which is an array of emoji objects
    */
@@ -2595,15 +2604,6 @@ class Client extends EventEmitter {
 
       return data;
     });
-  }
-
-  /**
-   * Get a guild from the guild's emoji ID
-   * @arg {String} emojiID The ID of the emoji
-   * @returns {Promise<Guild>}
-   */
-  getEmojiGuild(emojiID) {
-    return this.requestHandler.request("GET", Endpoints.CUSTOM_EMOJI_GUILD(emojiID), true).then((result) => new Guild(result, this));
   }
 
   /**

--- a/lib/Constants.d.ts
+++ b/lib/Constants.d.ts
@@ -459,6 +459,7 @@ export default interface Constants {
     FAILED_TO_MENTION_SOME_ROLES_IN_THREAD: 256;
     SUPPRESS_NOTIFICATIONS:                 4096;
     IS_VOICE_MESSAGE:                       8192;
+    IS_COMPONENTS_V2:                       32768;
   };
   MessageTypes: {
     DEFAULT:                                      0;

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -546,6 +546,7 @@ module.exports.MessageFlags = {
   FAILED_TO_MENTION_SOME_ROLES_IN_THREAD: 1 << 8,
   SUPPRESS_NOTIFICATIONS:                 1 << 12,
   IS_VOICE_MESSAGE:                       1 << 13,
+  IS_COMPONENTS_V2:                       1 << 15,
 };
 
 module.exports.MessageTypes = {

--- a/lib/command/Command.js
+++ b/lib/command/Command.js
@@ -128,30 +128,30 @@ class Command {
     this.errorMessage = options.errorMessage || "";
     this.reactionButtons = options.reactionButtons
       ? options.reactionButtons.map((button, index) => {
-        if (typeof button.response === "string") {
-          button.execute = () => button.response;
-          return button;
-        } else if (Array.isArray(button.response)) {
-          button.responses = button.response.map((item, otherIndex) => {
-            if (typeof item === "string") {
-              return () => item;
-            } else if (typeof item === "function") {
-              return item;
-            } else {
-              throw new Error(`Invalid reaction button response generator (index ${index}:${otherIndex})`);
-            }
-          });
-          button.execute = () => button.responses[Math.floor(Math.random() * button.responses.length)]();
-          return button;
-        } else if (typeof button.response === "function") {
-          button.execute = button.response;
-          return button;
-        } else if (button.type === "cancel") {
-          return button;
-        } else {
-          throw new Error(`Invalid reaction button response generator (index ${index})`);
-        }
-      })
+          if (typeof button.response === "string") {
+            button.execute = () => button.response;
+            return button;
+          } else if (Array.isArray(button.response)) {
+            button.responses = button.response.map((item, otherIndex) => {
+              if (typeof item === "string") {
+                return () => item;
+              } else if (typeof item === "function") {
+                return item;
+              } else {
+                throw new Error(`Invalid reaction button response generator (index ${index}:${otherIndex})`);
+              }
+            });
+            button.execute = () => button.responses[Math.floor(Math.random() * button.responses.length)]();
+            return button;
+          } else if (typeof button.response === "function") {
+            button.execute = button.response;
+            return button;
+          } else if (button.type === "cancel") {
+            return button;
+          } else {
+            throw new Error(`Invalid reaction button response generator (index ${index})`);
+          }
+        })
       : null;
     this.reactionButtonTimeout = options.reactionButtonTimeout || 60000;
     if (this.cooldown !== 0) {


### PR DESCRIPTION
**Guild Profile Editing:**
- Adds support for editing the bot’s profile within a specific guild, including nick, avatar, banner, and bio fields via editSelf(options, guildID).

**Components V2 Flag:**
- Adds the new IS_COMPONENTS_V2 flag to MessageFlags.

**Maintains backward compatibility with global user editing.**