### PR TITLE
fix(RequestHandler): parse content-type header in a spec-compliant way

### DIFF
--- a/lib/rest/RequestHandler.js
+++ b/lib/rest/RequestHandler.js
@@ -324,7 +324,7 @@ class RequestHandler {
               cb();
 
               if (response.length > 0) {
-                if (resp.headers["content-type"] === "application/json") {
+                if (resp.headers["content-type"] && resp.headers["content-type"].startsWith("application/json")) {
                   try {
                     response = JSON.parse(response);
                   } catch (err) {
@@ -349,7 +349,7 @@ class RequestHandler {
             }
 
             if (response.length > 0) {
-              if (resp.headers["content-type"] === "application/json") {
+              if (resp.headers["content-type"] && resp.headers["content-type"].startsWith("application/json")) {
                 try {
                   response = JSON.parse(response);
                 } catch (err) {


### PR DESCRIPTION
Fixes the `Content-Type` header check in `RequestHandler` to handle values that include extra parameters (e.g. `application/json; charset=utf-8`).

The current implementation uses strict equality (`===`) against `"application/json"`, which fails when the header contains a charset or other media type parameters as allowed by [RFC 7231](https://datatracker.ietf.org/doc/html/rfc7231#section-3.1.1.1). This causes JSON response bodies to be returned as raw strings instead of parsed objects.

Switched to `startsWith("application/json")` (with a null guard), which correctly matches regardless of any trailing parameters.

Closes #1605