### PR TITLE
feat(Role): Get role member counts

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2357,6 +2357,7 @@ declare namespace Eris {
     getGuildInvites(guildID: string): Promise<Invite[]>;
     getGuildOnboarding(guildID: string): Promise<GuildOnboarding>;
     getGuildPreview(guildID: string): Promise<GuildPreview>;
+    getGuildRoleMemberCounts(guildID: string): Promise<Record<string, number>>;
     getGuildScheduledEvents(guildID: string, options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent[]>;
     getGuildScheduledEventUsers(guildID: string, eventID: string, options?: GetGuildScheduledEventUsersOptions): Promise<GuildScheduledEventUser[]>;
     getGuildSoundboardSound(guildID: string, soundID: string): Promise<SoundboardSound>;
@@ -2768,6 +2769,7 @@ declare namespace Eris {
     getRESTScheduledEvent(eventID: string): Promise<GuildScheduledEvent>;
     getRESTSticker(stickerID: string): Promise<Sticker>;
     getRESTStickers(): Promise<Sticker[]>;
+    getRoleMemberCounts(): Promise<Record<string, number>>;
     getScheduledEvents(options?: GetGuildScheduledEventOptions): Promise<GuildScheduledEvent[]>;
     getScheduledEventUsers(eventID: string, options?: GetGuildScheduledEventUsersOptions): Promise<GuildScheduledEventUser[]>;
     getSoundboardSound(soundID: string): Promise<SoundboardSound>;

--- a/lib/Client.js
+++ b/lib/Client.js
@@ -2806,6 +2806,15 @@ class Client extends EventEmitter {
   }
 
   /**
+   * Get a guild's role member counts
+   * @arg {String} guildID The ID of the guild
+   * @returns {Promise<Object<String, Number>>} A map of role IDs to the number of members with the role. Does not include the @everyone role.
+   */
+  getGuildRoleMemberCounts(guildID) {
+    return this.requestHandler.request("GET", Endpoints.GUILD_ROLE_MEMBER_COUNTS(guildID), true);
+  }
+
+  /**
    * Get a guild's scheduled events
    * @arg {String} guildID The ID of the guild
    * @arg {Object} [options] Options for the request

--- a/lib/rest/Endpoints.js
+++ b/lib/rest/Endpoints.js
@@ -63,6 +63,7 @@ module.exports.GUILD_ONBOARDING =                                      (guildID)
 module.exports.GUILD_PREVIEW =                                         (guildID) => `/guilds/${guildID}/preview`;
 module.exports.GUILD_PRUNE =                                           (guildID) => `/guilds/${guildID}/prune`;
 module.exports.GUILD_ROLE =                                    (guildID, roleID) => `/guilds/${guildID}/roles/${roleID}`;
+module.exports.GUILD_ROLE_MEMBER_COUNTS =                              (guildID) => `/guilds/${guildID}/roles/member-counts`;
 module.exports.GUILD_ROLES =                                           (guildID) => `/guilds/${guildID}/roles`;
 module.exports.GUILD_SCHEDULED_EVENT =               (guildID, scheduledEventID) => `/guilds/${guildID}/scheduled-events/${scheduledEventID}`;
 module.exports.GUILD_SCHEDULED_EVENT_USERS =         (guildID, scheduledEventID) => `/guilds/${guildID}/scheduled-events/${scheduledEventID}/users`;

--- a/lib/structures/Guild.js
+++ b/lib/structures/Guild.js
@@ -1285,6 +1285,14 @@ class Guild extends Base {
   }
 
   /**
+   * Get the guild's role member counts
+   * @returns {Promise<Object<String, Number>>} A map of role IDs to the number of members with the role. Does not include the @everyone role.
+   */
+  getRoleMemberCounts() {
+    return this._client.getGuildRoleMemberCounts.call(this._client, this.id);
+  }
+
+  /**
    * Get the guild's scheduled events
    * @arg {Object} [options] Options for the request
    * @arg {Boolean} [options.withUserCount] Whether to include the number of users subscribed to each event


### PR DESCRIPTION
Ref:
- https://github.com/discord/discord-api-docs/pull/8025

Adds:
- `Client#getGuildRoleMemberCounts()`
- `Guild#getRoleMemberCounts()`